### PR TITLE
fix: 🐛 make closing modal on backdrop click more performant

### DIFF
--- a/src/Molecules/Modal/Modal.types.ts
+++ b/src/Molecules/Modal/Modal.types.ts
@@ -9,8 +9,13 @@ export type InnerProps = {
   closeOnBackdropClick?: boolean;
 };
 
+export type BackdropProps = {
+  onClick: (e: React.ChangeEvent<HTMLElement>) => void;
+};
+
 export type DialogProps = {
   show: boolean;
+  onClick: (e: React.MouseEvent<HTMLElement>) => void;
 };
 
 export type Props = {

--- a/src/Molecules/Modal/ModalInner.tsx
+++ b/src/Molecules/Modal/ModalInner.tsx
@@ -4,10 +4,9 @@ import { RemoveScroll } from 'react-remove-scroll';
 import FocusLock from 'react-focus-lock';
 import styled from 'styled-components';
 import { motion } from 'framer-motion';
-import { DialogProps, Props } from './Modal.types';
+import { DialogProps, BackdropProps, Props } from './Modal.types';
 import NormalizedElements from '../../common/NormalizedElements';
 import { isFunction } from '../../common/utils';
-import { useOnClickOutside } from '../../common/Hooks';
 import { Title } from './Title';
 import { Flexbox, Icon, useKeyPress } from '../..';
 
@@ -15,7 +14,7 @@ const PADDING_DESKTOP = 10;
 const PADDING_MOBILE = 5;
 const CLOSE_ICON_SIZE = 5;
 
-export const Backdrop = styled(Flexbox)`
+export const Backdrop = styled(Flexbox)<BackdropProps>`
   position: fixed;
   top: 0;
   left: 0;
@@ -113,8 +112,23 @@ export const ModalInner: React.FC<Props> = ({
   const seed = useUIDSeed();
   const titleId = seed('ModalTitle');
   const hasHeader = !hideClose || title;
-  const ref = useRef<HTMLDivElement>(null);
-  useOnClickOutside(ref, onClose as () => void);
+  const backdropRef = useRef<HTMLDivElement>(null);
+  const dialogRef = useRef<HTMLDivElement>(null);
+
+  const handleBackdropClick = (e: React.ChangeEvent<HTMLElement>) => {
+    if (
+      backdropRef.current &&
+      backdropRef.current.contains(e.target) &&
+      closeOnBackdropClick &&
+      isFunction(onClose)
+    ) {
+      onClose();
+    }
+  };
+
+  const handleDialogClick = (e: React.MouseEvent<HTMLElement>) => {
+    e.stopPropagation();
+  };
 
   useEffect(() => {
     setShow(true); // Show is only used for animation
@@ -132,14 +146,21 @@ export const ModalInner: React.FC<Props> = ({
     <>
       <FocusLock autoFocus={autoFocus}>
         <RemoveScroll>
-          <Backdrop container alignItems="center" justifyContent="center">
+          <Backdrop
+            container
+            alignItems="center"
+            justifyContent="center"
+            ref={backdropRef}
+            onClick={handleBackdropClick}
+          >
             <Dialog
               aria-labelledby={titleId}
               className={className}
               show={show}
               role="dialog"
-              {...closeOnBackdropClick && { ref }}
               {...animationProps}
+              ref={dialogRef}
+              onClick={handleDialogClick}
             >
               {hasHeader && <Header>{title && <Title title={title} uid={titleId} />}</Header>}
               {children}

--- a/src/Molecules/Modal/__snapshots__/Modal.stories.storyshot
+++ b/src/Molecules/Modal/__snapshots__/Modal.stories.storyshot
@@ -211,6 +211,7 @@ exports[`Storyshots Molecules | Modal Close On Backdrop Click Story 1`] = `
       >
         <div
           className="c1 c2"
+          onClick={[Function]}
         >
           <div>
             <div
@@ -519,6 +520,7 @@ exports[`Storyshots Molecules | Modal Default 1`] = `
       >
         <div
           className="c1 c2"
+          onClick={[Function]}
         >
           <div>
             <div
@@ -760,6 +762,7 @@ exports[`Storyshots Molecules | Modal Hide Close button 1`] = `
       >
         <div
           className="c1 c2"
+          onClick={[Function]}
         >
           <div>
             <div
@@ -1198,6 +1201,7 @@ exports[`Storyshots Molecules | Modal Integration: Modal with a footer and Butto
       >
         <div
           className="c1 c2"
+          onClick={[Function]}
         >
           <div>
             <div
@@ -1579,6 +1583,7 @@ exports[`Storyshots Molecules | Modal Node as Title 1`] = `
       >
         <div
           className="c1 c2"
+          onClick={[Function]}
         >
           <div>
             <div
@@ -1911,6 +1916,7 @@ exports[`Storyshots Molecules | Modal Uncontrolled behavior 1`] = `
       >
         <div
           className="c1 c2"
+          onClick={[Function]}
         >
           <div>
             <div
@@ -2199,6 +2205,7 @@ exports[`Storyshots Molecules | Modal Without header 1`] = `
       >
         <div
           className="c1 c2"
+          onClick={[Function]}
         >
           <div>
             <div


### PR DESCRIPTION
Using useOnClickOutside on the backdrop created performance problems in the modals and did not play very well with the framer-motion library. This fix is more performant and works as intended.