### PR TITLE
fix: 🐛 drawer menu now closes on step click

### DIFF
--- a/src/Molecules/MultiStepProgress/MultiStepProgress.stories.tsx
+++ b/src/Molecules/MultiStepProgress/MultiStepProgress.stories.tsx
@@ -56,6 +56,19 @@ basicMultiStepProgress.story = {
   name: 'Basic Multi Step Progress',
 };
 
+export const basicMultiStepProgressWithDrawerClose = () => (
+  <MultiStepProgress
+    steps={mockedSteps}
+    onStepClick={action(`step click`)}
+    onSubStepClick={action(`sub step click`)}
+    closeDrawerOnStepClick
+  />
+);
+
+basicMultiStepProgressWithDrawerClose.story = {
+  name: 'Basic Multi Step Progress (With Closing Drawer)',
+};
+
 export const notStartedMultiStepProgress = () => (
   <MultiStepProgress
     steps={mockedStepsNotStarted}

--- a/src/Molecules/MultiStepProgress/MultiStepProgress.tsx
+++ b/src/Molecules/MultiStepProgress/MultiStepProgress.tsx
@@ -20,6 +20,7 @@ export const MultiStepProgress: MultiStepProgressComponent = ({
   titleDone = 'Completed',
   titleNotDone = 'Not completed',
   mobileDrawerTitle = 'Start monthly savings',
+  closeDrawerOnStepClick = false,
 }) => {
   // TODO: use context to pass these lovely props down the rabbit hole
   const [open, setOpen] = useState(false);
@@ -31,6 +32,12 @@ export const MultiStepProgress: MultiStepProgressComponent = ({
   const onDrawerClose = () => {
     setOpen(false);
   };
+
+  const onStepClickDrawerClose = (value: string) => {
+    if (closeDrawerOnStepClick) onDrawerClose();
+    if (onStepClick) onStepClick(value);
+  };
+
   return (
     <>
       <Card>
@@ -61,7 +68,7 @@ export const MultiStepProgress: MultiStepProgressComponent = ({
         >
           <div role="group" aria-label={title}>
             <TopLevel
-              onStepClick={onStepClick}
+              onStepClick={onStepClickDrawerClose}
               onSubStepClick={onSubStepClick}
               steps={steps}
               titleDone={titleDone}

--- a/src/Molecules/MultiStepProgress/MultiStepProgress.types.ts
+++ b/src/Molecules/MultiStepProgress/MultiStepProgress.types.ts
@@ -18,6 +18,7 @@ export type MultiStepProgressProps = {
   /** Visible on non completed steps */
   titleNotDone?: string;
   mobileDrawerTitle?: string;
+  closeDrawerOnStepClick?: boolean;
 };
 
 export type MultiStepProgressComponent = React.FC<MultiStepProgressProps>;

--- a/src/Molecules/MultiStepProgress/__snapshots__/MultiStepProgress.stories.storyshot
+++ b/src/Molecules/MultiStepProgress/__snapshots__/MultiStepProgress.stories.storyshot
@@ -1,5 +1,738 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Storyshots Molecules | Multi Step Progress Basic Multi Step Progress (With Closing Drawer) 1`] = `
+Array [
+  .c9 {
+  padding-left: 44px;
+  padding-top: 12px;
+  padding-right: 12px;
+  padding-bottom: 12px;
+}
+
+.c22 {
+  padding-left: 44px;
+  padding-right: 12px;
+}
+
+.c26 {
+  padding-left: 44px;
+  padding-top: 12px;
+  padding-right: 12px;
+  padding-bottom: 12px;
+}
+
+.c0 {
+  background: #FFFFFF;
+  box-shadow: 0 2px 2px 0 rgba(0,0,0,0.03);
+}
+
+.c31 {
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c32 {
+  box-sizing: border-box;
+}
+
+.c11 {
+  position: absolute;
+  height: 1px;
+  width: 1px;
+  overflow: hidden;
+  -webkit-clip: rect(1px,1px,1px,1px);
+  clip: rect(1px,1px,1px,1px);
+}
+
+.c14 {
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  width: 24px;
+  height: 24px;
+  fill: #00D200;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  display: block;
+}
+
+.c33 {
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  width: 20px;
+  height: 20px;
+  fill: #282823;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  display: block;
+}
+
+.c15 {
+  fill: #FFFFFF;
+}
+
+.c34 {
+  -webkit-transform: rotate(0deg);
+  -ms-transform: rotate(0deg);
+  transform: rotate(0deg);
+}
+
+.c7 {
+  font-family: 'Nordnet Sans Mono',-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
+  color: inherit;
+  margin: 0;
+  font-weight: 700;
+  font-size: 14px;
+  line-height: 1.4285714285714286;
+}
+
+.c8 {
+  font-family: 'Nordnet Sans Mono',-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
+  color: #282823;
+  margin: 0;
+  font-weight: 400;
+  font-size: 16px;
+  line-height: 1.5;
+}
+
+.c12 {
+  font-family: 'Nordnet Sans Mono',-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
+  color: #282823;
+  margin: 0;
+  font-weight: 700;
+  font-size: 14px;
+  line-height: 1.4285714285714286;
+}
+
+.c17 {
+  font-family: 'Nordnet Sans Mono',-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
+  color: #282823;
+  margin: 0;
+  font-weight: 700;
+  font-size: 16px;
+  line-height: 1.5;
+}
+
+.c24 {
+  font-family: 'Nordnet Sans Mono',-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
+  color: #A0A09B;
+  margin: 0;
+  font-weight: 400;
+  font-size: 14px;
+  line-height: 1.4285714285714286;
+}
+
+.c25 {
+  font-family: 'Nordnet Sans Mono',-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
+  color: #A0A09B;
+  margin: 0;
+  font-weight: 400;
+  font-size: 16px;
+  line-height: 1.5;
+}
+
+.c5 {
+  font-family: inherit;
+  font-size: 100%;
+  line-height: 1.15;
+  margin: 0;
+  overflow: visible;
+  text-transform: none;
+  position: relative;
+  box-sizing: border-box;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 100%;
+  padding: 0;
+  background-color: transparent;
+  color: #282823;
+  border: none;
+  border-radius: 0;
+  cursor: pointer;
+}
+
+.c5,
+.c5[type='button'],
+.c5[type='reset'],
+.c5[type='submit'] {
+  -webkit-appearance: button;
+}
+
+.c5::-moz-focus-inner,
+.c5[type='button']::-moz-focus-inner,
+.c5[type='reset']::-moz-focus-inner,
+.c5[type='submit']::-moz-focus-inner {
+  border-style: none;
+  padding: 0;
+}
+
+.c5:-moz-focusring,
+.c5[type='button']:-moz-focusring,
+.c5[type='reset']:-moz-focusring,
+.c5[type='submit']:-moz-focusring {
+  outline: 1px dotted ButtonText;
+}
+
+.c23 {
+  font-family: inherit;
+  font-size: 100%;
+  line-height: 1.15;
+  margin: 0;
+  overflow: visible;
+  text-transform: none;
+  position: relative;
+  box-sizing: border-box;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  padding: 0;
+  background-color: transparent;
+  color: #282823;
+  border: none;
+  border-radius: 0;
+  cursor: pointer;
+}
+
+.c23,
+.c23[type='button'],
+.c23[type='reset'],
+.c23[type='submit'] {
+  -webkit-appearance: button;
+}
+
+.c23::-moz-focus-inner,
+.c23[type='button']::-moz-focus-inner,
+.c23[type='reset']::-moz-focus-inner,
+.c23[type='submit']::-moz-focus-inner {
+  border-style: none;
+  padding: 0;
+}
+
+.c23:-moz-focusring,
+.c23[type='button']:-moz-focusring,
+.c23[type='reset']:-moz-focusring,
+.c23[type='submit']:-moz-focusring {
+  outline: 1px dotted ButtonText;
+}
+
+.c13 {
+  position: absolute;
+  top: 12px;
+  left: 12px;
+}
+
+.c18 {
+  width: 24px;
+  height: 24px;
+  background-color: #0046FF;
+  color: #FFFFFF;
+  border-radius: 50%;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c27 {
+  width: 24px;
+  height: 24px;
+  background-color: #EBEBE8;
+  color: #A0A09B;
+  border-radius: 50%;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c19 {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  padding-bottom: 12px;
+}
+
+.c21 {
+  display: block;
+}
+
+.c21 + .c20 {
+  padding-top: 8px;
+}
+
+.c2 {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.c29 {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.c4 {
+  display: block;
+  position: relative;
+}
+
+.c4::before {
+  content: '';
+  display: block;
+  background: #0046FF;
+  width: 2px;
+  height: 100%;
+  position: absolute;
+  top: 0;
+  left: 0;
+  -webkit-transition: opacity 0.16s ease-out;
+  transition: opacity 0.16s ease-out;
+  opacity: 0;
+}
+
+.c4 + .c3 {
+  border-top: 8px solid #EBEBE8;
+}
+
+.c16 {
+  display: block;
+  position: relative;
+}
+
+.c16::before {
+  content: '';
+  display: block;
+  background: #0046FF;
+  width: 2px;
+  height: 100%;
+  position: absolute;
+  top: 0;
+  left: 0;
+  -webkit-transition: opacity 0.16s ease-out;
+  transition: opacity 0.16s ease-out;
+  opacity: 1;
+}
+
+.c16 + .c3 {
+  border-top: 8px solid #EBEBE8;
+}
+
+.c10 {
+  position: relative;
+}
+
+.c6 {
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+}
+
+.c30 {
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+}
+
+.c30 > span {
+  width: 100%;
+}
+
+@media (min-width:760px) {
+  .c9 {
+    padding-left: 52px;
+    padding-right: 20px;
+  }
+}
+
+@media (min-width:760px) {
+  .c22 {
+    padding-left: 52px;
+    padding-right: 20px;
+  }
+}
+
+@media (min-width:760px) {
+  .c26 {
+    padding-left: 52px;
+  }
+}
+
+@media not all and (min-width:976px) {
+  .c1 {
+    display: none;
+  }
+}
+
+@media not all and (max-width:975px) {
+  .c28 {
+    display: none;
+  }
+}
+
+@media (min-width:760px) {
+  .c13 {
+    left: 20px;
+  }
+}
+
+<div
+    className="c0"
+  >
+    <div
+      aria-label="Progress"
+      role="group"
+    >
+      <div
+        className="c1"
+      >
+        <ol
+          className="c2"
+        >
+          <li
+            className="c3 c4"
+          >
+            <button
+              className="NormalizedButton__Button-ey7f5x-0 c5 c6"
+              onClick={[Function]}
+              type="button"
+            >
+              <span
+                className="c7"
+              >
+                <span
+                  className="c8"
+                >
+                  <div
+                    className="c9 c10"
+                  >
+                    <div
+                      className="c11"
+                    >
+                      Completed
+                    </div>
+                    <span
+                      aria-hidden={true}
+                      className="c12 c13"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        className="c14"
+                        focusable="false"
+                        preserveAspectRatio="xMidYMid meet"
+                        role="presentation"
+                        viewBox="0 0 20 20"
+                      >
+                        <path
+                          d="M10,20 C4.4771525,20 0,15.5228475 0,10 C0,4.4771525 4.4771525,0 10,0 C15.5228475,0 20,4.4771525 20,10 C20,15.5228475 15.5228475,20 10,20 Z"
+                        />
+                        <polygon
+                          className="c15"
+                          points="13.695 6 15 7.314 8.696 13.69 5 9.924 6.319 8.656 8.696 11.059"
+                        />
+                      </svg>
+                    </span>
+                    Investment objective
+                  </div>
+                </span>
+              </span>
+            </button>
+          </li>
+          <li
+            className="c3 c16"
+          >
+            <button
+              className="NormalizedButton__Button-ey7f5x-0 c5 c6"
+              onClick={[Function]}
+              type="button"
+            >
+              <span
+                className="c7"
+              >
+                <span
+                  className="c17"
+                >
+                  <div
+                    className="c9 c10"
+                  >
+                    <span
+                      aria-hidden={true}
+                      className="c12 c13"
+                    >
+                      <span
+                        className="c18"
+                      >
+                        2
+                      </span>
+                    </span>
+                    Time and risk
+                  </div>
+                </span>
+              </span>
+            </button>
+            <ol
+              className="c19"
+            >
+              <li
+                className="c20 c21"
+              >
+                <div
+                  className="c22"
+                >
+                  <button
+                    className="NormalizedButton__Button-ey7f5x-0 c23"
+                    onClick={[Function]}
+                    type="button"
+                  >
+                    <span
+                      className="c7"
+                    >
+                      <span
+                        className="c24"
+                      >
+                        <div
+                          className="c11"
+                        >
+                          Completed
+                        </div>
+                        Investment period
+                      </span>
+                    </span>
+                  </button>
+                </div>
+              </li>
+              <li
+                className="c20 c21"
+              >
+                <div
+                  className="c22"
+                >
+                  <button
+                    className="NormalizedButton__Button-ey7f5x-0 c23"
+                    onClick={[Function]}
+                    type="button"
+                  >
+                    <span
+                      className="c7"
+                    >
+                      <span
+                        className="c12"
+                      >
+                        <div
+                          className="c11"
+                        >
+                          Not completed
+                        </div>
+                        Frequency
+                      </span>
+                    </span>
+                  </button>
+                </div>
+              </li>
+              <li
+                className="c20 c21"
+              >
+                <div
+                  className="c22"
+                >
+                  <span
+                    className="c24"
+                  >
+                    <div
+                      className="c11"
+                    >
+                      Not completed
+                    </div>
+                    Amount
+                  </span>
+                </div>
+              </li>
+            </ol>
+          </li>
+          <li
+            className="c3 c4"
+          >
+            <span
+              className="c25"
+            >
+              <div
+                className="c26 c10"
+              >
+                <div
+                  className="c11"
+                >
+                  Not completed
+                </div>
+                <span
+                  aria-hidden={true}
+                  className="c12 c13"
+                >
+                  <span
+                    className="c27"
+                  >
+                    3
+                  </span>
+                </span>
+                Allocations
+              </div>
+            </span>
+          </li>
+        </ol>
+      </div>
+      <div
+        className="c28"
+      >
+        <ol
+          className="c29"
+        >
+          <li
+            className="c3 c16"
+          >
+            <button
+              aria-expanded={false}
+              className="NormalizedButton__Button-ey7f5x-0 c5 c30"
+              onClick={[Function]}
+              type="button"
+            >
+              <span
+                className="c7"
+              >
+                <span
+                  className="c17"
+                >
+                  <div
+                    className="c9 c10"
+                  >
+                    <div
+                      className="c31"
+                    >
+                      <div
+                        className="c32"
+                      >
+                        <span
+                          aria-hidden={true}
+                          className="c12 c13"
+                        >
+                          <span
+                            className="c18"
+                          >
+                            2
+                          </span>
+                        </span>
+                        Time and risk
+                      </div>
+                      <div
+                        className="c32"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          className="c33 c34"
+                          direction="down"
+                          focusable="false"
+                          preserveAspectRatio="xMidYMid meet"
+                          role="presentation"
+                          viewBox="0 0 16 16"
+                        >
+                          <polygon
+                            points="14.620 3.580, 16.000 5.020, 8.000 12.730, 0.000 5.030, 1.400 3.580, 8.000 9.96"
+                          />
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+                </span>
+              </span>
+            </button>
+          </li>
+        </ol>
+      </div>
+    </div>
+  </div>,
+  @media (min-width:760px) {
+
+}
+
+@media (min-width:760px) {
+
+}
+
+@media (min-width:760px) {
+
+}
+
+@media not all and (min-width:976px) {
+
+}
+
+@media not all and (max-width:975px) {
+  .c0 {
+    display: none;
+  }
+}
+
+@media (min-width:760px) {
+
+}
+
+<div
+    className="c0"
+  />,
+]
+`;
+
 exports[`Storyshots Molecules | Multi Step Progress Basic Multi Step Progress 1`] = `
 Array [
   .c9 {


### PR DESCRIPTION
Added an optional prop 'closeDrawerOnStepClick' that activates feature of the mobile drawer menu closing on Step (not SubStep) click.