### PR TITLE
feat(spinner): add delay to show spinner

### DIFF
--- a/src/Atoms/Spinner/Spinner.stories.tsx
+++ b/src/Atoms/Spinner/Spinner.stories.tsx
@@ -20,7 +20,11 @@ storiesOf('Atoms | Spinner', module)
   ))
   .add('Spinner default', () => <Spinner id="mySpinner" />)
   .add('Spinner big', () => <Spinner size={16} id="mySpinner" />)
-  .add('Spinner without delay', () => <Spinner size={16} id="mySpinner" instant />)
+  .add('Spinner with default delay', () => <Spinner size={16} id="mySpinner" delay />)
+  .add('Spinner with delay is set to false', () => (
+    <Spinner size={16} id="mySpinner" delay={false} />
+  ))
+  .add('Spinner with custom 2 sec delay', () => <Spinner size={16} id="mySpinner" delay={2000} />)
   .add('Colors', () => (
     <Display
       items={[

--- a/src/Atoms/Spinner/Spinner.stories.tsx
+++ b/src/Atoms/Spinner/Spinner.stories.tsx
@@ -20,6 +20,7 @@ storiesOf('Atoms | Spinner', module)
   ))
   .add('Spinner default', () => <Spinner id="mySpinner" />)
   .add('Spinner big', () => <Spinner size={16} id="mySpinner" />)
+  .add('Spinner without delay', () => <Spinner size={16} id="mySpinner" instant />)
   .add('Colors', () => (
     <Display
       items={[

--- a/src/Atoms/Spinner/Spinner.tsx
+++ b/src/Atoms/Spinner/Spinner.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import styled, { withTheme } from 'styled-components';
 import { Props, PropsWithTheme } from './Spinner.types';
 
@@ -54,6 +54,22 @@ const RawSpinner: React.FC<PropsWithTheme> = ({ theme, size, color, id }) => {
   );
 };
 
-export const Spinner: React.FC<Props> = withTheme(RawSpinner);
+const TimeoutSpinner: React.FC<PropsWithTheme> = ({ instant = false, ...restProps }) => {
+  const [spinning, setSpinning] = useState(false);
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setSpinning(true);
+    }, 270);
+    return () => clearTimeout(timer);
+  }, []);
+
+  if (instant || spinning) {
+    return <RawSpinner {...restProps} />;
+  }
+
+  return null;
+};
+
+export const Spinner: React.FC<Props> = withTheme(TimeoutSpinner);
 
 Spinner.displayName = 'Spinner';

--- a/src/Atoms/Spinner/Spinner.tsx
+++ b/src/Atoms/Spinner/Spinner.tsx
@@ -54,16 +54,19 @@ const RawSpinner: React.FC<PropsWithTheme> = ({ theme, size, color, id }) => {
   );
 };
 
-const TimeoutSpinner: React.FC<PropsWithTheme> = ({ instant = false, ...restProps }) => {
+const TimeoutSpinner: React.FC<PropsWithTheme> = ({ delay, ...restProps }) => {
   const [spinning, setSpinning] = useState(false);
   useEffect(() => {
-    const timer = setTimeout(() => {
-      setSpinning(true);
-    }, 270);
+    const timer = setTimeout(
+      () => {
+        setSpinning(true);
+      },
+      typeof delay === 'boolean' ? 270 : delay || 0,
+    );
     return () => clearTimeout(timer);
   }, []);
 
-  if (instant || spinning) {
+  if (!delay || spinning) {
     return <RawSpinner {...restProps} />;
   }
 

--- a/src/Atoms/Spinner/Spinner.types.ts
+++ b/src/Atoms/Spinner/Spinner.types.ts
@@ -8,7 +8,7 @@ export type Props = {
   color?: ColorFn;
   /** Globally unique id for the spinner */
   id: string;
-  instant?: boolean;
+  delay?: boolean | number;
 };
 
 export type PropsWithTheme = Props & {

--- a/src/Atoms/Spinner/Spinner.types.ts
+++ b/src/Atoms/Spinner/Spinner.types.ts
@@ -8,6 +8,7 @@ export type Props = {
   color?: ColorFn;
   /** Globally unique id for the spinner */
   id: string;
+  instant?: boolean;
 };
 
 export type PropsWithTheme = Props & {

--- a/src/Atoms/Spinner/__snapshots__/Spinner.stories.storyshot
+++ b/src/Atoms/Spinner/__snapshots__/Spinner.stories.storyshot
@@ -1,16 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Storyshots Atoms | Spinner Colors 1`] = `
-.c3 {
-  display: inline-block;
-  -webkit-animation: spinner 1s linear infinite;
-  animation: spinner 1s linear infinite;
-}
-
-.c4 {
-  display: block;
-}
-
 .c0 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -81,70 +71,7 @@ exports[`Storyshots Atoms | Spinner Colors 1`] = `
     >
       Default
     </div>
-    <div>
-      <span
-        className="c3"
-      >
-        <svg
-          className="c4"
-          height={16}
-          viewBox="0 0 24 24"
-          width={16}
-        >
-          <defs>
-            <linearGradient
-              id="spinner-defaultSpinner-1"
-              x1="50%"
-              x2="50%"
-              y1="0%"
-              y2="100%"
-            >
-              <stop
-                offset="0%"
-                stopColor="#0046FF"
-                stopOpacity="0"
-              />
-              <stop
-                offset="100%"
-                stopColor="#0046FF"
-                stopOpacity=".5"
-              />
-            </linearGradient>
-            <linearGradient
-              id="spinner-defaultSpinner-2"
-              x1="50%"
-              x2="50%"
-              y1="0%"
-              y2="100%"
-            >
-              <stop
-                offset="0%"
-                stopColor="#0046FF"
-                stopOpacity=".5"
-              />
-              <stop
-                offset="100%"
-                stopColor="#0046FF"
-              />
-            </linearGradient>
-          </defs>
-          <g
-            fill="none"
-            fillRule="evenodd"
-          >
-            <path
-              d="M12,0 C18.627417,0 24,5.372583 24,12 C24,18.627417 18.627417,24 12,24 M12,21 C16.9705627,21 21,16.9705627 21,12 C21,7.02943725 16.9705627,3 12,3"
-              fill="url(#spinner-defaultSpinner-1)"
-            />
-            <path
-              d="M0,0 C6.627417,0 12,5.372583 12,12 C12,18.627417 6.627417,24 0,24 M0,21 C4.97056275,21 9,16.9705627 9,12 C9,7.02943725 4.97056275,3 0,3"
-              fill="url(#spinner-defaultSpinner-2)"
-              transform="rotate(-180 6 12)"
-            />
-          </g>
-        </svg>
-      </span>
-    </div>
+    <div />
   </div>
   <div
     className="c1"
@@ -155,70 +82,7 @@ exports[`Storyshots Atoms | Spinner Colors 1`] = `
     >
       Color: text
     </div>
-    <div>
-      <span
-        className="c3"
-      >
-        <svg
-          className="c4"
-          height={16}
-          viewBox="0 0 24 24"
-          width={16}
-        >
-          <defs>
-            <linearGradient
-              id="spinner-defaultSpinnerText-1"
-              x1="50%"
-              x2="50%"
-              y1="0%"
-              y2="100%"
-            >
-              <stop
-                offset="0%"
-                stopColor="#282823"
-                stopOpacity="0"
-              />
-              <stop
-                offset="100%"
-                stopColor="#282823"
-                stopOpacity=".5"
-              />
-            </linearGradient>
-            <linearGradient
-              id="spinner-defaultSpinnerText-2"
-              x1="50%"
-              x2="50%"
-              y1="0%"
-              y2="100%"
-            >
-              <stop
-                offset="0%"
-                stopColor="#282823"
-                stopOpacity=".5"
-              />
-              <stop
-                offset="100%"
-                stopColor="#282823"
-              />
-            </linearGradient>
-          </defs>
-          <g
-            fill="none"
-            fillRule="evenodd"
-          >
-            <path
-              d="M12,0 C18.627417,0 24,5.372583 24,12 C24,18.627417 18.627417,24 12,24 M12,21 C16.9705627,21 21,16.9705627 21,12 C21,7.02943725 16.9705627,3 12,3"
-              fill="url(#spinner-defaultSpinnerText-1)"
-            />
-            <path
-              d="M0,0 C6.627417,0 12,5.372583 12,12 C12,18.627417 6.627417,24 0,24 M0,21 C4.97056275,21 9,16.9705627 9,12 C9,7.02943725 4.97056275,3 0,3"
-              fill="url(#spinner-defaultSpinnerText-2)"
-              transform="rotate(-180 6 12)"
-            />
-          </g>
-        </svg>
-      </span>
-    </div>
+    <div />
   </div>
   <div
     className="c1"
@@ -229,70 +93,7 @@ exports[`Storyshots Atoms | Spinner Colors 1`] = `
     >
       Color: positive
     </div>
-    <div>
-      <span
-        className="c3"
-      >
-        <svg
-          className="c4"
-          height={16}
-          viewBox="0 0 24 24"
-          width={16}
-        >
-          <defs>
-            <linearGradient
-              id="spinner-defaultSpinnerPositive-1"
-              x1="50%"
-              x2="50%"
-              y1="0%"
-              y2="100%"
-            >
-              <stop
-                offset="0%"
-                stopColor="#00D200"
-                stopOpacity="0"
-              />
-              <stop
-                offset="100%"
-                stopColor="#00D200"
-                stopOpacity=".5"
-              />
-            </linearGradient>
-            <linearGradient
-              id="spinner-defaultSpinnerPositive-2"
-              x1="50%"
-              x2="50%"
-              y1="0%"
-              y2="100%"
-            >
-              <stop
-                offset="0%"
-                stopColor="#00D200"
-                stopOpacity=".5"
-              />
-              <stop
-                offset="100%"
-                stopColor="#00D200"
-              />
-            </linearGradient>
-          </defs>
-          <g
-            fill="none"
-            fillRule="evenodd"
-          >
-            <path
-              d="M12,0 C18.627417,0 24,5.372583 24,12 C24,18.627417 18.627417,24 12,24 M12,21 C16.9705627,21 21,16.9705627 21,12 C21,7.02943725 16.9705627,3 12,3"
-              fill="url(#spinner-defaultSpinnerPositive-1)"
-            />
-            <path
-              d="M0,0 C6.627417,0 12,5.372583 12,12 C12,18.627417 6.627417,24 0,24 M0,21 C4.97056275,21 9,16.9705627 9,12 C9,7.02943725 4.97056275,3 0,3"
-              fill="url(#spinner-defaultSpinnerPositive-2)"
-              transform="rotate(-180 6 12)"
-            />
-          </g>
-        </svg>
-      </span>
-    </div>
+    <div />
   </div>
   <div
     className="c1"
@@ -303,70 +104,7 @@ exports[`Storyshots Atoms | Spinner Colors 1`] = `
     >
       Color: negative
     </div>
-    <div>
-      <span
-        className="c3"
-      >
-        <svg
-          className="c4"
-          height={16}
-          viewBox="0 0 24 24"
-          width={16}
-        >
-          <defs>
-            <linearGradient
-              id="spinner-defaultSpinnerNegative-1"
-              x1="50%"
-              x2="50%"
-              y1="0%"
-              y2="100%"
-            >
-              <stop
-                offset="0%"
-                stopColor="#FF1900"
-                stopOpacity="0"
-              />
-              <stop
-                offset="100%"
-                stopColor="#FF1900"
-                stopOpacity=".5"
-              />
-            </linearGradient>
-            <linearGradient
-              id="spinner-defaultSpinnerNegative-2"
-              x1="50%"
-              x2="50%"
-              y1="0%"
-              y2="100%"
-            >
-              <stop
-                offset="0%"
-                stopColor="#FF1900"
-                stopOpacity=".5"
-              />
-              <stop
-                offset="100%"
-                stopColor="#FF1900"
-              />
-            </linearGradient>
-          </defs>
-          <g
-            fill="none"
-            fillRule="evenodd"
-          >
-            <path
-              d="M12,0 C18.627417,0 24,5.372583 24,12 C24,18.627417 18.627417,24 12,24 M12,21 C16.9705627,21 21,16.9705627 21,12 C21,7.02943725 16.9705627,3 12,3"
-              fill="url(#spinner-defaultSpinnerNegative-1)"
-            />
-            <path
-              d="M0,0 C6.627417,0 12,5.372583 12,12 C12,18.627417 6.627417,24 0,24 M0,21 C4.97056275,21 9,16.9705627 9,12 C9,7.02943725 4.97056275,3 0,3"
-              fill="url(#spinner-defaultSpinnerNegative-2)"
-              transform="rotate(-180 6 12)"
-            />
-          </g>
-        </svg>
-      </span>
-    </div>
+    <div />
   </div>
   <div
     className="c1"
@@ -377,70 +115,7 @@ exports[`Storyshots Atoms | Spinner Colors 1`] = `
     >
       Color: warning
     </div>
-    <div>
-      <span
-        className="c3"
-      >
-        <svg
-          className="c4"
-          height={16}
-          viewBox="0 0 24 24"
-          width={16}
-        >
-          <defs>
-            <linearGradient
-              id="spinner-defaultSpinnerWarning-1"
-              x1="50%"
-              x2="50%"
-              y1="0%"
-              y2="100%"
-            >
-              <stop
-                offset="0%"
-                stopColor="#FFCF00"
-                stopOpacity="0"
-              />
-              <stop
-                offset="100%"
-                stopColor="#FFCF00"
-                stopOpacity=".5"
-              />
-            </linearGradient>
-            <linearGradient
-              id="spinner-defaultSpinnerWarning-2"
-              x1="50%"
-              x2="50%"
-              y1="0%"
-              y2="100%"
-            >
-              <stop
-                offset="0%"
-                stopColor="#FFCF00"
-                stopOpacity=".5"
-              />
-              <stop
-                offset="100%"
-                stopColor="#FFCF00"
-              />
-            </linearGradient>
-          </defs>
-          <g
-            fill="none"
-            fillRule="evenodd"
-          >
-            <path
-              d="M12,0 C18.627417,0 24,5.372583 24,12 C24,18.627417 18.627417,24 12,24 M12,21 C16.9705627,21 21,16.9705627 21,12 C21,7.02943725 16.9705627,3 12,3"
-              fill="url(#spinner-defaultSpinnerWarning-1)"
-            />
-            <path
-              d="M0,0 C6.627417,0 12,5.372583 12,12 C12,18.627417 6.627417,24 0,24 M0,21 C4.97056275,21 9,16.9705627 9,12 C9,7.02943725 4.97056275,3 0,3"
-              fill="url(#spinner-defaultSpinnerWarning-2)"
-              transform="rotate(-180 6 12)"
-            />
-          </g>
-        </svg>
-      </span>
-    </div>
+    <div />
   </div>
   <div
     className="c1"
@@ -451,85 +126,12 @@ exports[`Storyshots Atoms | Spinner Colors 1`] = `
     >
       Color: label
     </div>
-    <div>
-      <span
-        className="c3"
-      >
-        <svg
-          className="c4"
-          height={16}
-          viewBox="0 0 24 24"
-          width={16}
-        >
-          <defs>
-            <linearGradient
-              id="spinner-defaultSpinnerLabel-1"
-              x1="50%"
-              x2="50%"
-              y1="0%"
-              y2="100%"
-            >
-              <stop
-                offset="0%"
-                stopColor="#6E6E69"
-                stopOpacity="0"
-              />
-              <stop
-                offset="100%"
-                stopColor="#6E6E69"
-                stopOpacity=".5"
-              />
-            </linearGradient>
-            <linearGradient
-              id="spinner-defaultSpinnerLabel-2"
-              x1="50%"
-              x2="50%"
-              y1="0%"
-              y2="100%"
-            >
-              <stop
-                offset="0%"
-                stopColor="#6E6E69"
-                stopOpacity=".5"
-              />
-              <stop
-                offset="100%"
-                stopColor="#6E6E69"
-              />
-            </linearGradient>
-          </defs>
-          <g
-            fill="none"
-            fillRule="evenodd"
-          >
-            <path
-              d="M12,0 C18.627417,0 24,5.372583 24,12 C24,18.627417 18.627417,24 12,24 M12,21 C16.9705627,21 21,16.9705627 21,12 C21,7.02943725 16.9705627,3 12,3"
-              fill="url(#spinner-defaultSpinnerLabel-1)"
-            />
-            <path
-              d="M0,0 C6.627417,0 12,5.372583 12,12 C12,18.627417 6.627417,24 0,24 M0,21 C4.97056275,21 9,16.9705627 9,12 C9,7.02943725 4.97056275,3 0,3"
-              fill="url(#spinner-defaultSpinnerLabel-2)"
-              transform="rotate(-180 6 12)"
-            />
-          </g>
-        </svg>
-      </span>
-    </div>
+    <div />
   </div>
 </div>
 `;
 
 exports[`Storyshots Atoms | Spinner Regression: 2 spinners with same color and size affects each other in Chrome 1`] = `
-.c1 {
-  display: inline-block;
-  -webkit-animation: spinner 1s linear infinite;
-  animation: spinner 1s linear infinite;
-}
-
-.c2 {
-  display: block;
-}
-
 .c0 {
   font-family: 'Nordnet Sans Mono',-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
   color: #282823;
@@ -562,144 +164,22 @@ exports[`Storyshots Atoms | Spinner Regression: 2 spinners with same color and s
         "display": "none",
       }
     }
-  >
-    <span
-      className="c1"
-    >
-      <svg
-        className="c2"
-        height={32}
-        viewBox="0 0 24 24"
-        width={32}
-      >
-        <defs>
-          <linearGradient
-            id="spinner-firstSpinner-1"
-            x1="50%"
-            x2="50%"
-            y1="0%"
-            y2="100%"
-          >
-            <stop
-              offset="0%"
-              stopColor="#0046FF"
-              stopOpacity="0"
-            />
-            <stop
-              offset="100%"
-              stopColor="#0046FF"
-              stopOpacity=".5"
-            />
-          </linearGradient>
-          <linearGradient
-            id="spinner-firstSpinner-2"
-            x1="50%"
-            x2="50%"
-            y1="0%"
-            y2="100%"
-          >
-            <stop
-              offset="0%"
-              stopColor="#0046FF"
-              stopOpacity=".5"
-            />
-            <stop
-              offset="100%"
-              stopColor="#0046FF"
-            />
-          </linearGradient>
-        </defs>
-        <g
-          fill="none"
-          fillRule="evenodd"
-        >
-          <path
-            d="M12,0 C18.627417,0 24,5.372583 24,12 C24,18.627417 18.627417,24 12,24 M12,21 C16.9705627,21 21,16.9705627 21,12 C21,7.02943725 16.9705627,3 12,3"
-            fill="url(#spinner-firstSpinner-1)"
-          />
-          <path
-            d="M0,0 C6.627417,0 12,5.372583 12,12 C12,18.627417 6.627417,24 0,24 M0,21 C4.97056275,21 9,16.9705627 9,12 C9,7.02943725 4.97056275,3 0,3"
-            fill="url(#spinner-firstSpinner-2)"
-            transform="rotate(-180 6 12)"
-          />
-        </g>
-      </svg>
-    </span>
-  </div>
+  />
   <div
     style={
       Object {
         "border": "1px green solid",
       }
     }
-  >
-    <span
-      className="c1"
-    >
-      <svg
-        className="c2"
-        height={32}
-        viewBox="0 0 24 24"
-        width={32}
-      >
-        <defs>
-          <linearGradient
-            id="spinner-secondSpinner-1"
-            x1="50%"
-            x2="50%"
-            y1="0%"
-            y2="100%"
-          >
-            <stop
-              offset="0%"
-              stopColor="#0046FF"
-              stopOpacity="0"
-            />
-            <stop
-              offset="100%"
-              stopColor="#0046FF"
-              stopOpacity=".5"
-            />
-          </linearGradient>
-          <linearGradient
-            id="spinner-secondSpinner-2"
-            x1="50%"
-            x2="50%"
-            y1="0%"
-            y2="100%"
-          >
-            <stop
-              offset="0%"
-              stopColor="#0046FF"
-              stopOpacity=".5"
-            />
-            <stop
-              offset="100%"
-              stopColor="#0046FF"
-            />
-          </linearGradient>
-        </defs>
-        <g
-          fill="none"
-          fillRule="evenodd"
-        >
-          <path
-            d="M12,0 C18.627417,0 24,5.372583 24,12 C24,18.627417 18.627417,24 12,24 M12,21 C16.9705627,21 21,16.9705627 21,12 C21,7.02943725 16.9705627,3 12,3"
-            fill="url(#spinner-secondSpinner-1)"
-          />
-          <path
-            d="M0,0 C6.627417,0 12,5.372583 12,12 C12,18.627417 6.627417,24 0,24 M0,21 C4.97056275,21 9,16.9705627 9,12 C9,7.02943725 4.97056275,3 0,3"
-            fill="url(#spinner-secondSpinner-2)"
-            transform="rotate(-180 6 12)"
-          />
-        </g>
-      </svg>
-    </span>
-  </div>
+  />
 </div>
 `;
 
-exports[`Storyshots Atoms | Spinner Spinner big 1`] = `
+exports[`Storyshots Atoms | Spinner Spinner big 1`] = `null`;
+
+exports[`Storyshots Atoms | Spinner Spinner default 1`] = `null`;
+
+exports[`Storyshots Atoms | Spinner Spinner without delay 1`] = `
 .c0 {
   display: inline-block;
   -webkit-animation: spinner 1s linear infinite;
@@ -718,81 +198,6 @@ exports[`Storyshots Atoms | Spinner Spinner big 1`] = `
     height={64}
     viewBox="0 0 24 24"
     width={64}
-  >
-    <defs>
-      <linearGradient
-        id="spinner-mySpinner-1"
-        x1="50%"
-        x2="50%"
-        y1="0%"
-        y2="100%"
-      >
-        <stop
-          offset="0%"
-          stopColor="#0046FF"
-          stopOpacity="0"
-        />
-        <stop
-          offset="100%"
-          stopColor="#0046FF"
-          stopOpacity=".5"
-        />
-      </linearGradient>
-      <linearGradient
-        id="spinner-mySpinner-2"
-        x1="50%"
-        x2="50%"
-        y1="0%"
-        y2="100%"
-      >
-        <stop
-          offset="0%"
-          stopColor="#0046FF"
-          stopOpacity=".5"
-        />
-        <stop
-          offset="100%"
-          stopColor="#0046FF"
-        />
-      </linearGradient>
-    </defs>
-    <g
-      fill="none"
-      fillRule="evenodd"
-    >
-      <path
-        d="M12,0 C18.627417,0 24,5.372583 24,12 C24,18.627417 18.627417,24 12,24 M12,21 C16.9705627,21 21,16.9705627 21,12 C21,7.02943725 16.9705627,3 12,3"
-        fill="url(#spinner-mySpinner-1)"
-      />
-      <path
-        d="M0,0 C6.627417,0 12,5.372583 12,12 C12,18.627417 6.627417,24 0,24 M0,21 C4.97056275,21 9,16.9705627 9,12 C9,7.02943725 4.97056275,3 0,3"
-        fill="url(#spinner-mySpinner-2)"
-        transform="rotate(-180 6 12)"
-      />
-    </g>
-  </svg>
-</span>
-`;
-
-exports[`Storyshots Atoms | Spinner Spinner default 1`] = `
-.c0 {
-  display: inline-block;
-  -webkit-animation: spinner 1s linear infinite;
-  animation: spinner 1s linear infinite;
-}
-
-.c1 {
-  display: block;
-}
-
-<span
-  className="c0"
->
-  <svg
-    className="c1"
-    height={16}
-    viewBox="0 0 24 24"
-    width={16}
   >
     <defs>
       <linearGradient

--- a/src/Atoms/Spinner/__snapshots__/Spinner.stories.storyshot
+++ b/src/Atoms/Spinner/__snapshots__/Spinner.stories.storyshot
@@ -1,6 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Storyshots Atoms | Spinner Colors 1`] = `
+.c3 {
+  display: inline-block;
+  -webkit-animation: spinner 1s linear infinite;
+  animation: spinner 1s linear infinite;
+}
+
+.c4 {
+  display: block;
+}
+
 .c0 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -71,7 +81,70 @@ exports[`Storyshots Atoms | Spinner Colors 1`] = `
     >
       Default
     </div>
-    <div />
+    <div>
+      <span
+        className="c3"
+      >
+        <svg
+          className="c4"
+          height={16}
+          viewBox="0 0 24 24"
+          width={16}
+        >
+          <defs>
+            <linearGradient
+              id="spinner-defaultSpinner-1"
+              x1="50%"
+              x2="50%"
+              y1="0%"
+              y2="100%"
+            >
+              <stop
+                offset="0%"
+                stopColor="#0046FF"
+                stopOpacity="0"
+              />
+              <stop
+                offset="100%"
+                stopColor="#0046FF"
+                stopOpacity=".5"
+              />
+            </linearGradient>
+            <linearGradient
+              id="spinner-defaultSpinner-2"
+              x1="50%"
+              x2="50%"
+              y1="0%"
+              y2="100%"
+            >
+              <stop
+                offset="0%"
+                stopColor="#0046FF"
+                stopOpacity=".5"
+              />
+              <stop
+                offset="100%"
+                stopColor="#0046FF"
+              />
+            </linearGradient>
+          </defs>
+          <g
+            fill="none"
+            fillRule="evenodd"
+          >
+            <path
+              d="M12,0 C18.627417,0 24,5.372583 24,12 C24,18.627417 18.627417,24 12,24 M12,21 C16.9705627,21 21,16.9705627 21,12 C21,7.02943725 16.9705627,3 12,3"
+              fill="url(#spinner-defaultSpinner-1)"
+            />
+            <path
+              d="M0,0 C6.627417,0 12,5.372583 12,12 C12,18.627417 6.627417,24 0,24 M0,21 C4.97056275,21 9,16.9705627 9,12 C9,7.02943725 4.97056275,3 0,3"
+              fill="url(#spinner-defaultSpinner-2)"
+              transform="rotate(-180 6 12)"
+            />
+          </g>
+        </svg>
+      </span>
+    </div>
   </div>
   <div
     className="c1"
@@ -82,7 +155,70 @@ exports[`Storyshots Atoms | Spinner Colors 1`] = `
     >
       Color: text
     </div>
-    <div />
+    <div>
+      <span
+        className="c3"
+      >
+        <svg
+          className="c4"
+          height={16}
+          viewBox="0 0 24 24"
+          width={16}
+        >
+          <defs>
+            <linearGradient
+              id="spinner-defaultSpinnerText-1"
+              x1="50%"
+              x2="50%"
+              y1="0%"
+              y2="100%"
+            >
+              <stop
+                offset="0%"
+                stopColor="#282823"
+                stopOpacity="0"
+              />
+              <stop
+                offset="100%"
+                stopColor="#282823"
+                stopOpacity=".5"
+              />
+            </linearGradient>
+            <linearGradient
+              id="spinner-defaultSpinnerText-2"
+              x1="50%"
+              x2="50%"
+              y1="0%"
+              y2="100%"
+            >
+              <stop
+                offset="0%"
+                stopColor="#282823"
+                stopOpacity=".5"
+              />
+              <stop
+                offset="100%"
+                stopColor="#282823"
+              />
+            </linearGradient>
+          </defs>
+          <g
+            fill="none"
+            fillRule="evenodd"
+          >
+            <path
+              d="M12,0 C18.627417,0 24,5.372583 24,12 C24,18.627417 18.627417,24 12,24 M12,21 C16.9705627,21 21,16.9705627 21,12 C21,7.02943725 16.9705627,3 12,3"
+              fill="url(#spinner-defaultSpinnerText-1)"
+            />
+            <path
+              d="M0,0 C6.627417,0 12,5.372583 12,12 C12,18.627417 6.627417,24 0,24 M0,21 C4.97056275,21 9,16.9705627 9,12 C9,7.02943725 4.97056275,3 0,3"
+              fill="url(#spinner-defaultSpinnerText-2)"
+              transform="rotate(-180 6 12)"
+            />
+          </g>
+        </svg>
+      </span>
+    </div>
   </div>
   <div
     className="c1"
@@ -93,7 +229,70 @@ exports[`Storyshots Atoms | Spinner Colors 1`] = `
     >
       Color: positive
     </div>
-    <div />
+    <div>
+      <span
+        className="c3"
+      >
+        <svg
+          className="c4"
+          height={16}
+          viewBox="0 0 24 24"
+          width={16}
+        >
+          <defs>
+            <linearGradient
+              id="spinner-defaultSpinnerPositive-1"
+              x1="50%"
+              x2="50%"
+              y1="0%"
+              y2="100%"
+            >
+              <stop
+                offset="0%"
+                stopColor="#00D200"
+                stopOpacity="0"
+              />
+              <stop
+                offset="100%"
+                stopColor="#00D200"
+                stopOpacity=".5"
+              />
+            </linearGradient>
+            <linearGradient
+              id="spinner-defaultSpinnerPositive-2"
+              x1="50%"
+              x2="50%"
+              y1="0%"
+              y2="100%"
+            >
+              <stop
+                offset="0%"
+                stopColor="#00D200"
+                stopOpacity=".5"
+              />
+              <stop
+                offset="100%"
+                stopColor="#00D200"
+              />
+            </linearGradient>
+          </defs>
+          <g
+            fill="none"
+            fillRule="evenodd"
+          >
+            <path
+              d="M12,0 C18.627417,0 24,5.372583 24,12 C24,18.627417 18.627417,24 12,24 M12,21 C16.9705627,21 21,16.9705627 21,12 C21,7.02943725 16.9705627,3 12,3"
+              fill="url(#spinner-defaultSpinnerPositive-1)"
+            />
+            <path
+              d="M0,0 C6.627417,0 12,5.372583 12,12 C12,18.627417 6.627417,24 0,24 M0,21 C4.97056275,21 9,16.9705627 9,12 C9,7.02943725 4.97056275,3 0,3"
+              fill="url(#spinner-defaultSpinnerPositive-2)"
+              transform="rotate(-180 6 12)"
+            />
+          </g>
+        </svg>
+      </span>
+    </div>
   </div>
   <div
     className="c1"
@@ -104,7 +303,70 @@ exports[`Storyshots Atoms | Spinner Colors 1`] = `
     >
       Color: negative
     </div>
-    <div />
+    <div>
+      <span
+        className="c3"
+      >
+        <svg
+          className="c4"
+          height={16}
+          viewBox="0 0 24 24"
+          width={16}
+        >
+          <defs>
+            <linearGradient
+              id="spinner-defaultSpinnerNegative-1"
+              x1="50%"
+              x2="50%"
+              y1="0%"
+              y2="100%"
+            >
+              <stop
+                offset="0%"
+                stopColor="#FF1900"
+                stopOpacity="0"
+              />
+              <stop
+                offset="100%"
+                stopColor="#FF1900"
+                stopOpacity=".5"
+              />
+            </linearGradient>
+            <linearGradient
+              id="spinner-defaultSpinnerNegative-2"
+              x1="50%"
+              x2="50%"
+              y1="0%"
+              y2="100%"
+            >
+              <stop
+                offset="0%"
+                stopColor="#FF1900"
+                stopOpacity=".5"
+              />
+              <stop
+                offset="100%"
+                stopColor="#FF1900"
+              />
+            </linearGradient>
+          </defs>
+          <g
+            fill="none"
+            fillRule="evenodd"
+          >
+            <path
+              d="M12,0 C18.627417,0 24,5.372583 24,12 C24,18.627417 18.627417,24 12,24 M12,21 C16.9705627,21 21,16.9705627 21,12 C21,7.02943725 16.9705627,3 12,3"
+              fill="url(#spinner-defaultSpinnerNegative-1)"
+            />
+            <path
+              d="M0,0 C6.627417,0 12,5.372583 12,12 C12,18.627417 6.627417,24 0,24 M0,21 C4.97056275,21 9,16.9705627 9,12 C9,7.02943725 4.97056275,3 0,3"
+              fill="url(#spinner-defaultSpinnerNegative-2)"
+              transform="rotate(-180 6 12)"
+            />
+          </g>
+        </svg>
+      </span>
+    </div>
   </div>
   <div
     className="c1"
@@ -115,7 +377,70 @@ exports[`Storyshots Atoms | Spinner Colors 1`] = `
     >
       Color: warning
     </div>
-    <div />
+    <div>
+      <span
+        className="c3"
+      >
+        <svg
+          className="c4"
+          height={16}
+          viewBox="0 0 24 24"
+          width={16}
+        >
+          <defs>
+            <linearGradient
+              id="spinner-defaultSpinnerWarning-1"
+              x1="50%"
+              x2="50%"
+              y1="0%"
+              y2="100%"
+            >
+              <stop
+                offset="0%"
+                stopColor="#FFCF00"
+                stopOpacity="0"
+              />
+              <stop
+                offset="100%"
+                stopColor="#FFCF00"
+                stopOpacity=".5"
+              />
+            </linearGradient>
+            <linearGradient
+              id="spinner-defaultSpinnerWarning-2"
+              x1="50%"
+              x2="50%"
+              y1="0%"
+              y2="100%"
+            >
+              <stop
+                offset="0%"
+                stopColor="#FFCF00"
+                stopOpacity=".5"
+              />
+              <stop
+                offset="100%"
+                stopColor="#FFCF00"
+              />
+            </linearGradient>
+          </defs>
+          <g
+            fill="none"
+            fillRule="evenodd"
+          >
+            <path
+              d="M12,0 C18.627417,0 24,5.372583 24,12 C24,18.627417 18.627417,24 12,24 M12,21 C16.9705627,21 21,16.9705627 21,12 C21,7.02943725 16.9705627,3 12,3"
+              fill="url(#spinner-defaultSpinnerWarning-1)"
+            />
+            <path
+              d="M0,0 C6.627417,0 12,5.372583 12,12 C12,18.627417 6.627417,24 0,24 M0,21 C4.97056275,21 9,16.9705627 9,12 C9,7.02943725 4.97056275,3 0,3"
+              fill="url(#spinner-defaultSpinnerWarning-2)"
+              transform="rotate(-180 6 12)"
+            />
+          </g>
+        </svg>
+      </span>
+    </div>
   </div>
   <div
     className="c1"
@@ -126,12 +451,85 @@ exports[`Storyshots Atoms | Spinner Colors 1`] = `
     >
       Color: label
     </div>
-    <div />
+    <div>
+      <span
+        className="c3"
+      >
+        <svg
+          className="c4"
+          height={16}
+          viewBox="0 0 24 24"
+          width={16}
+        >
+          <defs>
+            <linearGradient
+              id="spinner-defaultSpinnerLabel-1"
+              x1="50%"
+              x2="50%"
+              y1="0%"
+              y2="100%"
+            >
+              <stop
+                offset="0%"
+                stopColor="#6E6E69"
+                stopOpacity="0"
+              />
+              <stop
+                offset="100%"
+                stopColor="#6E6E69"
+                stopOpacity=".5"
+              />
+            </linearGradient>
+            <linearGradient
+              id="spinner-defaultSpinnerLabel-2"
+              x1="50%"
+              x2="50%"
+              y1="0%"
+              y2="100%"
+            >
+              <stop
+                offset="0%"
+                stopColor="#6E6E69"
+                stopOpacity=".5"
+              />
+              <stop
+                offset="100%"
+                stopColor="#6E6E69"
+              />
+            </linearGradient>
+          </defs>
+          <g
+            fill="none"
+            fillRule="evenodd"
+          >
+            <path
+              d="M12,0 C18.627417,0 24,5.372583 24,12 C24,18.627417 18.627417,24 12,24 M12,21 C16.9705627,21 21,16.9705627 21,12 C21,7.02943725 16.9705627,3 12,3"
+              fill="url(#spinner-defaultSpinnerLabel-1)"
+            />
+            <path
+              d="M0,0 C6.627417,0 12,5.372583 12,12 C12,18.627417 6.627417,24 0,24 M0,21 C4.97056275,21 9,16.9705627 9,12 C9,7.02943725 4.97056275,3 0,3"
+              fill="url(#spinner-defaultSpinnerLabel-2)"
+              transform="rotate(-180 6 12)"
+            />
+          </g>
+        </svg>
+      </span>
+    </div>
   </div>
 </div>
 `;
 
 exports[`Storyshots Atoms | Spinner Regression: 2 spinners with same color and size affects each other in Chrome 1`] = `
+.c1 {
+  display: inline-block;
+  -webkit-animation: spinner 1s linear infinite;
+  animation: spinner 1s linear infinite;
+}
+
+.c2 {
+  display: block;
+}
+
 .c0 {
   font-family: 'Nordnet Sans Mono',-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
   color: #282823;
@@ -164,22 +562,298 @@ exports[`Storyshots Atoms | Spinner Regression: 2 spinners with same color and s
         "display": "none",
       }
     }
-  />
+  >
+    <span
+      className="c1"
+    >
+      <svg
+        className="c2"
+        height={32}
+        viewBox="0 0 24 24"
+        width={32}
+      >
+        <defs>
+          <linearGradient
+            id="spinner-firstSpinner-1"
+            x1="50%"
+            x2="50%"
+            y1="0%"
+            y2="100%"
+          >
+            <stop
+              offset="0%"
+              stopColor="#0046FF"
+              stopOpacity="0"
+            />
+            <stop
+              offset="100%"
+              stopColor="#0046FF"
+              stopOpacity=".5"
+            />
+          </linearGradient>
+          <linearGradient
+            id="spinner-firstSpinner-2"
+            x1="50%"
+            x2="50%"
+            y1="0%"
+            y2="100%"
+          >
+            <stop
+              offset="0%"
+              stopColor="#0046FF"
+              stopOpacity=".5"
+            />
+            <stop
+              offset="100%"
+              stopColor="#0046FF"
+            />
+          </linearGradient>
+        </defs>
+        <g
+          fill="none"
+          fillRule="evenodd"
+        >
+          <path
+            d="M12,0 C18.627417,0 24,5.372583 24,12 C24,18.627417 18.627417,24 12,24 M12,21 C16.9705627,21 21,16.9705627 21,12 C21,7.02943725 16.9705627,3 12,3"
+            fill="url(#spinner-firstSpinner-1)"
+          />
+          <path
+            d="M0,0 C6.627417,0 12,5.372583 12,12 C12,18.627417 6.627417,24 0,24 M0,21 C4.97056275,21 9,16.9705627 9,12 C9,7.02943725 4.97056275,3 0,3"
+            fill="url(#spinner-firstSpinner-2)"
+            transform="rotate(-180 6 12)"
+          />
+        </g>
+      </svg>
+    </span>
+  </div>
   <div
     style={
       Object {
         "border": "1px green solid",
       }
     }
-  />
+  >
+    <span
+      className="c1"
+    >
+      <svg
+        className="c2"
+        height={32}
+        viewBox="0 0 24 24"
+        width={32}
+      >
+        <defs>
+          <linearGradient
+            id="spinner-secondSpinner-1"
+            x1="50%"
+            x2="50%"
+            y1="0%"
+            y2="100%"
+          >
+            <stop
+              offset="0%"
+              stopColor="#0046FF"
+              stopOpacity="0"
+            />
+            <stop
+              offset="100%"
+              stopColor="#0046FF"
+              stopOpacity=".5"
+            />
+          </linearGradient>
+          <linearGradient
+            id="spinner-secondSpinner-2"
+            x1="50%"
+            x2="50%"
+            y1="0%"
+            y2="100%"
+          >
+            <stop
+              offset="0%"
+              stopColor="#0046FF"
+              stopOpacity=".5"
+            />
+            <stop
+              offset="100%"
+              stopColor="#0046FF"
+            />
+          </linearGradient>
+        </defs>
+        <g
+          fill="none"
+          fillRule="evenodd"
+        >
+          <path
+            d="M12,0 C18.627417,0 24,5.372583 24,12 C24,18.627417 18.627417,24 12,24 M12,21 C16.9705627,21 21,16.9705627 21,12 C21,7.02943725 16.9705627,3 12,3"
+            fill="url(#spinner-secondSpinner-1)"
+          />
+          <path
+            d="M0,0 C6.627417,0 12,5.372583 12,12 C12,18.627417 6.627417,24 0,24 M0,21 C4.97056275,21 9,16.9705627 9,12 C9,7.02943725 4.97056275,3 0,3"
+            fill="url(#spinner-secondSpinner-2)"
+            transform="rotate(-180 6 12)"
+          />
+        </g>
+      </svg>
+    </span>
+  </div>
 </div>
 `;
 
-exports[`Storyshots Atoms | Spinner Spinner big 1`] = `null`;
+exports[`Storyshots Atoms | Spinner Spinner big 1`] = `
+.c0 {
+  display: inline-block;
+  -webkit-animation: spinner 1s linear infinite;
+  animation: spinner 1s linear infinite;
+}
 
-exports[`Storyshots Atoms | Spinner Spinner default 1`] = `null`;
+.c1 {
+  display: block;
+}
 
-exports[`Storyshots Atoms | Spinner Spinner without delay 1`] = `
+<span
+  className="c0"
+>
+  <svg
+    className="c1"
+    height={64}
+    viewBox="0 0 24 24"
+    width={64}
+  >
+    <defs>
+      <linearGradient
+        id="spinner-mySpinner-1"
+        x1="50%"
+        x2="50%"
+        y1="0%"
+        y2="100%"
+      >
+        <stop
+          offset="0%"
+          stopColor="#0046FF"
+          stopOpacity="0"
+        />
+        <stop
+          offset="100%"
+          stopColor="#0046FF"
+          stopOpacity=".5"
+        />
+      </linearGradient>
+      <linearGradient
+        id="spinner-mySpinner-2"
+        x1="50%"
+        x2="50%"
+        y1="0%"
+        y2="100%"
+      >
+        <stop
+          offset="0%"
+          stopColor="#0046FF"
+          stopOpacity=".5"
+        />
+        <stop
+          offset="100%"
+          stopColor="#0046FF"
+        />
+      </linearGradient>
+    </defs>
+    <g
+      fill="none"
+      fillRule="evenodd"
+    >
+      <path
+        d="M12,0 C18.627417,0 24,5.372583 24,12 C24,18.627417 18.627417,24 12,24 M12,21 C16.9705627,21 21,16.9705627 21,12 C21,7.02943725 16.9705627,3 12,3"
+        fill="url(#spinner-mySpinner-1)"
+      />
+      <path
+        d="M0,0 C6.627417,0 12,5.372583 12,12 C12,18.627417 6.627417,24 0,24 M0,21 C4.97056275,21 9,16.9705627 9,12 C9,7.02943725 4.97056275,3 0,3"
+        fill="url(#spinner-mySpinner-2)"
+        transform="rotate(-180 6 12)"
+      />
+    </g>
+  </svg>
+</span>
+`;
+
+exports[`Storyshots Atoms | Spinner Spinner default 1`] = `
+.c0 {
+  display: inline-block;
+  -webkit-animation: spinner 1s linear infinite;
+  animation: spinner 1s linear infinite;
+}
+
+.c1 {
+  display: block;
+}
+
+<span
+  className="c0"
+>
+  <svg
+    className="c1"
+    height={16}
+    viewBox="0 0 24 24"
+    width={16}
+  >
+    <defs>
+      <linearGradient
+        id="spinner-mySpinner-1"
+        x1="50%"
+        x2="50%"
+        y1="0%"
+        y2="100%"
+      >
+        <stop
+          offset="0%"
+          stopColor="#0046FF"
+          stopOpacity="0"
+        />
+        <stop
+          offset="100%"
+          stopColor="#0046FF"
+          stopOpacity=".5"
+        />
+      </linearGradient>
+      <linearGradient
+        id="spinner-mySpinner-2"
+        x1="50%"
+        x2="50%"
+        y1="0%"
+        y2="100%"
+      >
+        <stop
+          offset="0%"
+          stopColor="#0046FF"
+          stopOpacity=".5"
+        />
+        <stop
+          offset="100%"
+          stopColor="#0046FF"
+        />
+      </linearGradient>
+    </defs>
+    <g
+      fill="none"
+      fillRule="evenodd"
+    >
+      <path
+        d="M12,0 C18.627417,0 24,5.372583 24,12 C24,18.627417 18.627417,24 12,24 M12,21 C16.9705627,21 21,16.9705627 21,12 C21,7.02943725 16.9705627,3 12,3"
+        fill="url(#spinner-mySpinner-1)"
+      />
+      <path
+        d="M0,0 C6.627417,0 12,5.372583 12,12 C12,18.627417 6.627417,24 0,24 M0,21 C4.97056275,21 9,16.9705627 9,12 C9,7.02943725 4.97056275,3 0,3"
+        fill="url(#spinner-mySpinner-2)"
+        transform="rotate(-180 6 12)"
+      />
+    </g>
+  </svg>
+</span>
+`;
+
+exports[`Storyshots Atoms | Spinner Spinner with custom 2 sec delay 1`] = `null`;
+
+exports[`Storyshots Atoms | Spinner Spinner with default delay 1`] = `null`;
+
+exports[`Storyshots Atoms | Spinner Spinner with delay is set to false 1`] = `
 .c0 {
   display: inline-block;
   -webkit-animation: spinner 1s linear infinite;


### PR DESCRIPTION
A suggestion, we have this on graph component that if the data is loaded fast enough that the user is not even thinking about pressing F5 again yet we don't show the spinner at all.