### PR TITLE
feat: 🎸 add some onMouse props to Button component

### DIFF
--- a/src/Molecules/Button/Button.tsx
+++ b/src/Molecules/Button/Button.tsx
@@ -72,6 +72,9 @@ export const Button: ButtonComponent = React.forwardRef<
     as,
     loading,
     external,
+    onMouseEnter,
+    onMouseLeave,
+    onMouseOver,
   } = props;
   const externalIsNotPresent = typeof external === 'undefined';
   const toAndDisabledAreNotPresentTogether = !(to && disabled);
@@ -92,6 +95,9 @@ export const Button: ButtonComponent = React.forwardRef<
     fullWidth,
     colorFn: color,
     id,
+    onMouseEnter,
+    onMouseLeave,
+    onMouseOver,
   };
 
   if (colorFromTheme && (isPrimary(variant) || isSecondary(variant))) {

--- a/src/Molecules/Button/Button.types.ts
+++ b/src/Molecules/Button/Button.types.ts
@@ -4,6 +4,7 @@ import { Theme } from '../../theme/theme.types';
 
 type Colors = Theme['color'];
 type ColorFn = (t: Theme) => Colors['cta'] | Colors['negative'];
+
 export type ButtonProps = {
   /** @default primary */
   variant?: 'primary' | 'secondary' | 'neutral';
@@ -29,7 +30,7 @@ export type ButtonProps = {
   as?: any;
   loading?: boolean;
   ref?: React.Ref<HTMLAnchorElement> | React.Ref<HTMLButtonElement>;
-};
+} & Pick<React.DOMAttributes<HTMLButtonElement>, 'onMouseEnter' | 'onMouseLeave' | 'onMouseOver'>;
 
 type Omit<T, K> = Pick<T, Exclude<keyof T, K>>;
 type ForceRequired<T, K extends keyof T> = Omit<T, K> & Required<Pick<T, K>>;

--- a/src/Molecules/Button/Button.types.ts
+++ b/src/Molecules/Button/Button.types.ts
@@ -30,7 +30,10 @@ export type ButtonProps = {
   as?: any;
   loading?: boolean;
   ref?: React.Ref<HTMLAnchorElement> | React.Ref<HTMLButtonElement>;
-} & Pick<React.DOMAttributes<HTMLButtonElement>, 'onMouseEnter' | 'onMouseLeave' | 'onMouseOver'>;
+} & Pick<
+  React.DOMAttributes<HTMLButtonElement | HTMLAnchorElement>,
+  'onMouseEnter' | 'onMouseLeave' | 'onMouseOver'
+>;
 
 type Omit<T, K> = Pick<T, Exclude<keyof T, K>>;
 type ForceRequired<T, K extends keyof T> = Omit<T, K> & Required<Pick<T, K>>;


### PR DESCRIPTION
I'm very unsure about the best way to solve this problem but basically I want to allow some (or preferably all) React button attributes on the UI button component. Allowing all of them does however pose some problems as some conflict with the current Button props.

I've also thought about spreading rest of the props into the sharedProps object instead of picking the three I want but that would require me to omit some other props so idk.