### PR TITLE
make number input as type text

### DIFF
--- a/src/Molecules/Input/Number/Number.tsx
+++ b/src/Molecules/Input/Number/Number.tsx
@@ -98,12 +98,6 @@ const Input = styled(NormalizedElements.Input).attrs({ type: 'text' })<Partial<P
   text-align: center;
   box-sizing: border-box;
   z-index: 1;
-
-  &::-webkit-outer-spin-button,
-  &::-webkit-inner-spin-button {
-    -webkit-appearance: none; /* stylelint-disable-line property-no-vendor-prefix */
-    margin: 0;
-  }
 `;
 
 const components = {

--- a/src/Molecules/Input/Number/Number.tsx
+++ b/src/Molecules/Input/Number/Number.tsx
@@ -104,10 +104,6 @@ const Input = styled(NormalizedElements.Input).attrs({ type: 'text' })<Partial<P
     -webkit-appearance: none; /* stylelint-disable-line property-no-vendor-prefix */
     margin: 0;
   }
-
-  &[type='number'] {
-    -moz-appearance: textfield; /* stylelint-disable-line property-no-vendor-prefix */
-  }
 `;
 
 const components = {

--- a/src/Molecules/Input/Number/Number.types.ts
+++ b/src/Molecules/Input/Number/Number.types.ts
@@ -13,6 +13,21 @@ export type Props = {
   extraInfo?: string;
   fieldId: string;
   fullWidth?: boolean;
+  /**
+   * none
+     No virtual keyboard;
+     this is useful when the application or site
+     implements its own keyboard input control.
+   * decimal
+      Fractional numeric input keyboard containing the digits
+      and the appropriate separator character for the user's
+      locale (typically either "." or ",").
+      Devices may or may not show a minus key.
+    numeric
+      Numeric input keyboard; all that is needed are the digits 0 through 9.
+      Devices may or may not show a minus key.
+   */
+  inputMode?: 'none' | 'numeric' | 'decimal';
   max?: string | number;
   min?: string | number;
   name?: string;

--- a/src/Molecules/Input/Number/__snapshots__/Number.stories.storyshot
+++ b/src/Molecules/Input/Number/__snapshots__/Number.stories.storyshot
@@ -188,11 +188,12 @@ exports[`Storyshots Molecules | Input / Number Default 1`] = `
       <input
         className="c6"
         id="insert-unique-id"
+        inputMode="decimal"
         min={0}
         onChange={[Function]}
         onKeyDown={[Function]}
         step={1}
-        type="number"
+        type="text"
         value="1"
       />
       <button
@@ -431,11 +432,12 @@ exports[`Storyshots Molecules | Input / Number Disabled 1`] = `
         className="c6"
         disabled={true}
         id="insert-unique-id"
+        inputMode="decimal"
         min={0}
         onChange={[Function]}
         onKeyDown={[Function]}
         step="0.25"
-        type="number"
+        type="text"
         value="152.25"
       />
       <button
@@ -685,12 +687,13 @@ exports[`Storyshots Molecules | Input / Number Required 1`] = `
       <input
         className="c6"
         id="insert-unique-id"
+        inputMode="decimal"
         min={0}
         onChange={[Function]}
         onKeyDown={[Function]}
         required={true}
         step={1}
-        type="number"
+        type="text"
         value="91"
       />
       <button
@@ -938,11 +941,12 @@ exports[`Storyshots Molecules | Input / Number With a smaller step 1`] = `
       <input
         className="c6"
         id="insert-unique-id"
+        inputMode="decimal"
         min={0}
         onChange={[Function]}
         onKeyDown={[Function]}
         step="0.005"
-        type="number"
+        type="text"
         value="15.200"
       />
       <button
@@ -1190,6 +1194,7 @@ exports[`Storyshots Molecules | Input / Number With all actions 1`] = `
       <input
         className="c6"
         id="insert-unique-id"
+        inputMode="decimal"
         min={0}
         onBlur={[Function]}
         onChange={[Function]}
@@ -1199,7 +1204,7 @@ exports[`Storyshots Molecules | Input / Number With all actions 1`] = `
         onKeyPress={[Function]}
         onKeyUp={[Function]}
         step={1}
-        type="number"
+        type="text"
         value="1"
       />
       <button
@@ -1448,11 +1453,12 @@ exports[`Storyshots Molecules | Input / Number With auto focus 1`] = `
         autoFocus={true}
         className="c6"
         id="insert-unique-id"
+        inputMode="decimal"
         min={0}
         onChange={[Function]}
         onKeyDown={[Function]}
         step="0.25"
-        type="number"
+        type="text"
         value="152.25"
       />
       <button
@@ -1700,11 +1706,12 @@ exports[`Storyshots Molecules | Input / Number With default value (Uncontrolled 
       <input
         className="c6"
         id="insert-unique-id"
+        inputMode="decimal"
         min={0}
         onChange={[Function]}
         onKeyDown={[Function]}
         step="0.1"
-        type="number"
+        type="text"
         value="15.2"
       />
       <button
@@ -1962,11 +1969,12 @@ exports[`Storyshots Molecules | Input / Number With error if value is less than 
         aria-invalid={true}
         className="c6"
         id="insert-unique-id"
+        inputMode="decimal"
         min={0}
         onChange={[Function]}
         onKeyDown={[Function]}
         step="1"
-        type="number"
+        type="text"
         value="0"
       />
       <button
@@ -2236,11 +2244,12 @@ exports[`Storyshots Molecules | Input / Number With extra info and error 1`] = `
         aria-invalid={true}
         className="c6"
         id="insert-unique-id"
+        inputMode="decimal"
         min={0}
         onChange={[Function]}
         onKeyDown={[Function]}
         step={1}
-        type="number"
+        type="text"
         value="0"
       />
       <button
@@ -2509,11 +2518,12 @@ exports[`Storyshots Molecules | Input / Number With extra info below 1`] = `
       <input
         className="c6"
         id="insert-unique-id"
+        inputMode="decimal"
         min={0}
         onChange={[Function]}
         onKeyDown={[Function]}
         step={1}
-        type="number"
+        type="text"
         value="1"
       />
       <button
@@ -2774,11 +2784,12 @@ exports[`Storyshots Molecules | Input / Number With hidden label 1`] = `
       <input
         className="c6"
         id="insert-unique-id"
+        inputMode="decimal"
         min={0}
         onChange={[Function]}
         onKeyDown={[Function]}
         step={1}
-        type="number"
+        type="text"
         value="1"
       />
       <button
@@ -3026,12 +3037,13 @@ exports[`Storyshots Molecules | Input / Number With max and min 1`] = `
       <input
         className="c6"
         id="insert-unique-id"
+        inputMode="decimal"
         max="20"
         min="10"
         onChange={[Function]}
         onKeyDown={[Function]}
         step={1}
-        type="number"
+        type="text"
         value="12"
       />
       <button
@@ -3205,11 +3217,12 @@ exports[`Storyshots Molecules | Input / Number With no steppers 1`] = `
       <input
         className="c6"
         id="insert-unique-id"
+        inputMode="decimal"
         min={0}
         onChange={[Function]}
         onKeyDown={[Function]}
         step={1}
-        type="number"
+        type="text"
         value="1"
       />
     </div>
@@ -3554,11 +3567,12 @@ Array [
               <input
                 className="c9"
                 id="insert-unique-id"
+                inputMode="decimal"
                 min={0}
                 onChange={[Function]}
                 onKeyDown={[Function]}
                 step={1}
-                type="number"
+                type="text"
                 value="1"
               />
               <button
@@ -3654,11 +3668,12 @@ Array [
               <input
                 className="c9"
                 id="insert-unique-id"
+                inputMode="decimal"
                 min={0}
                 onChange={[Function]}
                 onKeyDown={[Function]}
                 step={1}
-                type="number"
+                type="text"
                 value="1"
               />
             </div>
@@ -3701,11 +3716,12 @@ Array [
                 aria-invalid={true}
                 className="c13"
                 id="insert-unique-id"
+                inputMode="decimal"
                 min={0}
                 onChange={[Function]}
                 onKeyDown={[Function]}
                 step={1}
-                type="number"
+                type="text"
                 value="1"
               />
               <button
@@ -3978,12 +3994,13 @@ exports[`Storyshots Molecules | Input / Number With success 1`] = `
       <input
         className="c6"
         id="insert-unique-id"
+        inputMode="decimal"
         min={0}
         onChange={[Function]}
         onKeyDown={[Function]}
         step={1}
         success={true}
-        type="number"
+        type="text"
         value="1"
       />
       <button
@@ -4232,11 +4249,12 @@ Array [
         <input
           className="c6"
           id="insert-unique-id"
+          inputMode="decimal"
           min={0}
           onChange={[Function]}
           onKeyDown={[Function]}
           step={1}
-          type="number"
+          type="text"
           value="10"
         />
         <button

--- a/src/Molecules/Input/Number/__snapshots__/Number.stories.storyshot
+++ b/src/Molecules/Input/Number/__snapshots__/Number.stories.storyshot
@@ -160,10 +160,6 @@ exports[`Storyshots Molecules | Input / Number Default 1`] = `
   margin: 0;
 }
 
-.c6[type='number'] {
-  -moz-appearance: textfield;
-}
-
 <div
   className="c0"
 >
@@ -401,10 +397,6 @@ exports[`Storyshots Molecules | Input / Number Disabled 1`] = `
 .c6::-webkit-inner-spin-button {
   -webkit-appearance: none;
   margin: 0;
-}
-
-.c6[type='number'] {
-  -moz-appearance: textfield;
 }
 
 <div
@@ -659,10 +651,6 @@ exports[`Storyshots Molecules | Input / Number Required 1`] = `
   margin: 0;
 }
 
-.c6[type='number'] {
-  -moz-appearance: textfield;
-}
-
 <div
   className="c0"
 >
@@ -913,10 +901,6 @@ exports[`Storyshots Molecules | Input / Number With a smaller step 1`] = `
   margin: 0;
 }
 
-.c6[type='number'] {
-  -moz-appearance: textfield;
-}
-
 <div
   className="c0"
 >
@@ -1164,10 +1148,6 @@ exports[`Storyshots Molecules | Input / Number With all actions 1`] = `
 .c6::-webkit-inner-spin-button {
   -webkit-appearance: none;
   margin: 0;
-}
-
-.c6[type='number'] {
-  -moz-appearance: textfield;
 }
 
 <div
@@ -1424,10 +1404,6 @@ exports[`Storyshots Molecules | Input / Number With auto focus 1`] = `
   margin: 0;
 }
 
-.c6[type='number'] {
-  -moz-appearance: textfield;
-}
-
 <div
   className="c0"
 >
@@ -1676,10 +1652,6 @@ exports[`Storyshots Molecules | Input / Number With default value (Uncontrolled 
 .c6::-webkit-inner-spin-button {
   -webkit-appearance: none;
   margin: 0;
-}
-
-.c6[type='number'] {
-  -moz-appearance: textfield;
 }
 
 <div
@@ -1938,10 +1910,6 @@ exports[`Storyshots Molecules | Input / Number With error if value is less than 
 .c6::-webkit-inner-spin-button {
   -webkit-appearance: none;
   margin: 0;
-}
-
-.c6[type='number'] {
-  -moz-appearance: textfield;
 }
 
 <div
@@ -2215,10 +2183,6 @@ exports[`Storyshots Molecules | Input / Number With extra info and error 1`] = `
   margin: 0;
 }
 
-.c6[type='number'] {
-  -moz-appearance: textfield;
-}
-
 <div
   className="c0"
 >
@@ -2490,10 +2454,6 @@ exports[`Storyshots Molecules | Input / Number With extra info below 1`] = `
   margin: 0;
 }
 
-.c6[type='number'] {
-  -moz-appearance: textfield;
-}
-
 <div
   className="c0"
 >
@@ -2756,10 +2716,6 @@ exports[`Storyshots Molecules | Input / Number With hidden label 1`] = `
   margin: 0;
 }
 
-.c6[type='number'] {
-  -moz-appearance: textfield;
-}
-
 <div
   className="c0"
 >
@@ -3009,10 +2965,6 @@ exports[`Storyshots Molecules | Input / Number With max and min 1`] = `
   margin: 0;
 }
 
-.c6[type='number'] {
-  -moz-appearance: textfield;
-}
-
 <div
   className="c0"
 >
@@ -3187,10 +3139,6 @@ exports[`Storyshots Molecules | Input / Number With no steppers 1`] = `
 .c6::-webkit-inner-spin-button {
   -webkit-appearance: none;
   margin: 0;
-}
-
-.c6[type='number'] {
-  -moz-appearance: textfield;
 }
 
 <div
@@ -3429,10 +3377,6 @@ Array [
   margin: 0;
 }
 
-.c9[type='number'] {
-  -moz-appearance: textfield;
-}
-
 .c13 {
   font-family: inherit;
   font-size: 100%;
@@ -3466,10 +3410,6 @@ Array [
 .c13::-webkit-inner-spin-button {
   -webkit-appearance: none;
   margin: 0;
-}
-
-.c13[type='number'] {
-  -moz-appearance: textfield;
 }
 
 .c0 {
@@ -3966,10 +3906,6 @@ exports[`Storyshots Molecules | Input / Number With success 1`] = `
   margin: 0;
 }
 
-.c6[type='number'] {
-  -moz-appearance: textfield;
-}
-
 <div
   className="c0"
 >
@@ -4219,10 +4155,6 @@ Array [
 .c6::-webkit-inner-spin-button {
   -webkit-appearance: none;
   margin: 0;
-}
-
-.c6[type='number'] {
-  -moz-appearance: textfield;
 }
 
 <div

--- a/src/Molecules/Input/Number/__snapshots__/Number.stories.storyshot
+++ b/src/Molecules/Input/Number/__snapshots__/Number.stories.storyshot
@@ -154,12 +154,6 @@ exports[`Storyshots Molecules | Input / Number Default 1`] = `
   z-index: 3;
 }
 
-.c6::-webkit-outer-spin-button,
-.c6::-webkit-inner-spin-button {
-  -webkit-appearance: none;
-  margin: 0;
-}
-
 <div
   className="c0"
 >
@@ -391,12 +385,6 @@ exports[`Storyshots Molecules | Input / Number Disabled 1`] = `
 .c6:focus {
   border-color: #0046FF;
   z-index: 3;
-}
-
-.c6::-webkit-outer-spin-button,
-.c6::-webkit-inner-spin-button {
-  -webkit-appearance: none;
-  margin: 0;
 }
 
 <div
@@ -645,12 +633,6 @@ exports[`Storyshots Molecules | Input / Number Required 1`] = `
   z-index: 3;
 }
 
-.c6::-webkit-outer-spin-button,
-.c6::-webkit-inner-spin-button {
-  -webkit-appearance: none;
-  margin: 0;
-}
-
 <div
   className="c0"
 >
@@ -895,12 +877,6 @@ exports[`Storyshots Molecules | Input / Number With a smaller step 1`] = `
   z-index: 3;
 }
 
-.c6::-webkit-outer-spin-button,
-.c6::-webkit-inner-spin-button {
-  -webkit-appearance: none;
-  margin: 0;
-}
-
 <div
   className="c0"
 >
@@ -1142,12 +1118,6 @@ exports[`Storyshots Molecules | Input / Number With all actions 1`] = `
 .c6:focus {
   border-color: #0046FF;
   z-index: 3;
-}
-
-.c6::-webkit-outer-spin-button,
-.c6::-webkit-inner-spin-button {
-  -webkit-appearance: none;
-  margin: 0;
 }
 
 <div
@@ -1398,12 +1368,6 @@ exports[`Storyshots Molecules | Input / Number With auto focus 1`] = `
   z-index: 3;
 }
 
-.c6::-webkit-outer-spin-button,
-.c6::-webkit-inner-spin-button {
-  -webkit-appearance: none;
-  margin: 0;
-}
-
 <div
   className="c0"
 >
@@ -1646,12 +1610,6 @@ exports[`Storyshots Molecules | Input / Number With default value (Uncontrolled 
 .c6:focus {
   border-color: #0046FF;
   z-index: 3;
-}
-
-.c6::-webkit-outer-spin-button,
-.c6::-webkit-inner-spin-button {
-  -webkit-appearance: none;
-  margin: 0;
 }
 
 <div
@@ -1904,12 +1862,6 @@ exports[`Storyshots Molecules | Input / Number With error if value is less than 
 .c6:focus {
   border-color: #0046FF;
   z-index: 3;
-}
-
-.c6::-webkit-outer-spin-button,
-.c6::-webkit-inner-spin-button {
-  -webkit-appearance: none;
-  margin: 0;
 }
 
 <div
@@ -2177,12 +2129,6 @@ exports[`Storyshots Molecules | Input / Number With extra info and error 1`] = `
   z-index: 3;
 }
 
-.c6::-webkit-outer-spin-button,
-.c6::-webkit-inner-spin-button {
-  -webkit-appearance: none;
-  margin: 0;
-}
-
 <div
   className="c0"
 >
@@ -2448,12 +2394,6 @@ exports[`Storyshots Molecules | Input / Number With extra info below 1`] = `
   z-index: 3;
 }
 
-.c6::-webkit-outer-spin-button,
-.c6::-webkit-inner-spin-button {
-  -webkit-appearance: none;
-  margin: 0;
-}
-
 <div
   className="c0"
 >
@@ -2710,12 +2650,6 @@ exports[`Storyshots Molecules | Input / Number With hidden label 1`] = `
   z-index: 3;
 }
 
-.c6::-webkit-outer-spin-button,
-.c6::-webkit-inner-spin-button {
-  -webkit-appearance: none;
-  margin: 0;
-}
-
 <div
   className="c0"
 >
@@ -2959,12 +2893,6 @@ exports[`Storyshots Molecules | Input / Number With max and min 1`] = `
   z-index: 3;
 }
 
-.c6::-webkit-outer-spin-button,
-.c6::-webkit-inner-spin-button {
-  -webkit-appearance: none;
-  margin: 0;
-}
-
 <div
   className="c0"
 >
@@ -3133,12 +3061,6 @@ exports[`Storyshots Molecules | Input / Number With no steppers 1`] = `
 .c6:focus {
   border-color: #0046FF;
   z-index: 3;
-}
-
-.c6::-webkit-outer-spin-button,
-.c6::-webkit-inner-spin-button {
-  -webkit-appearance: none;
-  margin: 0;
 }
 
 <div
@@ -3371,12 +3293,6 @@ Array [
   z-index: 3;
 }
 
-.c9::-webkit-outer-spin-button,
-.c9::-webkit-inner-spin-button {
-  -webkit-appearance: none;
-  margin: 0;
-}
-
 .c13 {
   font-family: inherit;
   font-size: 100%;
@@ -3404,12 +3320,6 @@ Array [
 .c13:focus {
   border-color: #0046FF;
   z-index: 3;
-}
-
-.c13::-webkit-outer-spin-button,
-.c13::-webkit-inner-spin-button {
-  -webkit-appearance: none;
-  margin: 0;
 }
 
 .c0 {
@@ -3900,12 +3810,6 @@ exports[`Storyshots Molecules | Input / Number With success 1`] = `
   z-index: 3;
 }
 
-.c6::-webkit-outer-spin-button,
-.c6::-webkit-inner-spin-button {
-  -webkit-appearance: none;
-  margin: 0;
-}
-
 <div
   className="c0"
 >
@@ -4149,12 +4053,6 @@ Array [
 .c6:focus {
   border-color: #0046FF;
   z-index: 3;
-}
-
-.c6::-webkit-outer-spin-button,
-.c6::-webkit-inner-spin-button {
-  -webkit-appearance: none;
-  margin: 0;
 }
 
 <div


### PR DESCRIPTION
input type number does not work well with localized values when using it together with react-intl. It's either we remove react-intl from this input or make it as text (as per this PR) with normalizing entered values to be numbers.

[inputmode](https://caniuse.com/#search=inputmode) is used for opening numerical keyboard on mobile devices when one has input type text, it's supported in few latest versions of  chrome and iOS safari which covers most of the users