### PR TITLE
fix: change types so it accepts react nodes

### DIFF
--- a/src/Molecules/FormField/FormField.types.ts
+++ b/src/Molecules/FormField/FormField.types.ts
@@ -4,12 +4,12 @@ export type LabelAddonProp = {
 };
 
 export type Props = {
-  label?: string;
+  label?: React.ReactNode;
   hideLabel?: boolean;
   children: React.ReactNode;
   className?: string;
-  error?: string;
-  extraInfo?: string;
+  error?: React.ReactNode;
+  extraInfo?: React.ReactNode;
   fieldId?: string;
   /** @deprecated use fieldId */
   forId?: string;


### PR DESCRIPTION
Changes types to accept react nodes. This works today already but the types complain. String is a type of ReactNode so the current implementations will keep working with the correct types. This is also how CardWithTitle does it