### PR TITLE
Fix/table key prop

### DIFF
--- a/src/Molecules/FlexTable/Row/components/ExpandItems/ExpandItems.tsx
+++ b/src/Molecules/FlexTable/Row/components/ExpandItems/ExpandItems.tsx
@@ -17,15 +17,15 @@ export const ExpandItems: ExpandItemsComponent = ({ items }) => {
     <>
       <Media query={t => t.media.lessThan(t.breakpoints.md)}>
         <List>
-          {items.map(item => (
-            <ExpandItem item={item} />
+          {items.map((item, index) => (
+            <ExpandItem key={`expandItem_mobile_${index + 1}`} item={item} />
           ))}
         </List>
       </Media>
       <Media query={t => t.media.greaterThan(t.breakpoints.md)}>
         <Flexbox container wrap="wrap" gutter={10} as={FlexList}>
-          {items.map(item => (
-            <ExpandItem item={item} />
+          {items.map((item, index) => (
+            <ExpandItem key={`expandItem_desktop_${index + 1}`} item={item} />
           ))}
         </Flexbox>
       </Media>

--- a/src/Molecules/FlexTable/shared/RenderForSizes/RenderForSizes.tsx
+++ b/src/Molecules/FlexTable/shared/RenderForSizes/RenderForSizes.tsx
@@ -62,7 +62,7 @@ export const RenderForSizes: RenderForSizesComponent = ({
         const container = Container({ children: component, ...props });
 
         if (size === 'xs' && !nextSize) {
-          return container;
+          return <React.Fragment key={size}>{container}</React.Fragment>;
         }
 
         const as = (() => container) as React.FC;

--- a/src/Molecules/FlexTable/shared/RenderForSizes/RenderForSizes.tsx
+++ b/src/Molecules/FlexTable/shared/RenderForSizes/RenderForSizes.tsx
@@ -67,7 +67,13 @@ export const RenderForSizes: RenderForSizesComponent = ({
 
         const as = (() => container) as React.FC;
 
-        return <Media key={size} query={t => getMediaQuery(t, size, nextSize)} as={as} />;
+        return (
+          <Media
+            key={`${size}${index + 1}`}
+            query={t => getMediaQuery(t, size, nextSize)}
+            as={as}
+          />
+        );
       })}
     </>
   );

--- a/src/Molecules/FlexTable/shared/RenderForSizes/RenderForSizes.tsx
+++ b/src/Molecules/FlexTable/shared/RenderForSizes/RenderForSizes.tsx
@@ -67,13 +67,7 @@ export const RenderForSizes: RenderForSizesComponent = ({
 
         const as = (() => container) as React.FC;
 
-        return (
-          <Media
-            key={`${size}${index + 1}`}
-            query={t => getMediaQuery(t, size, nextSize)}
-            as={as}
-          />
-        );
+        return <Media key={size} query={t => getMediaQuery(t, size, nextSize)} as={as} />;
       })}
     </>
   );


### PR DESCRIPTION
The new FlexTable missed som key-props for some maps, which this fixes