### PR TITLE
Enable SSR support for FlexTable

### DIFF
--- a/src/Atoms/Flexbox/Flexbox.types.ts
+++ b/src/Atoms/Flexbox/Flexbox.types.ts
@@ -66,12 +66,12 @@ export type ItemProps = {
   title?: string;
 };
 
-type InternalProps = ItemProps & ContainerProps & { className?: string };
+export type FlexProps = ItemProps & ContainerProps & { className?: string };
 type MediaRelatedProps<T> = {
   sm?: Partial<T>;
   md?: Partial<T>;
   lg?: Partial<T>;
+  xl?: Partial<T>;
 };
 
-export type Props = MediaRelatedProps<InternalProps> &
-  InternalProps & { children?: React.ReactNode };
+export type Props = MediaRelatedProps<FlexProps> & FlexProps & { children?: React.ReactNode };

--- a/src/Molecules/FlexTable/BigFlexTable.stories.tsx
+++ b/src/Molecules/FlexTable/BigFlexTable.stories.tsx
@@ -18,21 +18,19 @@ export default {
 };
 
 const StyledDiv = styled.div`
-  background-color: ${p => p.theme.color.background};
+  background-color: ${(p) => p.theme.color.background};
   &:not(:last-of-type) {
-    margin-bottom: ${p => p.theme.spacing.unit(10)}px;
+    margin-bottom: ${(p) => p.theme.spacing.unit(10)}px;
   }
 `;
 
 const StyledFlexTable = styled(FlexTable)`
   &:not(:last-of-type) {
-    margin-bottom: ${p => p.theme.spacing.unit(10)}px;
+    margin-bottom: ${(p) => p.theme.spacing.unit(10)}px;
   }
 `;
 const generateUniqueId = (rowIndex: number) =>
-  `${rowIndex}_${Math.random()
-    .toString(36)
-    .substr(2, 9)}`;
+  `${rowIndex}_${Math.random().toString(36).substr(2, 9)}`;
 
 const generateTableData = (rowsLength: number, columnsLength: number) =>
   [...Array(rowsLength)].map((_, rowIndex) => {
@@ -108,7 +106,7 @@ export const BigTable = () => {
               </FlexTable.Header>
             ))}
           </FlexTable.HeaderRow>
-          {sortedData.map(data => (
+          {sortedData.map((data) => (
             <BigTableRow key={data.rowId} data={data} />
           ))}
         </FlexTable>
@@ -263,7 +261,7 @@ export const BigTableWithoutStickyHeader = () => {
               </FlexTable.Header>
             ))}
           </FlexTable.HeaderRow>
-          {sortedData.map(data => (
+          {sortedData.map((data) => (
             <BigTableRow key={data.rowId} data={data} />
           ))}
         </FlexTable>
@@ -321,7 +319,7 @@ export const MultipleBigTablesWithStickyHeaders = () => {
               </FlexTable.Header>
             ))}
           </FlexTable.HeaderRow>
-          {sortedData.map(data => (
+          {sortedData.map((data) => (
             <BigTableRow key={data.rowId} data={data} />
           ))}
         </StyledFlexTable>
@@ -342,7 +340,7 @@ export const MultipleBigTablesWithStickyHeaders = () => {
               </FlexTable.Header>
             ))}
           </FlexTable.HeaderRow>
-          {sortedData.map(data => (
+          {sortedData.map((data) => (
             <BigTableRow key={data.rowId} data={data} />
           ))}
         </StyledFlexTable>

--- a/src/Molecules/FlexTable/Cell/Cell.tsx
+++ b/src/Molecules/FlexTable/Cell/Cell.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
 import styled from 'styled-components';
-import * as R from 'ramda';
 import { isElement, isFunction } from '../../../common/utils';
 import { Flexbox } from '../../..';
-import { useColumnLayout } from '../shared/ColumnProvider';
+import { useFlexCellProps } from '../shared/ColumnProvider';
 import { CellComponent, InnerCellComponent } from './Cell.types';
 import { TextWrapper } from './TextWrapper';
 import { useFlexTable } from '../shared/FlexTableProvider';
@@ -24,7 +23,8 @@ const InnerCell: InnerCellComponent = React.memo(
   ),
 );
 
-const Cell: CellComponent = ({ children, className, columnId }) => {
+const Cell: CellComponent = (props) => {
+  const { children, className, columnId } = props;
   const {
     fontSize: xsFontSize,
     sm: smTable,
@@ -32,11 +32,8 @@ const Cell: CellComponent = ({ children, className, columnId }) => {
     lg: lgTable,
     xl: xlTable,
   } = useFlexTable();
-  const [columnLayout] = useColumnLayout(columnId);
 
-  if (!R.prop('flexProps', columnLayout)) {
-    return null;
-  }
+  const flexProps = useFlexCellProps(props);
 
   return (
     <RenderForSizes
@@ -49,7 +46,7 @@ const Cell: CellComponent = ({ children, className, columnId }) => {
         <InnerCell
           className={className}
           columnId={columnId}
-          flexProps={columnLayout.flexProps}
+          flexProps={flexProps}
           fontSize={fontSize}
         >
           {component}

--- a/src/Molecules/FlexTable/Cell/Cell.types.ts
+++ b/src/Molecules/FlexTable/Cell/Cell.types.ts
@@ -1,6 +1,7 @@
 import React, { ReactNode } from 'react';
-import { FontSize, Density } from '../shared/shared.types';
+import { FontSize, Density, MediaRelatedProps } from '../shared/shared.types';
 import { FlexPropsType } from '../shared/ColumnProvider/ColumnProvider.types';
+import { FlexProps } from '../../../Atoms/Flexbox/Flexbox.types';
 
 type RenderPropArguments = { density: Density; fontSize: FontSize; columnId: string };
 type RenderFunc = (props: RenderPropArguments) => ReactNode;
@@ -13,7 +14,8 @@ export type Props = {
    * Define which column which cell it belongs to and sets the column layout defined in the `Header`
    */
   columnId: string;
-};
+} & MediaRelatedProps<FlexProps> &
+  FlexProps;
 
 export type TextWrapperProps = {
   /**
@@ -32,7 +34,7 @@ export type TextWrapperComponent = React.FC<TextWrapperProps>;
 
 export type CellComponents = { TextWrapper: TextWrapperComponent };
 
-export type CellComponent = React.FC<Props> & CellComponents;
+export type CellComponent = React.FC<Props & TextWrapperProps> & CellComponents;
 
 export type InnerCellComponent = React.FC<Props & TextWrapperProps & { flexProps: FlexPropsType }>;
 
@@ -52,4 +54,4 @@ type ExpandCellProps = {
   columnId: string;
 };
 
-export type ExpandCellComponent = React.FC<ExpandCellProps>;
+export type ExpandCellComponent = React.FC<ExpandCellProps & FlexProps>;

--- a/src/Molecules/FlexTable/Cell/ExpandCell.tsx
+++ b/src/Molecules/FlexTable/Cell/ExpandCell.tsx
@@ -8,8 +8,9 @@ export const ExpandCell: ExpandCellComponent = ({
   disabled = false,
   expanded,
   onClick,
+  ...cellProps
 }) => (
-  <Cell columnId={columnId}>
+  <Cell columnId={columnId} {...cellProps}>
     <ExpandButton expanded={expanded} onClick={onClick} disabled={disabled} />
   </Cell>
 );

--- a/src/Molecules/FlexTable/DefaultFlexTable.stories.tsx
+++ b/src/Molecules/FlexTable/DefaultFlexTable.stories.tsx
@@ -16,15 +16,15 @@ export default {
 };
 
 const StyledDiv = styled.div`
-  background-color: ${p => p.theme.color.background};
+  background-color: ${(p) => p.theme.color.background};
   &:not(:last-of-type) {
-    margin-bottom: ${p => p.theme.spacing.unit(10)}px;
+    margin-bottom: ${(p) => p.theme.spacing.unit(10)}px;
   }
 `;
 
 const StyledFlexTable = styled(FlexTable)`
   &:not(:last-of-type) {
-    margin-bottom: ${p => p.theme.spacing.unit(10)}px;
+    margin-bottom: ${(p) => p.theme.spacing.unit(10)}px;
   }
 `;
 
@@ -113,7 +113,7 @@ export const DefaultTableWithCustomTitle = () => {
           </Typography>
         </Flexbox>
         <Flexbox item>
-          <Typography type="secondary" color={t => t.color.label}>
+          <Typography type="secondary" color={(t) => t.color.label}>
             ({shortName})
           </Typography>
         </Flexbox>

--- a/src/Molecules/FlexTable/ExpandableFlexTable.stories.tsx
+++ b/src/Molecules/FlexTable/ExpandableFlexTable.stories.tsx
@@ -150,7 +150,7 @@ export const ControlledExpandedTable = () => {
     const onExpandClick = (rowId: string) => (newExpanded: boolean) =>
       newExpanded
         ? setExpandedRows([...expandedRows, rowId])
-        : setExpandedRows(expandedRows.filter(row => row !== rowId));
+        : setExpandedRows(expandedRows.filter((row) => row !== rowId));
     const expandItemsText = expandedItemsGenerator();
     const expandItemsComponents = expandedItemsGenerator(true);
     return (
@@ -234,7 +234,7 @@ export const ControlledExpandableTableWithCustomRow = () => {
     const toggleExpand = (rowId: string) => {
       const isAlreadyExpanded = expandedRows.includes(rowId);
       if (isAlreadyExpanded) {
-        return setExpandedRows(expandedRows.filter(row => row !== rowId));
+        return setExpandedRows(expandedRows.filter((row) => row !== rowId));
       }
       return setExpandedRows([...expandedRows, rowId]);
     };

--- a/src/Molecules/FlexTable/FlexTable.mdx
+++ b/src/Molecules/FlexTable/FlexTable.mdx
@@ -1,7 +1,7 @@
 import { Meta, Story, Preview, Props } from '@storybook/addon-docs/blocks';
 import { IntlProvider } from 'react-intl';
 import FlexTable from './FlexTable';
-import { Number } from "../..";
+import { Number } from '../..';
 
 <Meta title="Molecules | FlexTable" component={FlexTable} />
 
@@ -36,11 +36,12 @@ The Flextable component only handles UI states.
 </Preview>
 
 **Table of Contents**
+
 - Customization
 - FlexTable component
 - Header
   - Sorting
-  - Custom Header 
+  - Custom Header
 - Cell
   - Custom Cell
 - Footer
@@ -49,7 +50,6 @@ The Flextable component only handles UI states.
 - Constants
 - Design Notes
 - Performance
-
 
 ## Customization
 
@@ -129,11 +129,18 @@ This example cell will fit in with the rest of the cells and change its font siz
   </FlexTable>
 </Preview>
 
+## Layout properties
+
+The layout of the table can be customized using the same properties as `FlexBox` uses.
+For performance reason as well as to make the table compatible with server-side rendering (SSR), the layout properties have to be attached to each of the `Header`, `Cell` and `Footer` components with the same `columnId`.
+If no layout properties are specified, some default values will be used.
+
+**NOTE: Previously the layout properties were only attached to the `Header` component, and that would set the layout for the entire column. This API was designed with ease-of-use in mind, but unfortunately it creates
+some performance problems with cells being rendered multipxxwle times and it does not work at all in an SSR context. This API has therefore been deprecated and layout properties should now be added to each of the cells in a column instead.**
+
 ## Header
 
-Header sets the layout for the entire column and handles sorting as well.
-The layout is set using the same properties that `Flexbox`uses.
-Setting the same `columnId` on `Cell` and `Footer` makes them inherit the layout properties.
+`Header` uses layout properties from props and handles sorting.
 The `fontSize` defined in the `FlexTable` component is inherited here. If the content does not fit within the `Header`, it will be truncated and produces a tooltip on hover via the molecule `TruncateWithToolTip`.
 
 <Preview>
@@ -149,8 +156,12 @@ The `fontSize` defined in the `FlexTable` component is inherited here. If the co
     </FlexTable.HeaderRow>
     <FlexTable.Row>
       <FlexTable.Cell columnId="instrument-name">Ericsson</FlexTable.Cell>
-      <FlexTable.Cell columnId="currency">SEK</FlexTable.Cell>
-      <FlexTable.Cell columnId="country">SE</FlexTable.Cell>
+      <FlexTable.Cell columnId="currency" flex="0 0 150px">
+        SEK
+      </FlexTable.Cell>
+      <FlexTable.Cell columnId="country" justifyContent="flex-end" flex="2">
+        SE
+      </FlexTable.Cell>
     </FlexTable.Row>
   </FlexTable>
 </Preview>
@@ -170,8 +181,12 @@ The `fontSize` defined in the `FlexTable` component is inherited here. If the co
     </FlexTable.HeaderRow>
     <FlexTable.Row>
       <FlexTable.Cell columnId="instrument-name">Ericsson</FlexTable.Cell>
-      <FlexTable.Cell columnId="currency">SEK</FlexTable.Cell>
-      <FlexTable.Cell columnId="country">SE</FlexTable.Cell>
+      <FlexTable.Cell columnId="currency" hidden md={{ hidden: false }}>
+        SEK
+      </FlexTable.Cell>
+      <FlexTable.Cell columnId="country" md={{ justifyContent: 'flex-end' }}>
+        SE
+      </FlexTable.Cell>
     </FlexTable.Row>
   </FlexTable>
 </Preview>
@@ -179,9 +194,9 @@ The `fontSize` defined in the `FlexTable` component is inherited here. If the co
 ### Sorting
 
 To enable sorting, the `sortable` property has to be set to true. The user can have either a controlled or uncontrolled sorting state by setting the `sortOrder` property.
-In an uncontrolled state the header will unsort the other headers when a header is sorted. The default sorting rotation is _unsorted --> ascending --> descending --> unsorted_. 
+In an uncontrolled state the header will unsort the other headers when a header is sorted. The default sorting rotation is _unsorted --> ascending --> descending --> unsorted_.
 
-Note: To ease sorting, we recommend that the `columnId` for each column has the same name as the data property that the column represents. 
+Note: To ease sorting, we recommend that the `columnId` for each column has the same name as the data property that the column represents.
 In the example below, The `columnId` of the first column represents `instrumentName` field in the data, `columnId` of second column represents `currency` etc.
 
 ```jsx
@@ -225,8 +240,6 @@ const InstrumentTable = () => (
   )
 );
 ```
-
-
 
 ### Custom Header
 
@@ -276,7 +289,7 @@ const StyledFlexboxContainer = styled(Flexbox)
 
 ## Cell
 
-Cell consumes the layout properties of the `Header` with the same `columnId`.
+Cell uses the layout properties from props.
 
 ### Custom Cell
 
@@ -311,16 +324,18 @@ Similar functionality to `Cell`. Has like `Header` the property `isContent = fal
         <FlexTable.Header columnId="amt" hidden md={{ hidden: false }} justifyContent="flex-end">
           Amount
         </FlexTable.Header>
-        <FlexTable.Header columnId="percentage" justifyContent="flex-end">Percentage</FlexTable.Header>
+        <FlexTable.Header columnId="percentage" justifyContent="flex-end">
+          Percentage
+        </FlexTable.Header>
       </FlexTable.HeaderRow>
       <FlexTable.Row>
         <FlexTable.Cell columnId="instrument-name">Ericsson</FlexTable.Cell>
-        <FlexTable.Cell columnId="amt">
+        <FlexTable.Cell columnId="amt" hidden md={{ hidden: false }} justifyContent="flex-end">
           <FlexTable.Cell.TextWrapper>
             <Number value={100} />
           </FlexTable.Cell.TextWrapper>
         </FlexTable.Cell>
-        <FlexTable.Cell columnId="percentage">
+        <FlexTable.Cell columnId="percentage" justifyContent="flex-end">
           <FlexTable.Cell.TextWrapper>
             <Number value={25} percentage />
           </FlexTable.Cell.TextWrapper>
@@ -328,12 +343,12 @@ Similar functionality to `Cell`. Has like `Header` the property `isContent = fal
       </FlexTable.Row>
       <FlexTable.Row>
         <FlexTable.Cell columnId="instrument-name">Apple</FlexTable.Cell>
-        <FlexTable.Cell columnId="amt">
+        <FlexTable.Cell columnId="amt" hidden md={{ hidden: false }} justifyContent="flex-end">
           <FlexTable.Cell.TextWrapper>
             <Number value={300} />
           </FlexTable.Cell.TextWrapper>
         </FlexTable.Cell>
-        <FlexTable.Cell columnId="percentage">
+        <FlexTable.Cell columnId="percentage" justifyContent="flex-end">
           <FlexTable.Cell.TextWrapper>
             <Number value={75} percentage />
           </FlexTable.Cell.TextWrapper>
@@ -341,12 +356,12 @@ Similar functionality to `Cell`. Has like `Header` the property `isContent = fal
       </FlexTable.Row>
       <FlexTable.FooterRow>
         <FlexTable.Footer columnId="instrument-name">Summary</FlexTable.Footer>
-        <FlexTable.Footer columnId="amt">
+        <FlexTable.Footer columnId="amt" hidden md={{ hidden: false }} justifyContent="flex-end">
           <FlexTable.Footer.TextWrapper>
             <Number value={400} />
           </FlexTable.Footer.TextWrapper>
         </FlexTable.Footer>
-        <FlexTable.Footer columnId="percentage">
+        <FlexTable.Footer columnId="percentage" justifyContent="flex-end">
           <FlexTable.Footer.TextWrapper>
             <Number value={100} percentage />
           </FlexTable.Footer.TextWrapper>
@@ -378,7 +393,9 @@ const ConditionalMediaExpand = () => {
 
       <FlexTable.Row expandItems={columnData} md={{ expandItems: [] }}>
         <FlexTable.Cell columnId="instrumentName">Ericsson</FlexTable.Cell>
-        <FlexTable.Cell columnId="country">SE</FlexTable.Cell>
+        <FlexTable.Cell columnId="country" hidden md={{ hidden: false }}>
+          SE
+        </FlexTable.Cell>
       </FlexTable.Row>
     </StyledFlexTable>
   );
@@ -406,22 +423,23 @@ This keeps the row from rendering a chevron and instead provides a empty `Header
    The `id` that is assigned to `HeaderRow`'s empty `Header` and `Row`'s chevron.
 
 1. `ICON_COLUMN_DEFAULT_FLEX_PROPS`
-    
-    The layout properties used on the Icon column.
+
+   The layout properties used on the Icon column.
 
 ## Design Notes
+
 These pertain to the design standards of the FlexTable
 
 - In general, columns with cells that use number values should be right aligned, i.e. `justifyContent="flex-end"`
 - When `density` is `s`, `fontSize` value should be `s`. For other `density` values `fontSize` could be either `s` or `m`
 - If the column header ends with a currency, the currency shouldn't truncate. An example of how to truncate the rest can be found in the stories
 
-
 ## Performance
+
 The table should be able to handle large numbers of rows without a hitch. However sorting all the rows creates a lot of unnecessary re-renders. Each row is re-rendered to its new position
 and also each cell. That means for a 50 row table with 10 columns, we will have at least 500 components re-rendering. For this reason we have used `React.memo` on all components to
 smoothen data operations that does not change the table content, only the positioning such as when sorting.
 
-- Use `React.memo` on all custom `Row`, `Cell`, `Header` and `Footer` implementations. 
+- Use `React.memo` on all custom `Row`, `Cell`, `Header` and `Footer` implementations.
 - When sending in media objects, make sure that the objects are memoized. This will stop unnecesary re-renders of rows.
 - If you have more than 100 rows, it's worth looking into virtualization of rows. An example can be found in the `FlexTable` stories.

--- a/src/Molecules/FlexTable/FlexTable.stories.tsx
+++ b/src/Molecules/FlexTable/FlexTable.stories.tsx
@@ -16,15 +16,15 @@ export default {
 };
 
 const StyledDiv = styled.div`
-  background-color: ${p => p.theme.color.background};
+  background-color: ${(p) => p.theme.color.background};
   &:not(:last-of-type) {
-    margin-bottom: ${p => p.theme.spacing.unit(10)}px;
+    margin-bottom: ${(p) => p.theme.spacing.unit(10)}px;
   }
 `;
 
 const StyledFlexTable = styled(FlexTable)`
   &:not(:last-of-type) {
-    margin-bottom: ${p => p.theme.spacing.unit(10)}px;
+    margin-bottom: ${(p) => p.theme.spacing.unit(10)}px;
   }
 `;
 
@@ -56,7 +56,7 @@ export const FlexTableWithDifferentRows = () => {
         <FlexTable.Cell columnId="column2">No highlight and separator hidden</FlexTable.Cell>
         <FlexTable.Cell columnId="column3">No highlight and separator hidden</FlexTable.Cell>
       </FlexTable.Row>
-      <FlexTable.Row separatorColor={t => t.color.barChartColor1}>
+      <FlexTable.Row separatorColor={(t) => t.color.barChartColor1}>
         <FlexTable.Cell columnId="column1">Separator color set</FlexTable.Cell>
         <FlexTable.Cell columnId="column2">Separator color set</FlexTable.Cell>
         <FlexTable.Cell columnId="column3">Separator color set</FlexTable.Cell>

--- a/src/Molecules/FlexTable/FlexTableWithDifferentColumns.stories.tsx
+++ b/src/Molecules/FlexTable/FlexTableWithDifferentColumns.stories.tsx
@@ -15,15 +15,15 @@ export default {
 };
 
 const StyledDiv = styled.div`
-  background-color: ${p => p.theme.color.background};
+  background-color: ${(p) => p.theme.color.background};
   &:not(:last-of-type) {
-    margin-bottom: ${p => p.theme.spacing.unit(10)}px;
+    margin-bottom: ${(p) => p.theme.spacing.unit(10)}px;
   }
 `;
 
 const StyledFlexTable = styled(FlexTable)`
   &:not(:last-of-type) {
-    margin-bottom: ${p => p.theme.spacing.unit(10)}px;
+    margin-bottom: ${(p) => p.theme.spacing.unit(10)}px;
   }
 `;
 

--- a/src/Molecules/FlexTable/FlexTableWithDifferentHeaders.stories.tsx
+++ b/src/Molecules/FlexTable/FlexTableWithDifferentHeaders.stories.tsx
@@ -17,15 +17,15 @@ export default {
 };
 
 const StyledDiv = styled.div`
-  background-color: ${p => p.theme.color.background};
+  background-color: ${(p) => p.theme.color.background};
   &:not(:last-of-type) {
-    margin-bottom: ${p => p.theme.spacing.unit(10)}px;
+    margin-bottom: ${(p) => p.theme.spacing.unit(10)}px;
   }
 `;
 
 const StyledFlexTable = styled(FlexTable)`
   &:not(:last-of-type) {
-    margin-bottom: ${p => p.theme.spacing.unit(10)}px;
+    margin-bottom: ${(p) => p.theme.spacing.unit(10)}px;
   }
 `;
 
@@ -193,7 +193,7 @@ export const SortableHeadersOnlyAscendingDescending = () => {
         columnSort.columnId === columnId
           ? columnSort.sortOrder
           : FlexTable.CONSTANTS.SORT_ORDER_NONE;
-      const onSort: OnSort = columnId => {
+      const onSort: OnSort = (columnId) => {
         let nextSortOrder: SortOrder = FlexTable.CONSTANTS.SORT_ORDER_ASCENDING;
         const sameAsCurrentlySorted = columnId === columnSort.columnId;
         if (sameAsCurrentlySorted) {

--- a/src/Molecules/FlexTable/FlexTableWithDifferentSizeProps.stories.tsx
+++ b/src/Molecules/FlexTable/FlexTableWithDifferentSizeProps.stories.tsx
@@ -15,15 +15,15 @@ export default {
 };
 
 const StyledDiv = styled.div`
-  background-color: ${p => p.theme.color.background};
+  background-color: ${(p) => p.theme.color.background};
   &:not(:last-of-type) {
-    margin-bottom: ${p => p.theme.spacing.unit(10)}px;
+    margin-bottom: ${(p) => p.theme.spacing.unit(10)}px;
   }
 `;
 
 const StyledFlexTable = styled(FlexTable)`
   &:not(:last-of-type) {
-    margin-bottom: ${p => p.theme.spacing.unit(10)}px;
+    margin-bottom: ${(p) => p.theme.spacing.unit(10)}px;
   }
 `;
 

--- a/src/Molecules/FlexTable/Footer/Footer.tsx
+++ b/src/Molecules/FlexTable/Footer/Footer.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
 import styled from 'styled-components';
-import * as R from 'ramda';
 import { isElement, isFunction } from '../../../common/utils';
 import { Flexbox } from '../../..';
-import { useColumnLayout } from '../shared/ColumnProvider';
+import { useFlexCellProps } from '../shared/ColumnProvider';
 import { FooterComponent } from './Footer.types';
 import { TextWrapper } from './TextWrapper';
 import { useFlexTable } from '../shared/FlexTableProvider';
@@ -13,7 +12,9 @@ const StyledFlexbox = styled(Flexbox)`
   overflow: hidden;
 `;
 
-const Footer: FooterComponent = ({ children, className, columnId }) => {
+const Footer: FooterComponent = (props) => {
+  const { children, className, columnId } = props;
+
   const {
     fontSize: xsFontSize,
     sm: smTable,
@@ -21,11 +22,9 @@ const Footer: FooterComponent = ({ children, className, columnId }) => {
     lg: lgTable,
     xl: xlTable,
   } = useFlexTable();
-  const [columnLayout] = useColumnLayout(columnId);
 
-  if (!R.prop('flexProps', columnLayout)) {
-    return null;
-  }
+  const flexProps = useFlexCellProps(props);
+
   return (
     <RenderForSizes
       xs={{ fontSize: xsFontSize }}
@@ -34,7 +33,7 @@ const Footer: FooterComponent = ({ children, className, columnId }) => {
       lg={lgTable}
       xl={xlTable}
       Container={({ fontSize, children: component }) => (
-        <StyledFlexbox className={className} role="cell" {...columnLayout.flexProps}>
+        <StyledFlexbox className={className} role="cell" {...flexProps}>
           {isElement(component) && component}
           {isFunction(component)
             ? component({ fontSize, columnId })

--- a/src/Molecules/FlexTable/Footer/Footer.types.ts
+++ b/src/Molecules/FlexTable/Footer/Footer.types.ts
@@ -1,5 +1,6 @@
 import React, { ReactNode } from 'react';
-import { FontSize, Density } from '../shared/shared.types';
+import { FontSize, Density, MediaRelatedProps } from '../shared/shared.types';
+import { FlexProps } from '../../../Atoms/Flexbox/Flexbox.types';
 
 type RenderPropArguments = { density: Density; fontSize: FontSize; columnId: string };
 type RenderFunc = (props: RenderPropArguments) => ReactNode;
@@ -8,12 +9,12 @@ type Children = ReactNode | RenderFunc;
 export type Props = {
   children?: Children;
   className?: string;
-  fontSize?: FontSize;
   /**
    * Define which column which cell it belongs to and sets the column layout defined in the `Header`
    */
   columnId: string;
-};
+} & MediaRelatedProps<FlexProps> &
+  FlexProps;
 
 export type TextWrapperProps = {
   /**

--- a/src/Molecules/FlexTable/Header/Header.tsx
+++ b/src/Molecules/FlexTable/Header/Header.tsx
@@ -12,7 +12,6 @@ import {
   ACTION_SET_FLEX_PROPS,
   ACTION_SET_SORTING,
   ACTION_SET_INITIAL_SORTING,
-  useColumnLayout,
 } from '../shared/ColumnProvider';
 import { HeaderContent, TextWrapper, SortIcon, SortButton } from './HeaderContent';
 
@@ -34,7 +33,7 @@ const StyledFlexbox = styled(Flexbox)`
   overflow: hidden;
 `;
 
-const Header: HeaderComponent = props => {
+const Header: HeaderComponent = (props) => {
   const {
     children,
     className,
@@ -46,7 +45,6 @@ const Header: HeaderComponent = props => {
   } = props;
 
   const [columnState, columnDispatch] = useColumnData(columnId);
-  const [columnLayout] = useColumnLayout(columnId);
   const sortOrder = sortable
     ? getSortOrder(R.prop('sortOrder', columnState), sortOrderProp, initialSortOrder)
     : null;
@@ -79,19 +77,15 @@ const Header: HeaderComponent = props => {
   };
 
   useLayoutEffect(() => {
-    if (cellFlexProps) {
-      columnDispatch({ type: ACTION_SET_FLEX_PROPS, flexProps: cellFlexProps });
-    }
-  }, [cellFlexProps, columnDispatch]);
+    columnDispatch({ type: ACTION_SET_FLEX_PROPS, flexProps: cellFlexProps });
+    // Using JSON.stringify here to perform a "deep equality" check on cellFlexProps.
+    // Otherwise columnDispatch will re-trigger the hook since it updates the context which leads to a recursive loop
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [JSON.stringify(cellFlexProps), columnDispatch]);
 
   const sorted = !R.isNil(sortOrder) && sortOrder !== SORT_ORDER_NONE;
   return (
-    <StyledFlexbox
-      className={className}
-      role="columnheader"
-      {...ariaSorted}
-      {...R.propOr(cellFlexProps, 'flexProps', columnLayout)}
-    >
+    <StyledFlexbox className={className} role="columnheader" {...ariaSorted} {...cellFlexProps}>
       {isElement(children) && children}
       {isFunction(children)
         ? children({ sortable, sortOrder, onSortClick, sorted, columnId })

--- a/src/Molecules/FlexTable/Row/components/ExpandElement.tsx
+++ b/src/Molecules/FlexTable/Row/components/ExpandElement.tsx
@@ -26,6 +26,7 @@ export const ExpandElement: React.FC<
       expanded={expanded}
       onClick={() => (onExpandToggle ? onExpandToggle(!expanded) : setExpand(!expanded))}
       disabled={disabled}
+      {...ICON_COLUMN_DEFAULT_FLEX_PROPS}
     />
   );
 };

--- a/src/Molecules/FlexTable/__snapshots__/FlexTableWithDifferentSizeProps.stories.storyshot
+++ b/src/Molecules/FlexTable/__snapshots__/FlexTableWithDifferentSizeProps.stories.storyshot
@@ -1051,15 +1051,6 @@ exports[`Storyshots Molecules | FlexTable / FlexTable with different size props 
   line-height: 1.4285714285714286;
 }
 
-.c18 {
-  font-family: 'Nordnet Sans Mono',-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
-  color: #6E6E69;
-  margin: 0;
-  font-weight: 400;
-  font-size: 12px;
-  line-height: 1.3333333333333333;
-}
-
 .c17 {
   font-family: 'Nordnet Sans Mono',-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
   color: #282823;
@@ -1067,6 +1058,15 @@ exports[`Storyshots Molecules | FlexTable / FlexTable with different size props 
   font-weight: 400;
   font-size: 14px;
   line-height: 1.4285714285714286;
+}
+
+.c18 {
+  font-family: 'Nordnet Sans Mono',-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
+  color: #6E6E69;
+  margin: 0;
+  font-weight: 400;
+  font-size: 12px;
+  line-height: 1.3333333333333333;
 }
 
 .c19 {

--- a/src/Molecules/FlexTable/shared/ColumnProvider/ColumnProvider.types.ts
+++ b/src/Molecules/FlexTable/shared/ColumnProvider/ColumnProvider.types.ts
@@ -29,6 +29,7 @@ export type FlexPropsType = Pick<
   | 'sm'
   | 'wrap'
   | 'hidden'
+  | 'xl'
 >;
 
 export type ColumnLayoutTypes = {

--- a/src/Molecules/FlexTable/shared/ColumnProvider/useFlexCellProps.ts
+++ b/src/Molecules/FlexTable/shared/ColumnProvider/useFlexCellProps.ts
@@ -1,20 +1,30 @@
 import { useMemo } from 'react';
 import * as R from 'ramda';
 import { FlexPropsType } from './ColumnProvider.types';
+import { useColumnLayout } from './useColumn';
+import { assert } from '../../../../common/utils';
 
-export const useFlexCellProps = ({
+const EMPTY_OBJECT = {};
+const DEFAULT_CELL_FLEX_PROPS: Partial<FlexPropsType> = {
+  container: true,
+  flex: '1',
+  item: true,
+  wrap: 'nowrap',
+};
+
+const usePickFlexCellProps = ({
   align,
   alignContent,
   alignItems,
   alignSelf,
   basis,
-  container = true,
+  container,
   direction,
-  flex = '1',
+  flex,
   grow,
   gutter,
   height,
-  item = true,
+  item,
   justifyContent,
   lg,
   md,
@@ -22,12 +32,13 @@ export const useFlexCellProps = ({
   shrink,
   size,
   sm,
-  wrap = 'nowrap',
+  wrap,
   hidden,
+  xl,
 }: Partial<FlexPropsType>): Partial<FlexPropsType> => {
   const sharedProps = useMemo(
     () =>
-      R.filter(val => val !== undefined, {
+      R.filter((val) => val !== undefined, {
         align,
         alignContent,
         alignItems,
@@ -49,6 +60,7 @@ export const useFlexCellProps = ({
         sm,
         wrap,
         hidden,
+        xl,
       }),
     [
       align,
@@ -72,8 +84,34 @@ export const useFlexCellProps = ({
       sm,
       wrap,
       hidden,
+      xl,
     ],
   );
 
   return sharedProps;
+};
+
+export const useFlexCellProps = (props: Partial<FlexPropsType> & { columnId: string }) => {
+  const { columnId } = props;
+  const cellFlexProps = usePickFlexCellProps(props);
+  const [columnLayout] = useColumnLayout(columnId);
+
+  const cellOrColumnLayoutProps = !R.isEmpty(cellFlexProps)
+    ? cellFlexProps
+    : (columnLayout && columnLayout.flexProps) || EMPTY_OBJECT;
+
+  if (process.env.NODE_ENV !== 'production') {
+    const isOldApi =
+      R.isEmpty(cellFlexProps) &&
+      !R.isEmpty(columnLayout?.flexProps ?? {}) &&
+      JSON.stringify(columnLayout.flexProps) !== JSON.stringify(DEFAULT_CELL_FLEX_PROPS);
+    assert(
+      !isOldApi,
+      `It seems like you are trying to assign all flexProps via the header for ${columnId}, which doesn't support SSR. Set flexProps on each cell instead.`,
+      { level: 'warn' },
+    );
+  }
+
+  const flexProps = { ...DEFAULT_CELL_FLEX_PROPS, ...cellOrColumnLayoutProps };
+  return flexProps;
 };

--- a/src/Molecules/FlexTable/shared/ColumnProvider/useFlexCellProps.ts
+++ b/src/Molecules/FlexTable/shared/ColumnProvider/useFlexCellProps.ts
@@ -107,7 +107,7 @@ export const useFlexCellProps = (props: Partial<FlexPropsType> & { columnId: str
       JSON.stringify(columnLayout.flexProps) !== JSON.stringify(DEFAULT_CELL_FLEX_PROPS);
     assert(
       !isOldApi,
-      `It seems like you are trying to assign all flexProps via the header for ${columnId}, which doesn't support SSR. Set flexProps on each cell instead.`,
+      `It seems like you are trying to assign all flex props via the header, which doesn't support SSR. Please set the flex props on each cell instead.`,
       { level: 'warn' },
     );
   }


### PR DESCRIPTION
This change enables `FlexTable` to be rendered on the server. In order to do this, there were a few changes that needed to be done.

- Cell and Footer now accepts same layout properties as Header making them independent from `columnDispatch`
- The old FlexTable API (specifying layout properties only on Header) has been deprecated, but currently still supported for backwards compatibility
- Log warning if old FlexTable API is used instead of the new way
- Update documentation 