### PR TITLE
fix: add min-width 0 to fix firefox

### DIFF
--- a/src/Molecules/Input/Number/Number.tsx
+++ b/src/Molecules/Input/Number/Number.tsx
@@ -117,6 +117,7 @@ const Input = styled(NormalizedElements.Input).attrs(() => ({ type: 'text' }))<P
       : `
       padding: ${p.theme.spacing.unit(2)}px;
       margin: 0 -1px;
+      min-width: 0;
       z-index: 1;
       `}
   

--- a/src/Molecules/Input/Number/__snapshots__/Number.stories.storyshot
+++ b/src/Molecules/Input/Number/__snapshots__/Number.stories.storyshot
@@ -153,6 +153,7 @@ exports[`Storyshots Molecules | Input / Number Default 1`] = `
   box-sizing: border-box;
   padding: 8px;
   margin: 0 -1px;
+  min-width: 0;
   z-index: 1;
 }
 
@@ -436,6 +437,7 @@ exports[`Storyshots Molecules | Input / Number Disabled 1`] = `
   box-sizing: border-box;
   padding: 8px;
   margin: 0 -1px;
+  min-width: 0;
   z-index: 1;
 }
 
@@ -752,6 +754,7 @@ Array [
   box-sizing: border-box;
   padding: 8px;
   margin: 0 -1px;
+  min-width: 0;
   z-index: 1;
 }
 
@@ -1232,6 +1235,7 @@ exports[`Storyshots Molecules | Input / Number With a smaller step 1`] = `
   box-sizing: border-box;
   padding: 8px;
   margin: 0 -1px;
+  min-width: 0;
   z-index: 1;
 }
 
@@ -1520,6 +1524,7 @@ exports[`Storyshots Molecules | Input / Number With all actions 1`] = `
   box-sizing: border-box;
   padding: 8px;
   margin: 0 -1px;
+  min-width: 0;
   z-index: 1;
 }
 
@@ -1813,6 +1818,7 @@ exports[`Storyshots Molecules | Input / Number With auto focus 1`] = `
   box-sizing: border-box;
   padding: 8px;
   margin: 0 -1px;
+  min-width: 0;
   z-index: 1;
 }
 
@@ -2337,6 +2343,7 @@ exports[`Storyshots Molecules | Input / Number With default value (Uncontrolled 
   box-sizing: border-box;
   padding: 8px;
   margin: 0 -1px;
+  min-width: 0;
   z-index: 1;
 }
 
@@ -2634,6 +2641,7 @@ exports[`Storyshots Molecules | Input / Number With error if value is less than 
   box-sizing: border-box;
   padding: 8px;
   margin: 0 -1px;
+  min-width: 0;
   z-index: 1;
 }
 
@@ -2944,6 +2952,7 @@ exports[`Storyshots Molecules | Input / Number With extra info and error 1`] = `
   box-sizing: border-box;
   padding: 8px;
   margin: 0 -1px;
+  min-width: 0;
   z-index: 1;
 }
 
@@ -3254,6 +3263,7 @@ exports[`Storyshots Molecules | Input / Number With extra info below 1`] = `
   box-sizing: border-box;
   padding: 8px;
   margin: 0 -1px;
+  min-width: 0;
   z-index: 1;
 }
 
@@ -3543,6 +3553,7 @@ exports[`Storyshots Molecules | Input / Number With hidden label 1`] = `
   box-sizing: border-box;
   padding: 8px;
   margin: 0 -1px;
+  min-width: 0;
   z-index: 1;
 }
 
@@ -3849,6 +3860,7 @@ exports[`Storyshots Molecules | Input / Number With label tooltip 1`] = `
   box-sizing: border-box;
   padding: 8px;
   margin: 0 -1px;
+  min-width: 0;
   z-index: 1;
 }
 
@@ -4386,6 +4398,7 @@ exports[`Storyshots Molecules | Input / Number With max and min 1`] = `
   box-sizing: border-box;
   padding: 8px;
   margin: 0 -1px;
+  min-width: 0;
   z-index: 1;
 }
 
@@ -4601,6 +4614,7 @@ exports[`Storyshots Molecules | Input / Number With no steppers 1`] = `
   box-sizing: border-box;
   padding: 8px;
   margin: 0 -1px;
+  min-width: 0;
   z-index: 1;
 }
 
@@ -4915,6 +4929,7 @@ Array [
   box-sizing: border-box;
   padding: 8px;
   margin: 0 -1px;
+  min-width: 0;
   z-index: 1;
 }
 
@@ -5100,6 +5115,7 @@ Array [
   box-sizing: border-box;
   padding: 8px;
   margin: 0 -1px;
+  min-width: 0;
   z-index: 1;
 }
 
@@ -5889,6 +5905,7 @@ Array [
   box-sizing: border-box;
   padding: 8px;
   margin: 0 -1px;
+  min-width: 0;
   z-index: 1;
 }
 
@@ -5950,6 +5967,7 @@ Array [
   box-sizing: border-box;
   padding: 8px;
   margin: 0 -1px;
+  min-width: 0;
   z-index: 1;
 }
 
@@ -6011,6 +6029,7 @@ Array [
   box-sizing: border-box;
   padding: 8px;
   margin: 0 -1px;
+  min-width: 0;
   z-index: 1;
 }
 
@@ -6556,6 +6575,7 @@ exports[`Storyshots Molecules | Input / Number With success 1`] = `
   box-sizing: border-box;
   padding: 8px;
   margin: 0 -1px;
+  min-width: 0;
   z-index: 1;
 }
 
@@ -6845,6 +6865,7 @@ Array [
   box-sizing: border-box;
   padding: 8px;
   margin: 0 -1px;
+  min-width: 0;
   z-index: 1;
 }
 


### PR DESCRIPTION
Firefox defaults min-width on flex items to auto which breaks % based widths.
Setting it to zero fixes the problem.