### PR TITLE
Faster ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 node_js:
-  # Latest stable
-  - "node"
+  - 10
 
 before_install:
   # Download latest yarn since travis defaults to v1.3.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
-  - 10
+  # Latest stable
+  - "node"
 
 before_install:
   # Download latest yarn since travis defaults to v1.3.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ jobs:
         - npm run lint
         - npm run test-ci
         - npm run build
-        - npm run build-storybook
 
     - stage: release
       script:


### PR DESCRIPTION
* skip double building storybook - previously we built storybook as part of `test-and-build` so that we could verify that renovate update PRs to e.g. webpack didn't break the build. However we don't use renovate right now so this will carve off a good 40s of CI time. If we re-enable renovate maybe we can conditionally test build storybook?
* ~~use latest version of node - this _should_ result in faster builds, it's pretty common to use the latest version in CI.~~