### PR TITLE
feat: 🎸 left align number when no steppers for input.number

### DIFF
--- a/src/Molecules/Input/Number/Number.tsx
+++ b/src/Molecules/Input/Number/Number.tsx
@@ -109,7 +109,7 @@ const Input = styled(NormalizedElements.Input).attrs({ type: 'text' })<Partial<P
       ? `
       padding-top: ${p.theme.spacing.unit(2)}px;
       padding-bottom: ${p.theme.spacing.unit(2)}px;
-      padding-left: ${p.leftAddon ? p.theme.spacing.unit(10) : p.theme.spacing.unit(2)}px;
+      padding-left: ${p.leftAddon ? p.theme.spacing.unit(8) : p.theme.spacing.unit(2)}px;
       padding-right: ${p.rightAddon ? p.theme.spacing.unit(10) : p.theme.spacing.unit(2)}px;
       `
       : `

--- a/src/Molecules/Input/Number/Number.tsx
+++ b/src/Molecules/Input/Number/Number.tsx
@@ -102,12 +102,15 @@ const Input = styled(NormalizedElements.Input).attrs({ type: 'text' })<Partial<P
   ${borderStyles}
   ${height}
   width: 100%;
-  text-align: center;
+  text-align: ${p => (p.showSteppers ? 'center' : 'left')};
   box-sizing: border-box;
   ${p =>
     p.leftAddon || p.rightAddon
       ? `
-      padding: ${p.theme.spacing.unit(2)}px ${p.theme.spacing.unit(10)}px;
+      padding-top: ${p.theme.spacing.unit(2)}px;
+      padding-bottom: ${p.theme.spacing.unit(2)}px;
+      padding-left: ${p.leftAddon ? p.theme.spacing.unit(10) : p.theme.spacing.unit(2)}px;
+      padding-right: ${p.rightAddon ? p.theme.spacing.unit(10) : p.theme.spacing.unit(2)}px;
       `
       : `
       padding: ${p.theme.spacing.unit(2)}px;
@@ -288,6 +291,7 @@ const NumberInput: NumberComponent & {
               success,
               value: removeNonNumberCharacters(value),
               inputMode,
+              showSteppers,
             }}
             {...(hasError(error) ? { 'aria-invalid': true } : {})}
           />

--- a/src/Molecules/Input/Number/__snapshots__/Number.stories.storyshot
+++ b/src/Molecules/Input/Number/__snapshots__/Number.stories.storyshot
@@ -1772,9 +1772,12 @@ exports[`Storyshots Molecules | Input / Number With both addons 1`] = `
   position: relative;
   height: 40px;
   width: 100%;
-  text-align: center;
+  text-align: left;
   box-sizing: border-box;
-  padding: 8px 40px;
+  padding-top: 8px;
+  padding-bottom: 8px;
+  padding-left: 40px;
+  padding-right: 40px;
 }
 
 .c6:hover {
@@ -3225,9 +3228,12 @@ exports[`Storyshots Molecules | Input / Number With left addon 1`] = `
   position: relative;
   height: 40px;
   width: 100%;
-  text-align: center;
+  text-align: left;
   box-sizing: border-box;
-  padding: 8px 40px;
+  padding-top: 8px;
+  padding-bottom: 8px;
+  padding-left: 40px;
+  padding-right: 8px;
 }
 
 .c6:hover {
@@ -3601,7 +3607,7 @@ exports[`Storyshots Molecules | Input / Number With no steppers 1`] = `
   position: relative;
   height: 40px;
   width: 100%;
-  text-align: center;
+  text-align: left;
   box-sizing: border-box;
   padding: 8px;
   margin: 0 -1px;
@@ -3741,9 +3747,12 @@ exports[`Storyshots Molecules | Input / Number With right addon 1`] = `
   position: relative;
   height: 40px;
   width: 100%;
-  text-align: center;
+  text-align: left;
   box-sizing: border-box;
-  padding: 8px 40px;
+  padding-top: 8px;
+  padding-bottom: 8px;
+  padding-left: 8px;
+  padding-right: 40px;
 }
 
 .c6:hover {
@@ -3892,7 +3901,7 @@ Array [
   line-height: 1.4285714285714286;
 }
 
-.c14 {
+.c15 {
   font-family: 'Nordnet Sans Mono',-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
   color: #FF1900;
   margin: 0;
@@ -3999,11 +4008,11 @@ Array [
   overflow: visible;
   background-color: #FFFFFF;
   outline: none;
-  border: 1px solid #FF1900;
+  border: 1px solid #BCBCB6;
   position: relative;
   height: 32px;
   width: 100%;
-  text-align: center;
+  text-align: left;
   box-sizing: border-box;
   padding: 8px;
   margin: 0 -1px;
@@ -4016,6 +4025,35 @@ Array [
 }
 
 .c13:focus {
+  border-color: #0046FF;
+  z-index: 3;
+}
+
+.c14 {
+  font-family: inherit;
+  font-size: 100%;
+  line-height: 1.15;
+  margin: 0;
+  overflow: visible;
+  background-color: #FFFFFF;
+  outline: none;
+  border: 1px solid #FF1900;
+  position: relative;
+  height: 32px;
+  width: 100%;
+  text-align: center;
+  box-sizing: border-box;
+  padding: 8px;
+  margin: 0 -1px;
+  z-index: 1;
+}
+
+.c14:hover {
+  border-color: #4B4B46;
+  z-index: 2;
+}
+
+.c14:focus {
   border-color: #0046FF;
   z-index: 3;
 }
@@ -4212,7 +4250,7 @@ Array [
               className="c7 c8"
             >
               <input
-                className="c9"
+                className="c13"
                 id="insert-unique-id"
                 inputMode="decimal"
                 min={0}
@@ -4259,7 +4297,7 @@ Array [
             >
               <input
                 aria-invalid={true}
-                className="c13"
+                className="c14"
                 id="insert-unique-id"
                 inputMode="decimal"
                 min={0}
@@ -4327,7 +4365,7 @@ Array [
           </span>
           <div>
             <span
-              className="c14"
+              className="c15"
             >
               <div
                 className="c11"

--- a/src/Molecules/Input/Number/__snapshots__/Number.stories.storyshot
+++ b/src/Molecules/Input/Number/__snapshots__/Number.stories.storyshot
@@ -1776,7 +1776,7 @@ exports[`Storyshots Molecules | Input / Number With both addons 1`] = `
   box-sizing: border-box;
   padding-top: 8px;
   padding-bottom: 8px;
-  padding-left: 40px;
+  padding-left: 32px;
   padding-right: 40px;
 }
 
@@ -3232,7 +3232,7 @@ exports[`Storyshots Molecules | Input / Number With left addon 1`] = `
   box-sizing: border-box;
   padding-top: 8px;
   padding-bottom: 8px;
-  padding-left: 40px;
+  padding-left: 32px;
   padding-right: 8px;
 }
 

--- a/src/common/NormalizedElements/NormalizedInput.tsx
+++ b/src/common/NormalizedElements/NormalizedInput.tsx
@@ -19,6 +19,7 @@ const CleanInput = React.forwardRef((props: any, ref: React.Ref<HTMLInputElement
         'size',
         'sizeProp',
         'success',
+        'showSteppers',
       ],
       props,
     )}


### PR DESCRIPTION
Made the number left aligned when steppers aren't used. Steppers aren't used when noSteppers is set or when either/both left and right addon is used.  

![no_steppers](https://user-images.githubusercontent.com/6574350/66549977-c06a3480-eb44-11e9-9258-6c01f516f040.png)
![right_addon](https://user-images.githubusercontent.com/6574350/66549974-c06a3480-eb44-11e9-8bac-0b1e8741e191.png)
![left_addon](https://user-images.githubusercontent.com/6574350/66549975-c06a3480-eb44-11e9-93f9-355ba37e8194.png)
![both_addons](https://user-images.githubusercontent.com/6574350/66549973-c06a3480-eb44-11e9-9dba-42aad70687f9.png)
![steppers](https://user-images.githubusercontent.com/6574350/66549972-bfd19e00-eb44-11e9-93fd-8c0e867aea2c.png)