### PR TITLE
Fix/table cell responsive fontsize

### DIFF
--- a/src/Molecules/FlexTable/Cell/Cell.tsx
+++ b/src/Molecules/FlexTable/Cell/Cell.tsx
@@ -7,6 +7,7 @@ import { useColumnLayout } from '../shared/ColumnProvider';
 import { CellComponent, InnerCellComponent } from './Cell.types';
 import { TextWrapper } from './TextWrapper';
 import { useFlexTable } from '../shared/FlexTableProvider';
+import { RenderForSizes } from '../shared';
 
 const StyledFlexbox = styled(Flexbox)`
   overflow: hidden;
@@ -24,22 +25,38 @@ const InnerCell: InnerCellComponent = React.memo(
 );
 
 const Cell: CellComponent = ({ children, className, columnId }) => {
+  const {
+    fontSize: xsFontSize,
+    sm: smTable,
+    md: mdTable,
+    lg: lgTable,
+    xl: xlTable,
+  } = useFlexTable();
   const [columnLayout] = useColumnLayout(columnId);
-  const { fontSize } = useFlexTable();
 
   if (!R.prop('flexProps', columnLayout)) {
     return null;
   }
 
   return (
-    <InnerCell
-      className={className}
-      columnId={columnId}
-      flexProps={columnLayout.flexProps}
-      fontSize={fontSize}
-    >
-      {children}
-    </InnerCell>
+    <RenderForSizes
+      xs={{ fontSize: xsFontSize }}
+      sm={smTable}
+      md={mdTable}
+      lg={lgTable}
+      xl={xlTable}
+      Container={({ fontSize, children: component }) => (
+        <InnerCell
+          className={className}
+          columnId={columnId}
+          flexProps={columnLayout.flexProps}
+          fontSize={fontSize}
+        >
+          {component}
+        </InnerCell>
+      )}
+      Component={() => children}
+    />
   );
 };
 

--- a/src/Molecules/FlexTable/Header/HeaderContent/HeaderContent.tsx
+++ b/src/Molecules/FlexTable/Header/HeaderContent/HeaderContent.tsx
@@ -8,7 +8,7 @@ import { SortIcon } from './SortIcon';
 import { SortButton } from './SortButton';
 import { useFlexTable } from '../../shared/FlexTableProvider';
 import { Flexbox } from '../../../..';
-import { CellInlineContainer } from '../../shared';
+import { CellInlineContainer, RenderForSizes } from '../../shared';
 
 const StyledFlexboxContainer = styled(Flexbox)`
   justify-content: inherit;
@@ -20,30 +20,57 @@ export const HeaderContent: React.FC<Props & UIProps> = ({
   onSortClick,
   children,
 }) => {
-  const { fontSize } = useFlexTable();
+  const {
+    fontSize: xsFontSize,
+    sm: smTable,
+    md: mdTable,
+    lg: lgTable,
+    xl: xlTable,
+  } = useFlexTable();
+
   if (!sortable || sortOrder === null) {
     return (
-      <TextWrapper fontSize={fontSize} sorted={false}>
-        {children}
-      </TextWrapper>
+      <RenderForSizes
+        xs={{ fontSize: xsFontSize }}
+        sm={smTable}
+        md={mdTable}
+        lg={lgTable}
+        xl={xlTable}
+        Container={({ fontSize, children: component }) => (
+          <TextWrapper fontSize={fontSize} sorted={false}>
+            {component}
+          </TextWrapper>
+        )}
+        Component={() => children}
+      />
     );
   }
 
   return (
-    <SortButton onClick={onSortClick}>
-      <StyledFlexboxContainer container>
-        <CellInlineContainer item>
-          <TextWrapper
-            fontSize={fontSize}
-            sorted={!R.isNil(sortOrder) && sortOrder !== SORT_ORDER_NONE}
-          >
-            {children}
-          </TextWrapper>
-        </CellInlineContainer>
-        <Flexbox item>
-          <SortIcon sortOrder={sortOrder} />
-        </Flexbox>
-      </StyledFlexboxContainer>
-    </SortButton>
+    <RenderForSizes
+      xs={{ fontSize: xsFontSize }}
+      sm={smTable}
+      md={mdTable}
+      lg={lgTable}
+      xl={xlTable}
+      Container={({ children: component }) => (
+        <SortButton onClick={onSortClick}>{component}</SortButton>
+      )}
+      Component={({ fontSize }) => (
+        <StyledFlexboxContainer container>
+          <CellInlineContainer item>
+            <TextWrapper
+              fontSize={fontSize}
+              sorted={!R.isNil(sortOrder) && sortOrder !== SORT_ORDER_NONE}
+            >
+              {children}
+            </TextWrapper>
+          </CellInlineContainer>
+          <Flexbox item>
+            <SortIcon sortOrder={sortOrder} />
+          </Flexbox>
+        </StyledFlexboxContainer>
+      )}
+    />
   );
 };


### PR DESCRIPTION
Previously, `HeaderContent` and `Cell` didn't respond to the responsive `fontSize` based on Media from `FlexTable`, this changes that by adding `<RenderForSizes />` to the components.