### PR TITLE
Number and development improvements

### DIFF
--- a/src/Atoms/Number/Number.stories.tsx
+++ b/src/Atoms/Number/Number.stories.tsx
@@ -99,6 +99,13 @@ storiesOf('Atoms | Number', module)
     // @ts-ignore
     return <Number value={10} currency={null} />;
   })
+  .add('Regression: value is positive, but rounded value is 0', () => (
+    <Display
+        items={[
+          { title: 'value = 0.1', component: <Number value={0.1} sign decimals={0} /> },
+        ]}
+      />
+  ))
   .add('Integration: with different typographies', () => {
     const items = Object.values(TYPOGRAPHY_TYPES).map(type => ({
       title: type,

--- a/src/Atoms/Number/Number.stories.tsx
+++ b/src/Atoms/Number/Number.stories.tsx
@@ -35,6 +35,7 @@ storiesOf('Atoms | Number', module)
           { title: 'value = 10.378', component: <Number value={10.378} decimals={2} /> },
           { title: 'value = 10.333', component: <Number value={10.333} decimals={2} /> },
           { title: 'value = 10', component: <Number value={10} decimals={2} /> },
+          { title: 'value = 10.5', component: <Number value={10.5} decimals={2} /> },
         ]}
       />
     );
@@ -67,6 +68,7 @@ storiesOf('Atoms | Number', module)
           items={[
             { title: 'value = 0.55555', component: <Number value={0.55555} ticks={ticks} /> },
             { title: 'value = 10.333', component: <Number value={10.333} ticks={ticks} /> },
+            { title: 'value = 10.5', component: <Number value={10.5} ticks={ticks} /> },
             { title: 'value = 100001.22', component: <Number value={100001.22} ticks={ticks} /> },
           ]}
         />

--- a/src/Atoms/Number/Number.tsx
+++ b/src/Atoms/Number/Number.tsx
@@ -1,10 +1,17 @@
 import React from 'react';
 import { injectIntl } from 'react-intl';
+import * as R from 'ramda'
 import { NumberComponent as NumberComponentType, Ticks } from './Number.types';
+import { assert } from '../../common/utils';
 
 const getPrefix = (sign: boolean, value: number) => (sign && value > 0 ? '+' : '');
 
 const getTickDecimals = (value: number, ticks: Ticks) => {
+  if (process.env.NODE_ENV !== 'production') {
+    // @ts-ignore
+    const wrongTick = ticks.find(R.or(R.has('from_price'), R.has('to_price')));
+    assert(!wrongTick, `Found ticks with snake cased keys, they should be camelcased.`)
+  }
   const tick = ticks.find(t => value >= t.fromPrice && value < t.toPrice + (t.tick || 0));
 
   return tick ? tick.decimals : undefined;

--- a/src/Atoms/Number/Number.tsx
+++ b/src/Atoms/Number/Number.tsx
@@ -35,6 +35,11 @@ const getNumberOptions = (value: number, ticks?: Ticks, decimals?: number) => {
   return {};
 };
 
+export const getRoundedValue = (value: number, ticks?: Ticks, decimals?: number) => {
+  const dec = ticks ? getTickDecimals(value, ticks) : decimals;
+  return dec === 0 ? 0 : +Number(value).toPrecision(dec);
+}
+
 const NumberComponent: NumberComponentType = ({
   intl,
   value,
@@ -47,9 +52,10 @@ const NumberComponent: NumberComponentType = ({
   if (typeof value === 'undefined' || value === null || !Number.isFinite(value)) return <>-</>;
   if (typeof currency !== 'undefined' && currency === null) return <>-</>;
 
+  const roundedValue = getRoundedValue(value, ticks, decimals);
   return (
     <>
-      {getPrefix(sign, value)}
+      {getPrefix(sign, roundedValue)}
       {intl.formatNumber(value, getNumberOptions(value, ticks, decimals))}
       {percentage && '%'}
       {currency && ` ${currency}`}

--- a/src/Atoms/Number/__snapshots__/Number.stories.storyshot
+++ b/src/Atoms/Number/__snapshots__/Number.stories.storyshot
@@ -1060,6 +1060,20 @@ Array [
       <div
         className="c2"
       >
+        value = 10.5
+      </div>
+      <div>
+        
+        10.50
+      </div>
+    </div>
+    <div
+      className="c1"
+      direction="row"
+    >
+      <div
+        className="c2"
+      >
         value = 100001.22
       </div>
       <div>
@@ -1173,6 +1187,20 @@ exports[`Storyshots Atoms | Number Number with 2 decimals  1`] = `
     <div>
       
       10.00
+    </div>
+  </div>
+  <div
+    className="c1"
+    direction="row"
+  >
+    <div
+      className="c2"
+    >
+      value = 10.5
+    </div>
+    <div>
+      
+      10.50
     </div>
   </div>
 </div>
@@ -1296,6 +1324,85 @@ exports[`Storyshots Atoms | Number Number with sign 1`] = `
     <div>
       
       -1
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots Atoms | Number Regression: value is positive, but rounded value is 0 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  border: 0px;
+}
+
+.c0 > * {
+  padding: 0px;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  border: 1px solid #eee;
+}
+
+.c1 > * {
+  padding: 20px;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.c2 {
+  border-right: 1px solid #eee;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+}
+
+<div
+  className="c0"
+  direction="column"
+>
+  <div
+    className="c1"
+    direction="row"
+  >
+    <div
+      className="c2"
+    >
+      value = 0.1
+    </div>
+    <div>
+      
+      0
     </div>
   </div>
 </div>

--- a/src/Molecules/Development/Development.stories.tsx
+++ b/src/Molecules/Development/Development.stories.tsx
@@ -58,6 +58,14 @@ storiesOf('Molecules | Development', module)
       ]}
     />
   ))
+  .add('Regression: value is non-zero, but rounded value is 0', () => (
+    <Display
+      items={[
+        { title: '`value = 0.3`', component: <Development value={0.3} decimals={0} /> },
+        { title: '`value = -0.3`', component: <Development value={-0.3} decimals={0} /> },
+      ]}
+    />
+  ))
   .add('Integration: with different typographies', () => {
     const items = Object.values(TYPOGRAPHY_TYPES).map(type => ({
       title: type,

--- a/src/Molecules/Development/Development.tsx
+++ b/src/Molecules/Development/Development.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 import { DevelopmentProps, DevelopmentComponent } from './Development.types';
 import { Number as NumberComponent } from '../..';
 import { Theme } from '../../theme/theme.types';
+import { getRoundedValue } from '../../Atoms/Number/Number';
 
 const getPrefix = (value?: number | null) => {
   if (!value) return '';
@@ -18,12 +19,16 @@ const StyledDevelopment = styled.span<DevelopmentProps>`
   color: ${getColor};
 `;
 
-const Development: DevelopmentComponent = ({ value, className, icon = false, ...props }) => (
-  <StyledDevelopment className={className} value={value}>
-    <span aria-hidden>{icon && getPrefix(value)}</span>
-    <NumberComponent value={value} sign {...props} />
-  </StyledDevelopment>
-);
+const Development: DevelopmentComponent = props => {
+  const { value, decimals, ticks, className, icon = false, } = props;
+  const roundedValue = typeof value !== 'undefined' && value !== null ? getRoundedValue(value, ticks, decimals) : value;
+  return (
+    <StyledDevelopment className={className} value={roundedValue}>
+      <span aria-hidden>{icon && getPrefix(roundedValue)}</span>
+      <NumberComponent sign {...props} />
+    </StyledDevelopment>
+  )
+};
 
 export { Development };
 Development.displayName = 'Development';

--- a/src/Molecules/Development/__snapshots__/Development.stories.storyshot
+++ b/src/Molecules/Development/__snapshots__/Development.stories.storyshot
@@ -1344,6 +1344,119 @@ exports[`Storyshots Molecules | Development Integration: with different typograp
 </div>
 `;
 
+exports[`Storyshots Molecules | Development Regression: value is non-zero, but rounded value is 0 1`] = `
+.c3 {
+  color: #282823;
+}
+
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  border: 0px;
+}
+
+.c0 > * {
+  padding: 0px;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  border: 1px solid #eee;
+}
+
+.c1 > * {
+  padding: 20px;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.c2 {
+  border-right: 1px solid #eee;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+}
+
+<div
+  className="c0"
+  direction="column"
+>
+  <div
+    className="c1"
+    direction="row"
+  >
+    <div
+      className="c2"
+    >
+      \`value = 0.3\`
+    </div>
+    <div>
+      <span
+        className="c3"
+        value={0}
+      >
+        <span
+          aria-hidden={true}
+        />
+        
+        0
+      </span>
+    </div>
+  </div>
+  <div
+    className="c1"
+    direction="row"
+  >
+    <div
+      className="c2"
+    >
+      \`value = -0.3\`
+    </div>
+    <div>
+      <span
+        className="c3"
+        value={0}
+      >
+        <span
+          aria-hidden={true}
+        />
+        
+        -0
+      </span>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Storyshots Molecules | Development With icon 1`] = `
 .c3 {
   color: #00D200;


### PR DESCRIPTION
Mainly fixes a case where the value sent in (e.g. value=0.1) is non-zero, but the rounded value (e.g. value=0) is zero, so it got a plus sign and development color, even though it shouldn't.

The rest is printing warnings for a very common, bad use case, namely that ticks are snake cased. And I also added some documentation. See the commits which should be chunked up properly. 