### PR TITLE
fix: rounding with zero decimals

### DIFF
--- a/src/Atoms/Number/Number.tsx
+++ b/src/Atoms/Number/Number.tsx
@@ -37,7 +37,7 @@ const getNumberOptions = (value: number, ticks?: Ticks, decimals?: number) => {
 
 export const getRoundedValue = (value: number, ticks?: Ticks, decimals?: number) => {
   const dec = ticks ? getTickDecimals(value, ticks) : decimals;
-  return dec === 0 ? 0 : +Number(value).toPrecision(dec);
+  return dec === 0 ? Math.round(value) : +Number(value).toPrecision(dec);
 };
 
 const NumberComponent: NumberComponentType = ({

--- a/src/Molecules/Development/__snapshots__/Development.stories.storyshot
+++ b/src/Molecules/Development/__snapshots__/Development.stories.storyshot
@@ -1444,7 +1444,7 @@ exports[`Storyshots Molecules | Development Regression: value is non-zero, but r
     <div>
       <span
         className="c3"
-        value={0}
+        value={-0}
       >
         <span
           aria-hidden={true}


### PR DESCRIPTION
I screwed up the rounding if decimals was `0` in my recent PR.