### PR TITLE
fix(CollapsibleCard): prevent onClick being called twice on mobiles

### DIFF
--- a/src/Molecules/CollapsibleCard/CollapsibleCard.stories.tsx
+++ b/src/Molecules/CollapsibleCard/CollapsibleCard.stories.tsx
@@ -7,6 +7,20 @@ const styledText = styled.p`
   margin: 0;
 `;
 
+const ExampleWithOnClick = () => {
+  const [clicked, setClicked] = React.useState(0);
+  return (
+    <CollapsibleCard
+      title={`I've been clicked ${clicked} times`}
+      onClick={() => setClicked(clicked + 1)}
+    >
+      <Typography type="primary" as={styledText}>
+        On mobile the onClick event should fire for onTouchStart and not onClick.
+      </Typography>
+    </CollapsibleCard>
+  );
+};
+
 storiesOf('Molecules | CollapsibleCard', module)
   .add('Default', () => {
     return (
@@ -41,4 +55,5 @@ storiesOf('Molecules | CollapsibleCard', module)
         </Typography>
       </CollapsibleCard>
     );
-  });
+  })
+  .add('Collapsible with onClick listener', () => <ExampleWithOnClick />);

--- a/src/Molecules/CollapsibleCard/CollapsibleCard.tsx
+++ b/src/Molecules/CollapsibleCard/CollapsibleCard.tsx
@@ -134,19 +134,7 @@ export const CollapsibleCard: React.FC<CollapsibleProps> = ({
   };
 
   const toggle = (e: React.MouseEvent | React.TouchEvent) => {
-    // If touchstart was fired, prevent the following click event
-    // https://developer.mozilla.org/en-US/docs/Web/API/Touch_events/Supporting_both_TouchEvent_and_MouseEvent
-    // The browser will fire touchstart before click, if touchstart is supported,
-    // this will make it feel more responsive.
-    e.preventDefault();
-
-    if (document && 'ontouchstart' in document.documentElement) {
-      if (e.type !== 'click') {
-        onClick(e);
-      }
-    } else {
-      onClick(e);
-    }
+    onClick(e);
 
     if (collapsed) {
       setExpanding(true);
@@ -155,12 +143,14 @@ export const CollapsibleCard: React.FC<CollapsibleProps> = ({
     }
   };
 
+  const hasOnTouch =
+    document && document.documentElement && 'ontouchstart' in document.documentElement;
+
   return (
     <Card>
       <StyledButton
         type="button"
-        onClick={toggle}
-        onTouchStart={toggle}
+        {...{ [hasOnTouch ? 'onTouchStart' : 'onClick']: toggle }}
         collapsed={collapsed}
         aria-expanded={!collapsed}
       >

--- a/src/Molecules/CollapsibleCard/CollapsibleCard.tsx
+++ b/src/Molecules/CollapsibleCard/CollapsibleCard.tsx
@@ -139,7 +139,15 @@ export const CollapsibleCard: React.FC<CollapsibleProps> = ({
     // The browser will fire touchstart before click, if touchstart is supported,
     // this will make it feel more responsive.
     e.preventDefault();
-    onClick(e);
+
+    if ('ontouchstart' in document.documentElement) {
+      if (e.type !== 'click') {
+        onClick(e);
+      }
+    } else {
+      onClick(e);
+    }
+
     if (collapsed) {
       setExpanding(true);
     } else {

--- a/src/Molecules/CollapsibleCard/CollapsibleCard.tsx
+++ b/src/Molecules/CollapsibleCard/CollapsibleCard.tsx
@@ -140,7 +140,7 @@ export const CollapsibleCard: React.FC<CollapsibleProps> = ({
     // this will make it feel more responsive.
     e.preventDefault();
 
-    if ('ontouchstart' in document.documentElement) {
+    if (document && 'ontouchstart' in document.documentElement) {
       if (e.type !== 'click') {
         onClick(e);
       }

--- a/src/Molecules/CollapsibleCard/__snapshots__/CollapsibleCard.stories.storyshot
+++ b/src/Molecules/CollapsibleCard/__snapshots__/CollapsibleCard.stories.storyshot
@@ -380,6 +380,195 @@ exports[`Storyshots Molecules | CollapsibleCard Collapsible with custom componen
 </div>
 `;
 
+exports[`Storyshots Molecules | CollapsibleCard Collapsible with onClick listener 1`] = `
+.c0 {
+  background: #FFFFFF;
+  box-shadow: 0 2px 2px 0 rgba(0,0,0,0.03);
+}
+
+.c3 {
+  box-sizing: border-box;
+}
+
+.c2 {
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c2 > *:not(:first-child) {
+  margin-left: 16px;
+}
+
+.c6 {
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  width: 8px;
+  height: 8px;
+  fill: currentColor;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  color: #282823;
+  display: block;
+}
+
+.c8 {
+  font-family: 'Nordnet Sans Mono',-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
+  color: #282823;
+  margin: 0;
+  font-weight: 400;
+  font-size: 16px;
+  line-height: 1.5;
+}
+
+.c4 {
+  font-family: 'Nordnet Sans Mono',-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
+  color: #282823;
+  margin: 0;
+  font-weight: 800;
+  font-size: 18px;
+  line-height: 1.3333333333333333;
+}
+
+.c7 {
+  overflow: hidden;
+  will-change: height;
+  height: auto;
+  -webkit-transition: height 0.16s ease-out;
+  transition: height 0.16s ease-out;
+}
+
+.c7[hidden] {
+  display: none;
+}
+
+.c1 {
+  touch-action: none;
+  position: relative;
+  background: none;
+  cursor: pointer;
+  display: block;
+  width: 100%;
+  padding: 20px 20px;
+  border: 0;
+}
+
+.c1::before {
+  content: '';
+  display: block;
+  background: #0046FF;
+  width: 2px;
+  height: 100%;
+  position: absolute;
+  top: 0;
+  left: 0;
+  -webkit-transition: opacity 0.16s ease-out;
+  transition: opacity 0.16s ease-out;
+  opacity: 0;
+}
+
+.c5 {
+  -webkit-transform: rodate(0);
+  -ms-transform: rodate(0);
+  transform: rodate(0);
+  -webkit-transform-origin: center center;
+  -ms-transform-origin: center center;
+  transform-origin: center center;
+  -webkit-transition: -webkit-transform 0.16s ease-out;
+  -webkit-transition: transform 0.16s ease-out;
+  transition: transform 0.16s ease-out;
+}
+
+.c9 {
+  margin: 0;
+}
+
+@media (min-width:360px) {
+  .c8 {
+    font-size: 16px;
+    line-height: 1.5;
+  }
+}
+
+@media (min-width:360px) {
+  .c4 {
+    font-size: 20px;
+    line-height: 1.2;
+  }
+}
+
+<div
+  className="c0"
+>
+  <button
+    aria-expanded={true}
+    className="c1"
+    onClick={[Function]}
+    onTouchStart={[Function]}
+    type="button"
+  >
+    <div
+      className="c2"
+      justifyContent="space-between"
+    >
+      <div
+        className="c3"
+      >
+        <h2
+          className="c4"
+          type="title3"
+        >
+          I've been clicked 0 times
+        </h2>
+      </div>
+      <div
+        className="c3"
+      >
+        <svg
+          aria-hidden="true"
+          className="c5 c6"
+          focusable="false"
+          role="presentation"
+          size={2}
+          viewBox="0 0 24 24"
+        >
+          <polygon
+            points="19.969 4 24 8.027 12 20 0 8.027 4.031 4 12 11.952"
+            transform="rotate(-180 12 12)"
+          />
+        </svg>
+      </div>
+    </div>
+  </button>
+  <div
+    className="c7"
+    height={null}
+    hidden={false}
+    onTransitionEnd={[Function]}
+  >
+    <p
+      className="c8 c9"
+      type="primary"
+    >
+      On mobile the onClick event should fire for onTouchStart and not onClick.
+    </p>
+  </div>
+</div>
+`;
+
 exports[`Storyshots Molecules | CollapsibleCard Default 1`] = `
 .c0 {
   background: #FFFFFF;

--- a/src/Molecules/CollapsibleCard/__snapshots__/CollapsibleCard.stories.storyshot
+++ b/src/Molecules/CollapsibleCard/__snapshots__/CollapsibleCard.stories.storyshot
@@ -137,7 +137,6 @@ exports[`Storyshots Molecules | CollapsibleCard Collapsed initially 1`] = `
     aria-expanded={false}
     className="c1"
     onClick={[Function]}
-    onTouchStart={[Function]}
     type="button"
   >
     <div
@@ -326,7 +325,6 @@ exports[`Storyshots Molecules | CollapsibleCard Collapsible with custom componen
     aria-expanded={true}
     className="c1"
     onClick={[Function]}
-    onTouchStart={[Function]}
     type="button"
   >
     <div
@@ -517,7 +515,6 @@ exports[`Storyshots Molecules | CollapsibleCard Collapsible with onClick listene
     aria-expanded={true}
     className="c1"
     onClick={[Function]}
-    onTouchStart={[Function]}
     type="button"
   >
     <div
@@ -706,7 +703,6 @@ exports[`Storyshots Molecules | CollapsibleCard Default 1`] = `
     aria-expanded={true}
     className="c1"
     onClick={[Function]}
-    onTouchStart={[Function]}
     type="button"
   >
     <div


### PR DESCRIPTION
The `onClick` callback was called both on `touchstart` and `click` events on mobile phones.