### PR TITLE
fix: add missing stories for text component

### DIFF
--- a/src/Atoms/Text/Text.stories.tsx
+++ b/src/Atoms/Text/Text.stories.tsx
@@ -4,8 +4,73 @@ import Text from './index';
 
 const stories = storiesOf('Atoms/Text', module);
 
-stories.add('Primary default', () => <Text.Primary>Primary text</Text.Primary>);
-stories.add('Secondary default', () => <Text.Secondary>Secondary text</Text.Secondary>);
-stories.add('Tertiary default', () => <Text.Tertiary>Tertiary text</Text.Tertiary>);
-stories.add('Title1 default', () => <Text.Title1>Title1 text</Text.Title1>);
-stories.add('Title3 default', () => <Text.Title3>Title3 text</Text.Title3>);
+stories.add('Primary', () => (
+  <>
+    <div>
+      <Text.Primary>Primary text</Text.Primary>
+    </div>
+    <div>
+      <Text.Primary weight="bold">Primary bold</Text.Primary>
+    </div>
+    <div>
+      <Text.Primary weight="extrabold">Primary text</Text.Primary>
+    </div>
+  </>
+));
+
+stories.add('Secondary', () => (
+  <>
+    <div>
+      <Text.Secondary>Secondary text</Text.Secondary>
+    </div>
+    <div>
+      <Text.Secondary weight="bold">Secondary bold</Text.Secondary>
+    </div>
+    <div>
+      <Text.Secondary weight="extrabold">Secondary text</Text.Secondary>
+    </div>
+  </>
+));
+
+stories.add('Tertiary', () => (
+  <>
+    <div>
+      <Text.Tertiary>Tertiary text</Text.Tertiary>
+    </div>
+    <div>
+      <Text.Tertiary weight="bold">Tertiary bold</Text.Tertiary>
+    </div>
+    <div>
+      <Text.Tertiary weight="extrabold">Tertiary text</Text.Tertiary>
+    </div>
+  </>
+));
+
+stories.add('Title1', () => <Text.Title1>Title1 text</Text.Title1>);
+stories.add('Title3', () => <Text.Title3>Title3 text</Text.Title3>);
+
+stories.add('Colors', () => (
+  <>
+    <div>
+      <Text.Primary>Default</Text.Primary>
+    </div>
+    <div>
+      <Text.Primary color={t => t.color.text}>Text</Text.Primary>
+    </div>
+    <div>
+      <Text.Primary color={t => t.color.positive}>Positive</Text.Primary>
+    </div>
+    <div>
+      <Text.Primary color={t => t.color.negative}>Negative</Text.Primary>
+    </div>
+    <div>
+      <Text.Primary color={t => t.color.warning}>Warning</Text.Primary>
+    </div>
+    <div>
+      <Text.Primary color={t => t.color.cta}>CTA</Text.Primary>
+    </div>
+    <div>
+      <Text.Primary color={t => t.color.label}>Label</Text.Primary>
+    </div>
+  </>
+));

--- a/src/Atoms/Text/Text.types.ts
+++ b/src/Atoms/Text/Text.types.ts
@@ -8,7 +8,7 @@ export type StyledTextProps = {
   colorFn?: ColorFn;
   weight: Weight;
 };
-type ColorFn = (t: Theme) => keyof Theme['color'];
+type ColorFn = (t: Theme) => Theme['color'][keyof Theme['color']];
 
 export type BaseProps = {
   as?: keyof JSX.IntrinsicElements | React.ComponentType<any>;


### PR DESCRIPTION
Adding missing stories for `Text` component. Also grouping and cleaning up stories for `bold` property.

![Screenshot 2019-03-27 at 16 45 30](https://user-images.githubusercontent.com/807629/55090852-1ea35e80-50b0-11e9-9eee-fd8be2283d7f.png)
![Screenshot 2019-03-27 at 16 45 37](https://user-images.githubusercontent.com/807629/55090862-206d2200-50b0-11e9-99fe-bd446fa882cf.png)
