### PR TITLE
fix: 🐛 expand item width to correct from design

### DIFF
--- a/src/Molecules/FlexTable/Row/ExpandItems/ExpandItem.tsx
+++ b/src/Molecules/FlexTable/Row/ExpandItems/ExpandItem.tsx
@@ -7,7 +7,7 @@ import { Props as FlexBoxProps } from '../../../../Atoms/Flexbox/Flexbox.types';
 import { TextWrapperLabel, TextWrapperValue } from './TextWrappers';
 
 const StyledFlexboxItem = styled(Flexbox)<FlexBoxProps>`
-  max-width: ${p => p.theme.spacing.unit(40)}px;
+  max-width: ${p => p.theme.spacing.unit(75)}px;
   padding-bottom: ${p => p.theme.spacing.unit(5)}px;
 `;
 

--- a/src/Molecules/FlexTable/__snapshots__/FlexTable.stories.storyshot
+++ b/src/Molecules/FlexTable/__snapshots__/FlexTable.stories.storyshot
@@ -107940,7 +107940,7 @@ exports[`Storyshots Molecules | FlexTable Expandable Table 1`] = `
 }
 
 .c34 {
-  max-width: 160px;
+  max-width: 300px;
   padding-bottom: 20px;
 }
 


### PR DESCRIPTION
Based on input from design, the max-width for expand item is now changed to 75 units/300px