### PR TITLE
fix: 🐛 remove legacy expand and rework types

### DIFF
--- a/src/Molecules/FlexTable/Row/Row.types.ts
+++ b/src/Molecules/FlexTable/Row/Row.types.ts
@@ -9,32 +9,20 @@ import { MediaRelatedProps } from '../shared/shared.types';
 
 type HtmlProps = {} & React.HTMLAttributes<HTMLDivElement>;
 
-interface Expand {
+export type ExpandAreaProps = {
   expanded?: boolean;
   expandChildren?: ReactNode;
   expandItems?: ExpandItems;
-}
-
-interface IncludeExpand extends Expand {
-  includeExpand?: true;
-  onExpandToggle?: (expanded: boolean) => void;
-}
-
-interface ExcludeExpand extends Expand {
-  includeExpand?: false;
-  onExpandToggle?: undefined;
-}
-
-export type ExpandProps = IncludeExpand | ExcludeExpand;
-export type ExpandAreaProps = Expand;
+  onExpandToggle?: (expanded: boolean) => void | undefined;
+};
 
 type Props = {
   hideSeparator?: boolean;
   hoverHighlight?: boolean;
   separatorColor?: ColorFn;
   isContent?: boolean;
-} & ExpandProps &
-  MediaRelatedProps<Pick<Expand, 'expandItems' | 'expandChildren'>> &
+} & ExpandAreaProps &
+  MediaRelatedProps<Pick<ExpandAreaProps, 'expandItems' | 'expandChildren'>> &
   HtmlProps;
 
 export type RowComponents = {

--- a/src/Molecules/FlexTable/Row/components/ExpandElement.tsx
+++ b/src/Molecules/FlexTable/Row/components/ExpandElement.tsx
@@ -1,11 +1,15 @@
 import React from 'react';
 import FlexTable from '../..';
-import { ExpandProps } from '../Row.types';
+import { ExpandAreaProps } from '../Row.types';
 import { ExpandCell } from '../../Cell/ExpandCell';
 import { ICON_COLUMN_DEFAULT_FLEX_PROPS, COLUMN_ID_EXPAND } from '../../shared/constants';
 
 export const ExpandElement: React.FC<
-  ExpandProps & { isContent: boolean; disabled?: boolean; setExpand: (expanded: boolean) => void }
+  ExpandAreaProps & {
+    isContent: boolean;
+    disabled?: boolean;
+    setExpand: (expanded: boolean) => void;
+  }
 > = ({ isContent, expanded = false, onExpandToggle, setExpand, disabled }) => {
   if (!isContent) {
     return (


### PR DESCRIPTION
Removed old `expand` functionality after `expandable` was moved to table-level