### PR TITLE
fix: 🐛 FeedbackBanner text no longer overflows in IE

### DIFF
--- a/src/Molecules/FeedbackBanner/FeedbackBanner.tsx
+++ b/src/Molecules/FeedbackBanner/FeedbackBanner.tsx
@@ -46,20 +46,24 @@ const StyledContainer = styled.div<FeedbackBannerProps>`
   box-sizing: border-box;
 `;
 
+const TextFlexbox = styled(Flexbox)`
+  width: 100%;
+`;
+
 export const FeedbackBanner: FeedbackBannerComponent = props => {
   const { variant, title, children, className } = props;
   return (
     <StyledContainer className={className} variant={variant}>
       <Flexbox container direction="row" alignItems="center" gutter={3}>
         <span>{getIcon(variant)}</span>
-        <Flexbox container item direction="column">
+        <TextFlexbox container item direction="column">
           {title && (
             <Typography type="secondary" weight="bold">
               {title}
             </Typography>
           )}
           <Typography type="secondary">{children}</Typography>
-        </Flexbox>
+        </TextFlexbox>
       </Flexbox>
     </StyledContainer>
   );

--- a/src/Molecules/FeedbackBanner/__snapshots__/FeedbackBanner.stories.storyshot
+++ b/src/Molecules/FeedbackBanner/__snapshots__/FeedbackBanner.stories.storyshot
@@ -27,7 +27,7 @@ exports[`Storyshots Molecules | FeedbackBanner Complex Children 1`] = `
   padding-top: 0;
 }
 
-.c3 {
+.c4 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -52,7 +52,7 @@ exports[`Storyshots Molecules | FeedbackBanner Complex Children 1`] = `
   display: block;
 }
 
-.c5 {
+.c6 {
   font-family: 'Nordnet Sans Mono',-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
   color: #282823;
   margin: 0;
@@ -61,7 +61,7 @@ exports[`Storyshots Molecules | FeedbackBanner Complex Children 1`] = `
   line-height: 1.4285714285714286;
 }
 
-.c4 {
+.c5 {
   font-family: 'Nordnet Sans Mono',-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
   color: #282823;
   margin: 0;
@@ -77,7 +77,11 @@ exports[`Storyshots Molecules | FeedbackBanner Complex Children 1`] = `
   box-sizing: border-box;
 }
 
-.c6 {
+.c3 {
+  width: 100%;
+}
+
+.c7 {
   display: inline;
   padding: 0;
   color: #0046FF;
@@ -85,7 +89,7 @@ exports[`Storyshots Molecules | FeedbackBanner Complex Children 1`] = `
   text-decoration: none;
 }
 
-.c6:hover {
+.c7:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
@@ -116,15 +120,15 @@ exports[`Storyshots Molecules | FeedbackBanner Complex Children 1`] = `
       </svg>
     </span>
     <div
-      className="c3"
+      className="c3 c4"
     >
       <span
-        className="c4"
+        className="c5"
       >
         Warning, complex child
       </span>
       <span
-        className="c5"
+        className="c6"
       >
         <div>
           <div>
@@ -133,7 +137,7 @@ exports[`Storyshots Molecules | FeedbackBanner Complex Children 1`] = `
           <div>
             For example, you can provide a 
             <a
-              className="c6"
+              className="c7"
               href="#/"
               onClick={[Function]}
             >
@@ -175,7 +179,7 @@ exports[`Storyshots Molecules | FeedbackBanner Default Usage 1`] = `
   padding-top: 0;
 }
 
-.c3 {
+.c4 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -200,7 +204,7 @@ exports[`Storyshots Molecules | FeedbackBanner Default Usage 1`] = `
   display: block;
 }
 
-.c5 {
+.c6 {
   font-family: 'Nordnet Sans Mono',-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
   color: #282823;
   margin: 0;
@@ -209,7 +213,7 @@ exports[`Storyshots Molecules | FeedbackBanner Default Usage 1`] = `
   line-height: 1.4285714285714286;
 }
 
-.c4 {
+.c5 {
   font-family: 'Nordnet Sans Mono',-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
   color: #282823;
   margin: 0;
@@ -223,6 +227,10 @@ exports[`Storyshots Molecules | FeedbackBanner Default Usage 1`] = `
   border-left: 4px solid #0046FF;
   padding: 4px 12px;
   box-sizing: border-box;
+}
+
+.c3 {
+  width: 100%;
 }
 
 <div
@@ -251,15 +259,15 @@ exports[`Storyshots Molecules | FeedbackBanner Default Usage 1`] = `
       </svg>
     </span>
     <div
-      className="c3"
+      className="c3 c4"
     >
       <span
-        className="c4"
+        className="c5"
       >
         Feedback banner
       </span>
       <span
-        className="c5"
+        className="c6"
       >
         Feedback banner should be used within modules to display information that needs attention. Content is flexible, it can contain links and plain text.
       </span>
@@ -295,7 +303,7 @@ exports[`Storyshots Molecules | FeedbackBanner Different Variant 1`] = `
   padding-top: 0;
 }
 
-.c6 {
+.c7 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -320,7 +328,7 @@ exports[`Storyshots Molecules | FeedbackBanner Different Variant 1`] = `
   display: block;
 }
 
-.c10 {
+.c11 {
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -334,7 +342,7 @@ exports[`Storyshots Molecules | FeedbackBanner Different Variant 1`] = `
   display: block;
 }
 
-.c12 {
+.c13 {
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -348,7 +356,7 @@ exports[`Storyshots Molecules | FeedbackBanner Different Variant 1`] = `
   display: block;
 }
 
-.c14 {
+.c15 {
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -362,7 +370,7 @@ exports[`Storyshots Molecules | FeedbackBanner Different Variant 1`] = `
   display: block;
 }
 
-.c8 {
+.c9 {
   font-family: 'Nordnet Sans Mono',-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
   color: #282823;
   margin: 0;
@@ -371,7 +379,7 @@ exports[`Storyshots Molecules | FeedbackBanner Different Variant 1`] = `
   line-height: 1.4285714285714286;
 }
 
-.c7 {
+.c8 {
   font-family: 'Nordnet Sans Mono',-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
   color: #282823;
   margin: 0;
@@ -387,25 +395,29 @@ exports[`Storyshots Molecules | FeedbackBanner Different Variant 1`] = `
   box-sizing: border-box;
 }
 
-.c9 {
+.c10 {
   background-color: #F5F5F5;
   border-left: 4px solid #FF1900;
   padding: 4px 12px;
   box-sizing: border-box;
 }
 
-.c11 {
+.c12 {
   background-color: #F5F5F5;
   border-left: 4px solid #FFCF00;
   padding: 4px 12px;
   box-sizing: border-box;
 }
 
-.c13 {
+.c14 {
   background-color: #F5F5F5;
   border-left: 4px solid #00D200;
   padding: 4px 12px;
   box-sizing: border-box;
+}
+
+.c6 {
+  width: 100%;
 }
 
 .c0 {
@@ -505,15 +517,15 @@ exports[`Storyshots Molecules | FeedbackBanner Different Variant 1`] = `
             </svg>
           </span>
           <div
-            className="c6"
+            className="c6 c7"
           >
             <span
-              className="c7"
+              className="c8"
             >
               Info
             </span>
             <span
-              className="c8"
+              className="c9"
             >
               This is an information message
             </span>
@@ -533,7 +545,7 @@ exports[`Storyshots Molecules | FeedbackBanner Different Variant 1`] = `
     </div>
     <div>
       <div
-        className="c9"
+        className="c10"
       >
         <div
           className="c4"
@@ -541,7 +553,7 @@ exports[`Storyshots Molecules | FeedbackBanner Different Variant 1`] = `
           <span>
             <svg
               aria-hidden="true"
-              className="c10"
+              className="c11"
               focusable="false"
               preserveAspectRatio="xMidYMid meet"
               role="presentation"
@@ -564,15 +576,15 @@ exports[`Storyshots Molecules | FeedbackBanner Different Variant 1`] = `
             </svg>
           </span>
           <div
-            className="c6"
+            className="c6 c7"
           >
             <span
-              className="c7"
+              className="c8"
             >
               Error
             </span>
             <span
-              className="c8"
+              className="c9"
             >
               This is an error message
             </span>
@@ -592,7 +604,7 @@ exports[`Storyshots Molecules | FeedbackBanner Different Variant 1`] = `
     </div>
     <div>
       <div
-        className="c11"
+        className="c12"
       >
         <div
           className="c4"
@@ -600,7 +612,7 @@ exports[`Storyshots Molecules | FeedbackBanner Different Variant 1`] = `
           <span>
             <svg
               aria-hidden="true"
-              className="c12"
+              className="c13"
               focusable="false"
               preserveAspectRatio="xMidYMid meet"
               role="presentation"
@@ -617,15 +629,15 @@ exports[`Storyshots Molecules | FeedbackBanner Different Variant 1`] = `
             </svg>
           </span>
           <div
-            className="c6"
+            className="c6 c7"
           >
             <span
-              className="c7"
+              className="c8"
             >
               Warning
             </span>
             <span
-              className="c8"
+              className="c9"
             >
               This is a warning message
             </span>
@@ -645,7 +657,7 @@ exports[`Storyshots Molecules | FeedbackBanner Different Variant 1`] = `
     </div>
     <div>
       <div
-        className="c13"
+        className="c14"
       >
         <div
           className="c4"
@@ -653,7 +665,7 @@ exports[`Storyshots Molecules | FeedbackBanner Different Variant 1`] = `
           <span>
             <svg
               aria-hidden="true"
-              className="c14"
+              className="c15"
               focusable="false"
               preserveAspectRatio="xMidYMid meet"
               role="presentation"
@@ -670,15 +682,15 @@ exports[`Storyshots Molecules | FeedbackBanner Different Variant 1`] = `
             </svg>
           </span>
           <div
-            className="c6"
+            className="c6 c7"
           >
             <span
-              className="c7"
+              className="c8"
             >
               Success
             </span>
             <span
-              className="c8"
+              className="c9"
             >
               This is a success message
             </span>
@@ -717,7 +729,7 @@ exports[`Storyshots Molecules | FeedbackBanner Displaying Title 1`] = `
   padding-top: 0;
 }
 
-.c6 {
+.c7 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -742,7 +754,7 @@ exports[`Storyshots Molecules | FeedbackBanner Displaying Title 1`] = `
   display: block;
 }
 
-.c8 {
+.c9 {
   font-family: 'Nordnet Sans Mono',-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
   color: #282823;
   margin: 0;
@@ -751,7 +763,7 @@ exports[`Storyshots Molecules | FeedbackBanner Displaying Title 1`] = `
   line-height: 1.4285714285714286;
 }
 
-.c7 {
+.c8 {
   font-family: 'Nordnet Sans Mono',-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
   color: #282823;
   margin: 0;
@@ -765,6 +777,10 @@ exports[`Storyshots Molecules | FeedbackBanner Displaying Title 1`] = `
   border-left: 4px solid #0046FF;
   padding: 4px 12px;
   box-sizing: border-box;
+}
+
+.c6 {
+  width: 100%;
 }
 
 .c0 {
@@ -864,15 +880,15 @@ exports[`Storyshots Molecules | FeedbackBanner Displaying Title 1`] = `
             </svg>
           </span>
           <div
-            className="c6"
+            className="c6 c7"
           >
             <span
-              className="c7"
+              className="c8"
             >
               This is a title
             </span>
             <span
-              className="c8"
+              className="c9"
             >
               This message has a title
             </span>
@@ -917,10 +933,10 @@ exports[`Storyshots Molecules | FeedbackBanner Displaying Title 1`] = `
             </svg>
           </span>
           <div
-            className="c6"
+            className="c6 c7"
           >
             <span
-              className="c8"
+              className="c9"
             >
               This message does not have a title
             </span>


### PR DESCRIPTION
Previous:
![image](https://user-images.githubusercontent.com/2612174/67559196-bcc7d780-f718-11e9-9c05-64e70cb817b6.png)

Updated:
![image](https://user-images.githubusercontent.com/2612174/67559259-e08b1d80-f718-11e9-98fc-541f98a97ab8.png)
