### PR TITLE
typography `as` is no longer bypassing the clean-step

### DIFF
--- a/src/Atoms/Portal/__snapshots__/Portal.stories.storyshot
+++ b/src/Atoms/Portal/__snapshots__/Portal.stories.storyshot
@@ -13,7 +13,6 @@ exports[`Storyshots Atoms | Portal Default Story 1`] = `
 <portal-dummy>
   <p
     className="c0"
-    type="primary"
   >
     This element is moved to the bottom of the body tag
   </p>
@@ -36,7 +35,6 @@ exports[`Storyshots Atoms | Portal If Attach To Prop Is Not A Html Element Then 
   <portal-dummy>
     <p
       className="c0"
-      type="primary"
     >
       This element should not be rendered
     </p>

--- a/src/Atoms/Typography/Typography.tsx
+++ b/src/Atoms/Typography/Typography.tsx
@@ -169,9 +169,14 @@ const getTypeStyles = (props: ThemedStyledProps<Props, Theme>) => {
     
   `;
 };
+const Span = styled.span``;
 
 const CleanSpan = React.forwardRef<HTMLSpanElement, any>((props, ref) => (
-  <span ref={ref} {...R.omit(['color', 'type', 'weight', 'lineHeight'])(props)} />
+  <Span
+    ref={ref}
+    as={props.forwardedAs}
+    {...R.omit(['color', 'type', 'weight', 'lineHeight'])(props)}
+  />
 ));
 
 const StyledTypography = styled(CleanSpan)<Props>`
@@ -189,7 +194,7 @@ export const Typography: React.FC<Props> = React.forwardRef<HTMLElement, Props>(
     <StyledTypography
       className={className}
       id={id}
-      as={as}
+      forwardedAs={as}
       color={color}
       type={type}
       weight={weight}

--- a/src/Molecules/CardWithTitle/__snapshots__/CardWithTitle.stories.storyshot
+++ b/src/Molecules/CardWithTitle/__snapshots__/CardWithTitle.stories.storyshot
@@ -215,7 +215,6 @@ exports[`Storyshots Molecules | CardWithTitle Integration Card With Title With C
       >
         <h2
           className="c5"
-          type="title3"
         >
           Konton
         </h2>
@@ -434,7 +433,6 @@ exports[`Storyshots Molecules | CardWithTitle Integration Faded Scroll With Heig
   >
     <h2
       className="c4"
-      type="title3"
     >
       Konton
     </h2>
@@ -600,7 +598,6 @@ exports[`Storyshots Molecules | CardWithTitle Integration With Faded Scroll 1`] 
   >
     <h2
       className="c3"
-      type="title3"
     >
       Konton
     </h2>

--- a/src/Molecules/CollapsibleCard/__snapshots__/CollapsibleCard.stories.storyshot
+++ b/src/Molecules/CollapsibleCard/__snapshots__/CollapsibleCard.stories.storyshot
@@ -146,7 +146,6 @@ exports[`Storyshots Molecules | CollapsibleCard Collapsed Initially 1`] = `
       >
         <h2
           className="c4"
-          type="title3"
         >
           Collapsed initially
         </h2>
@@ -179,7 +178,6 @@ exports[`Storyshots Molecules | CollapsibleCard Collapsed Initially 1`] = `
   >
     <p
       className="c8 c9"
-      type="primary"
     >
       Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
     </p>
@@ -333,7 +331,6 @@ exports[`Storyshots Molecules | CollapsibleCard Collapsible With Custom Componen
       >
         <h2
           className="c4"
-          type="title3"
         >
           <div>
             Custom title
@@ -368,7 +365,6 @@ exports[`Storyshots Molecules | CollapsibleCard Collapsible With Custom Componen
   >
     <p
       className="c8 c9"
-      type="primary"
     >
       Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
     </p>
@@ -522,7 +518,6 @@ exports[`Storyshots Molecules | CollapsibleCard Collapsible With On Click Listen
       >
         <h2
           className="c4"
-          type="title3"
         >
           I've been clicked 0 times
         </h2>
@@ -555,7 +550,6 @@ exports[`Storyshots Molecules | CollapsibleCard Collapsible With On Click Listen
   >
     <p
       className="c8 c9"
-      type="primary"
     >
       On mobile the onClick event should fire for onTouchStart and not onClick.
     </p>
@@ -709,7 +703,6 @@ exports[`Storyshots Molecules | CollapsibleCard Default Story 1`] = `
       >
         <h2
           className="c4"
-          type="title3"
         >
           Collapsible
         </h2>
@@ -742,7 +735,6 @@ exports[`Storyshots Molecules | CollapsibleCard Default Story 1`] = `
   >
     <p
       className="c8 c9"
-      type="primary"
     >
       Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
     </p>

--- a/src/Molecules/Drawer/__snapshots__/Drawer.stories.storyshot
+++ b/src/Molecules/Drawer/__snapshots__/Drawer.stories.storyshot
@@ -308,7 +308,6 @@ exports[`Storyshots Molecules | Drawer Default Story 1`] = `
               >
                 <h2
                   className="c2 c3"
-                  type="title2"
                 >
                   Drawer title
                 </h2>
@@ -357,7 +356,6 @@ exports[`Storyshots Molecules | Drawer Default Story 1`] = `
                 <div>
                   <p
                     className="c13"
-                    type="primary"
                   >
                     Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo.
                   </p>
@@ -381,7 +379,6 @@ exports[`Storyshots Molecules | Drawer Default Story 1`] = `
                   </span>
                   <p
                     className="c13"
-                    type="primary"
                   >
                     Quisque sit amet est et sapien ullamcorper pharetra. Vestibulum erat wisi, condimentum sed, commodo vitae, ornare sit amet, wisi. Aenean fermentum, elit eget tincidunt condimentum, eros ipsum rutrum orci, sagittis tempus lacus enim ac dui. Donec non enim in turpis pulvinar facilisis. Ut felis. Praesent dapibus, neque id cursus faucibus, tortor neque egestas augue, eu vulputate magna eros eu erat. Aliquam erat volutpat. Nam dui mi, tincidunt quis, accumsan porttitor, facilisis luctus, metus
                   </p>
@@ -756,7 +753,6 @@ exports[`Storyshots Molecules | Drawer With Custom Title 1`] = `
                   </svg>
                   <h2
                     className="c4"
-                    type="title2"
                   >
                     Custom title
                   </h2>
@@ -806,7 +802,6 @@ exports[`Storyshots Molecules | Drawer With Custom Title 1`] = `
                 <div>
                   <p
                     className="c13"
-                    type="primary"
                   >
                     Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo.
                   </p>
@@ -830,7 +825,6 @@ exports[`Storyshots Molecules | Drawer With Custom Title 1`] = `
                   </span>
                   <p
                     className="c13"
-                    type="primary"
                   >
                     Quisque sit amet est et sapien ullamcorper pharetra. Vestibulum erat wisi, condimentum sed, commodo vitae, ornare sit amet, wisi. Aenean fermentum, elit eget tincidunt condimentum, eros ipsum rutrum orci, sagittis tempus lacus enim ac dui. Donec non enim in turpis pulvinar facilisis. Ut felis. Praesent dapibus, neque id cursus faucibus, tortor neque egestas augue, eu vulputate magna eros eu erat. Aliquam erat volutpat. Nam dui mi, tincidunt quis, accumsan porttitor, facilisis luctus, metus
                   </p>

--- a/src/Molecules/Modal/__snapshots__/Modal.stories.storyshot
+++ b/src/Molecules/Modal/__snapshots__/Modal.stories.storyshot
@@ -221,7 +221,6 @@ exports[`Storyshots Molecules | Modal Default Story 1`] = `
               >
                 <h2
                   className="c4 c5"
-                  type="title2"
                 >
                   Dialog information
                 </h2>
@@ -232,7 +231,6 @@ exports[`Storyshots Molecules | Modal Default Story 1`] = `
             >
               <p
                 className="c7"
-                type="primary"
               >
                 Modals should be used with care as they are quite intrusive on the user experience and demand immediate attention (while also blocking all other actions on the site). Always consider if you can solve a problem in another way first before you choose to go with the modal.
               </p>
@@ -242,7 +240,6 @@ exports[`Storyshots Molecules | Modal Default Story 1`] = `
             >
               <p
                 className="c7"
-                type="primary"
               >
                 That being said they are a good tool if you need to grab the users attention, either to communicate something very important or make them take an action before proceeding.
               </p>
@@ -252,14 +249,12 @@ exports[`Storyshots Molecules | Modal Default Story 1`] = `
             >
               <p
                 className="c7"
-                type="primary"
               >
                 Nielsen/Norman has an excellent article about their usage here
               </p>
             </div>
             <p
               className="c7"
-              type="primary"
             >
               <a
                 href="https:// www.nngroup.com/articles/modal-nonmodal-dialog/"
@@ -718,7 +713,6 @@ exports[`Storyshots Molecules | Modal Footer Story 1`] = `
               >
                 <h2
                   className="c4 c5"
-                  type="title2"
                 >
                   Dialog information
                 </h2>
@@ -741,7 +735,6 @@ exports[`Storyshots Molecules | Modal Footer Story 1`] = `
                   >
                     <p
                       className="c11"
-                      type="primary"
                     >
                       Modals should be used with care as they are quite intrusive on the user experience and demand immediate attention (while also blocking all other actions on the site). Always consider if you can solve a problem in another way first before you choose to go with the modal. Modals should be used with care as they are quite intrusive on the user experience and demand immediate attention (while also blocking all other actions on the site). Always consider if you can solve a problem in another way first before you choose to go with the modal.
                     </p>
@@ -751,7 +744,6 @@ exports[`Storyshots Molecules | Modal Footer Story 1`] = `
                   >
                     <p
                       className="c11"
-                      type="primary"
                     >
                       That being said they are a good tool if you need to grab the users attention, either to communicate something very important or make them take an action before proceeding. That being said they are a good tool if you need to grab the users attention, either to communicate something very important or make them take an action before proceeding.
                     </p>
@@ -761,7 +753,6 @@ exports[`Storyshots Molecules | Modal Footer Story 1`] = `
                   >
                     <p
                       className="c11"
-                      type="primary"
                     >
                       Modals should be used with care as they are quite intrusive on the user experience and demand immediate attention (while also blocking all other actions on the site). Always consider if you can solve a problem in another way first before you choose to go with the modal. Modals should be used with care as they are quite intrusive on the user experience and demand immediate attention (while also blocking all other actions on the site). Always consider if you can solve a problem in another way first before you choose to go with the modal.
                     </p>
@@ -771,7 +762,6 @@ exports[`Storyshots Molecules | Modal Footer Story 1`] = `
                   >
                     <p
                       className="c11"
-                      type="primary"
                     >
                       Modals should be used with care as they are quite intrusive on the user experience and demand immediate attention (while also blocking all other actions on the site). Always consider if you can solve a problem in another way first before you choose to go with the modal. Modals should be used with care as they are quite intrusive on the user experience and demand immediate attention (while also blocking all other actions on the site). Always consider if you can solve a problem in another way first before you choose to go with the modal.
                     </p>
@@ -781,14 +771,12 @@ exports[`Storyshots Molecules | Modal Footer Story 1`] = `
                   >
                     <p
                       className="c11"
-                      type="primary"
                     >
                       Nielsen/Norman has an excellent article about their usage here
                     </p>
                   </div>
                   <p
                     className="c11"
-                    type="primary"
                   >
                     <a
                       href="https:// www.nngroup.com/articles/modal-nonmodal-dialog/"
@@ -808,7 +796,6 @@ exports[`Storyshots Molecules | Modal Footer Story 1`] = `
               <div>
                 <p
                   className="c11"
-                  type="primary"
                 >
                   This is a footer which is a ReactNode, which could e.g. contain a button or only text
                 </p>
@@ -1027,7 +1014,6 @@ exports[`Storyshots Molecules | Modal Hide Close 1`] = `
               >
                 <h2
                   className="c4 c5"
-                  type="title2"
                 >
                   Dialog information
                 </h2>
@@ -1038,7 +1024,6 @@ exports[`Storyshots Molecules | Modal Hide Close 1`] = `
             >
               <p
                 className="c7"
-                type="primary"
               >
                 The close button in the upper right corner is now hidden because the prop hideClose is true.
               </p>
@@ -1316,7 +1301,6 @@ exports[`Storyshots Molecules | Modal Node As Title 1`] = `
                   </svg>
                   <h2
                     className="c6"
-                    type="title2"
                   >
                     React Node Title
                   </h2>
@@ -1341,7 +1325,6 @@ exports[`Storyshots Molecules | Modal Node As Title 1`] = `
             >
               <p
                 className="c8"
-                type="primary"
               >
                 Modals should be used with care as they are quite intrusive on the user experience and demand immediate attention (while also blocking all other actions on the site). Always consider if you can solve a problem in another way first before you choose to go with the modal.
               </p>
@@ -1351,7 +1334,6 @@ exports[`Storyshots Molecules | Modal Node As Title 1`] = `
             >
               <p
                 className="c8"
-                type="primary"
               >
                 That being said they are a good tool if you need to grab the users attention, either to communicate something very important or make them take an action before proceeding.
               </p>
@@ -1361,14 +1343,12 @@ exports[`Storyshots Molecules | Modal Node As Title 1`] = `
             >
               <p
                 className="c8"
-                type="primary"
               >
                 Nielsen/Norman has an excellent article about their usage here
               </p>
             </div>
             <p
               className="c8"
-              type="primary"
             >
               <a
                 href="https:// www.nngroup.com/articles/modal-nonmodal-dialog/"
@@ -1637,7 +1617,6 @@ exports[`Storyshots Molecules | Modal Uncontrolled Behavior 1`] = `
               >
                 <h2
                   className="c4 c5"
-                  type="title2"
                 >
                   Dialog information
                 </h2>
@@ -1648,7 +1627,6 @@ exports[`Storyshots Molecules | Modal Uncontrolled Behavior 1`] = `
             >
               <p
                 className="c7"
-                type="primary"
               >
                 Modals should be used with care as they are quite intrusive on the user experience and demand immediate attention (while also blocking all other actions on the site). Always consider if you can solve a problem in another way first before you choose to go with the modal.
               </p>
@@ -1658,7 +1636,6 @@ exports[`Storyshots Molecules | Modal Uncontrolled Behavior 1`] = `
             >
               <p
                 className="c7"
-                type="primary"
               >
                 That being said they are a good tool if you need to grab the users attention, either to communicate something very important or make them take an action before proceeding.
               </p>
@@ -1668,14 +1645,12 @@ exports[`Storyshots Molecules | Modal Uncontrolled Behavior 1`] = `
             >
               <p
                 className="c7"
-                type="primary"
               >
                 Nielsen/Norman has an excellent article about their usage here
               </p>
             </div>
             <p
               className="c7"
-              type="primary"
             >
               <a
                 href="https:// www.nngroup.com/articles/modal-nonmodal-dialog/"
@@ -1918,7 +1893,6 @@ exports[`Storyshots Molecules | Modal Without Header 1`] = `
             >
               <p
                 className="c4"
-                type="primary"
               >
                 Modals should be used with care as they are quite intrusive on the user experience and demand immediate attention (while also blocking all other actions on the site). Always consider if you can solve a problem in another way first before you choose to go with the modal.
               </p>
@@ -1928,7 +1902,6 @@ exports[`Storyshots Molecules | Modal Without Header 1`] = `
             >
               <p
                 className="c4"
-                type="primary"
               >
                 That being said they are a good tool if you need to grab the users attention, either to communicate something very important or make them take an action before proceeding.
               </p>
@@ -1938,14 +1911,12 @@ exports[`Storyshots Molecules | Modal Without Header 1`] = `
             >
               <p
                 className="c4"
-                type="primary"
               >
                 Nielsen/Norman has an excellent article about their usage here
               </p>
             </div>
             <p
               className="c4"
-              type="primary"
             >
               <a
                 href="https:// www.nngroup.com/articles/modal-nonmodal-dialog/"

--- a/src/Molecules/Number/__snapshots__/Number.stories.storyshot
+++ b/src/Molecules/Number/__snapshots__/Number.stories.storyshot
@@ -1229,7 +1229,6 @@ Array [
 
 <div
     className="c0"
-    type="title2"
   >
     <div
       className="c1"
@@ -1292,7 +1291,6 @@ Array [
 
 <div
     className="c0"
-    type="primary"
   >
     <div
       className="c1"

--- a/src/Molecules/PageHeaderCard/__snapshots__/PageHeaderCard.stories.storyshot
+++ b/src/Molecules/PageHeaderCard/__snapshots__/PageHeaderCard.stories.storyshot
@@ -123,7 +123,6 @@ exports[`Storyshots Molecules | PageHeader Page Header React Node Title 1`] = `
           >
             <h1
               className="c5"
-              type="title2"
             >
               I am a ReactNode
             </h1>
@@ -401,7 +400,6 @@ exports[`Storyshots Molecules | PageHeader Page Header With Children 1`] = `
           >
             <h1
               className="c5"
-              type="title2"
             >
               Your darkest loaves
             </h1>
@@ -585,7 +583,6 @@ exports[`Storyshots Molecules | PageHeader Regular Page Header 1`] = `
           >
             <h1
               className="c5"
-              type="title2"
             >
               Your darkest loaves
             </h1>

--- a/src/Organisms/CardWithTabs/__snapshots__/CardWithTabs.stories.storyshot
+++ b/src/Organisms/CardWithTabs/__snapshots__/CardWithTabs.stories.storyshot
@@ -203,7 +203,6 @@ Array [
     >
       <h2
         className="c5"
-        type="title3"
       >
         Title for the card
       </h2>
@@ -556,7 +555,6 @@ exports[`Storyshots Organisms | CardWithTabs Integration With Faded Scroll 1`] =
   >
     <h2
       className="c5"
-      type="title3"
     >
       Title for the card
     </h2>
@@ -987,7 +985,6 @@ exports[`Storyshots Organisms | CardWithTabs Integration With Faded Scroll With 
   >
     <h2
       className="c6"
-      type="title3"
     >
       Title for the card
     </h2>
@@ -1301,7 +1298,6 @@ exports[`Storyshots Organisms | CardWithTabs Integration With Typography And Ext
   >
     <h2
       className="c5"
-      type="title3"
     >
       Title for the card
     </h2>
@@ -1598,7 +1594,6 @@ exports[`Storyshots Organisms | CardWithTabs With Initial Active Tab Index 1`] =
   >
     <h2
       className="c5"
-      type="title3"
     >
       Title for the card
     </h2>


### PR DESCRIPTION
Before this fix:
If using `as`-prop in typography the `CleanSpan` is never used and therefore a warning/error is shown in the developer console if any other non-DOM prop is passed to the component.

```
<Typography as="h1" color={t = t.color.primary} />
```

After this fix:
The prop cleaning logic is applied even when using an `as` prop. 