### PR TITLE
feat: enabled to use items style with 0 as value

### DIFF
--- a/src/Atoms/Flexbox/Flexbox.tsx
+++ b/src/Atoms/Flexbox/Flexbox.tsx
@@ -67,7 +67,7 @@ ${
 `;
 
 const getItemStyles = (p: Props & { theme: Theme }) => `
-  ${!R.isNil(p.size) ? getSizeStyles(p.size) : ''}
+  ${p.size ? getSizeStyles(p.size) : ''}
   ${!R.isNil(p.order) ? `order: ${p.order};` : ''}
   ${!R.isNil(p.grow) ? `flex-grow: ${p.grow};` : ''}
   ${!R.isNil(p.shrink) ? `flex-shrink: ${p.shrink};` : ''}

--- a/src/Atoms/Flexbox/Flexbox.tsx
+++ b/src/Atoms/Flexbox/Flexbox.tsx
@@ -67,13 +67,13 @@ ${
 `;
 
 const getItemStyles = (p: Props & { theme: Theme }) => `
-${p.size ? getSizeStyles(p.size) : ''}
-${p.order ? `order: ${p.order};` : ''}
-${p.grow ? `flex-grow: ${p.grow};` : ''}
-${p.shrink ? `flex-shrink: ${p.shrink};` : ''}
-${p.basis ? `flex-basis: ${p.basis};` : ''}
-${p.flex ? `flex: ${p.flex};` : ''}
-${p.align ? `align-self: ${p.align};` : ''}
+  ${!R.isNil(p.size) ? getSizeStyles(p.size) : ''}
+  ${!R.isNil(p.order) ? `order: ${p.order};` : ''}
+  ${!R.isNil(p.grow) ? `flex-grow: ${p.grow};` : ''}
+  ${!R.isNil(p.shrink) ? `flex-shrink: ${p.shrink};` : ''}
+  ${p.basis ? `flex-basis: ${p.basis};` : ''}
+  ${p.flex ? `flex: ${p.flex};` : ''}
+  ${p.align ? `align-self: ${p.align};` : ''}
 `;
 
 const sanitizeProps = R.omit([


### PR DESCRIPTION
It wasn't possible to e.g. apply `shrink={0}` to an flexbox item before because of boolean check.