### PR TITLE
fix: 🐛 make render for sizes container use media styles in ssr

### DIFF
--- a/src/Atoms/IsomorphicMedia/IsomorphicMedia.tsx
+++ b/src/Atoms/IsomorphicMedia/IsomorphicMedia.tsx
@@ -6,14 +6,10 @@ import useSSR from 'use-ssr';
 import { Props } from './IsomorphicMedia.types';
 import { Theme } from '../../theme/theme.types';
 
-const negateMedia = R.pipe(
-  R.split(' '),
-  R.insert(1, 'not all and'),
-  R.join(' '),
-);
+const negateMedia = R.pipe(R.split(' '), R.insert(1, 'not all and'), R.join(' '));
 
 const StyledDiv = styled.div<{ query: Props['query'] }>`
-  ${p => negateMedia(typeof p.query === 'string' ? p.query : p.query(p.theme))} {
+  ${(p) => negateMedia(typeof p.query === 'string' ? p.query : p.query(p.theme))} {
     display: none;
   }
 `;
@@ -49,7 +45,7 @@ const useIsomorphicMedia = (query: string | ((t: Theme) => string)) => {
   return matches;
 };
 
-const IsomorphicMedia: React.FunctionComponent<Props> = props => {
+const IsomorphicMedia: React.FunctionComponent<Props> = (props) => {
   const { isServer } = useSSR();
   const As = props.as || 'div';
   const matches = useIsomorphicMedia(props.query);

--- a/src/Molecules/FlexTable/Cell/Cell.tsx
+++ b/src/Molecules/FlexTable/Cell/Cell.tsx
@@ -42,9 +42,9 @@ const Cell: CellComponent = (props) => {
       md={mdTable}
       lg={lgTable}
       xl={xlTable}
-      Container={({ fontSize, children: component }) => (
+      Container={({ fontSize, children: component, className: mediaClassName }) => (
         <InnerCell
-          className={className}
+          className={mediaClassName ? `${className} ${mediaClassName}` : className}
           columnId={columnId}
           flexProps={flexProps}
           fontSize={fontSize}

--- a/src/Molecules/FlexTable/Footer/Footer.tsx
+++ b/src/Molecules/FlexTable/Footer/Footer.tsx
@@ -32,8 +32,12 @@ const Footer: FooterComponent = (props) => {
       md={mdTable}
       lg={lgTable}
       xl={xlTable}
-      Container={({ fontSize, children: component }) => (
-        <StyledFlexbox className={className} role="cell" {...flexProps}>
+      Container={({ fontSize, children: component, className: mediaClassName }) => (
+        <StyledFlexbox
+          className={mediaClassName ? `${className} ${mediaClassName}` : className}
+          role="cell"
+          {...flexProps}
+        >
           {isElement(component) && component}
           {isFunction(component)
             ? component({ fontSize, columnId })

--- a/src/Molecules/FlexTable/Header/HeaderContent/HeaderContent.tsx
+++ b/src/Molecules/FlexTable/Header/HeaderContent/HeaderContent.tsx
@@ -36,8 +36,8 @@ export const HeaderContent: React.FC<Props & UIProps> = ({
         md={mdTable}
         lg={lgTable}
         xl={xlTable}
-        Container={({ fontSize, children: component }) => (
-          <TextWrapper fontSize={fontSize} sorted={false}>
+        Container={({ fontSize, children: component, className: mediaClassName }) => (
+          <TextWrapper className={mediaClassName} fontSize={fontSize} sorted={false}>
             {component}
           </TextWrapper>
         )}
@@ -53,8 +53,10 @@ export const HeaderContent: React.FC<Props & UIProps> = ({
       md={mdTable}
       lg={lgTable}
       xl={xlTable}
-      Container={({ children: component }) => (
-        <SortButton onClick={onSortClick}>{component}</SortButton>
+      Container={({ children: component, className: mediaClassName }) => (
+        <SortButton className={mediaClassName} onClick={onSortClick}>
+          {component}
+        </SortButton>
       )}
       Component={({ fontSize }) => (
         <StyledFlexboxContainer container>

--- a/src/Molecules/FlexTable/Header/HeaderContent/HeaderContent.types.ts
+++ b/src/Molecules/FlexTable/Header/HeaderContent/HeaderContent.types.ts
@@ -2,6 +2,7 @@ import React from 'react';
 import { FontSize } from '../../shared/shared.types';
 
 export type TextWrapperProps = {
+  className?: string;
   /**
    * Set font size
    * @default 'm'
@@ -29,6 +30,7 @@ export type SortIconProps = {
 export type SortIconComponent = React.FC<SortIconProps>;
 
 export type SortButtonProps = {
+  className?: string;
   onClick: () => void;
   children: React.ReactChild | React.ReactChild[];
 };

--- a/src/Molecules/FlexTable/Header/HeaderContent/SortButton.tsx
+++ b/src/Molecules/FlexTable/Header/HeaderContent/SortButton.tsx
@@ -10,15 +10,16 @@ const StyledLink = styled.a`
   width: 100%;
 `;
 
-export const SortButton: React.FC<SortButtonProps> = ({ children, onClick }) => (
+export const SortButton: React.FC<SortButtonProps> = ({ children, onClick, className }) => (
   <StyledLink
+    className={className}
     href="#"
     role="button"
-    onClick={e => {
+    onClick={(e) => {
       e.preventDefault();
       onClick();
     }}
-    onKeyDown={e => {
+    onKeyDown={(e) => {
       // Link should trigger on spacebar clicked like actual button.
       if (e.keyCode === 32) {
         onClick();

--- a/src/Molecules/FlexTable/Header/HeaderContent/TextWrapper.tsx
+++ b/src/Molecules/FlexTable/Header/HeaderContent/TextWrapper.tsx
@@ -5,14 +5,16 @@ import { Typography } from '../../../..';
 import { StyledTruncateTooltip } from '../../shared';
 import { FontSize } from '../../shared/shared.types';
 
-const Text: React.FC<{ fontSize: FontSize; sorted?: boolean }> = ({
+const Text: React.FC<{ className?: string; fontSize: FontSize; sorted?: boolean }> = ({
+  className,
   children,
   sorted,
   fontSize,
 }) => (
   <Typography
+    className={className}
     type={getFontSizeTypographyType(fontSize)}
-    color={t => (sorted ? t.color.text : t.color.label)}
+    color={(t) => (sorted ? t.color.text : t.color.label)}
     weight={sorted ? 'bold' : 'regular'}
   >
     {children}
@@ -20,6 +22,7 @@ const Text: React.FC<{ fontSize: FontSize; sorted?: boolean }> = ({
 );
 
 export const TextWrapper: TextWrapperComponent = ({
+  className,
   fontSize = 'm',
   sorted,
   children,
@@ -27,14 +30,14 @@ export const TextWrapper: TextWrapperComponent = ({
 }) => {
   if (!truncate) {
     return (
-      <Text fontSize={fontSize} sorted={sorted}>
+      <Text className={className} fontSize={fontSize} sorted={sorted}>
         {children}
       </Text>
     );
   }
 
   return (
-    <StyledTruncateTooltip label={children}>
+    <StyledTruncateTooltip className={className} label={children}>
       <Text fontSize={fontSize} sorted={sorted}>
         {children}
       </Text>

--- a/src/Molecules/FlexTable/Row/Row.tsx
+++ b/src/Molecules/FlexTable/Row/Row.tsx
@@ -12,7 +12,7 @@ import { ExpandElement, ExpandArea } from './components';
 
 /* the cells are padded by row gutter 1 unit (4px) */
 const StyledRow = styled(Flexbox).withConfig({
-  shouldForwardProp: prop =>
+  shouldForwardProp: (prop) =>
     ![
       'hideSeparator',
       'expanded',
@@ -29,25 +29,25 @@ const StyledRow = styled(Flexbox).withConfig({
   density: Density;
   expandable: boolean;
 }>`
-  background: ${p => p.theme.color.tableRowBackground};
-  ${p =>
+  background: ${(p) => p.theme.color.tableRowBackground};
+  ${(p) =>
     !p.hideSeparator && !p.expanded ? `border-bottom: 1px solid ${p.separatorColor(p.theme)}` : ''};
 
-  padding-right: ${p => (p.expandable ? p.theme.spacing.unit(2) : p.theme.spacing.unit(1))}px;
-  padding-left: ${p => (p.expandable ? p.theme.spacing.unit(1.5) : p.theme.spacing.unit(0.5))}px;
+  padding-right: ${(p) => (p.expandable ? p.theme.spacing.unit(2) : p.theme.spacing.unit(1))}px;
+  padding-left: ${(p) => (p.expandable ? p.theme.spacing.unit(1.5) : p.theme.spacing.unit(0.5))}px;
 
-  border-left: ${p => p.theme.spacing.unit(0.5)}px solid
-    ${p => (p.expanded && p.expandable ? p.theme.color.cta : 'transparent')};
+  border-left: ${(p) => p.theme.spacing.unit(0.5)}px solid
+    ${(p) => (p.expanded && p.expandable ? p.theme.color.cta : 'transparent')};
 
-  ${p =>
+  ${(p) =>
     p.hoverHighlight &&
     !p.expanded &&
     `&:hover {
       background: ${p.theme.color.tableRowHover};
     }`};
 
-  padding-top: ${p => getDensityPaddings(p.density)}px;
-  padding-bottom: ${p => getDensityPaddings(p.density)}px;
+  padding-top: ${(p) => getDensityPaddings(p.density)}px;
+  padding-bottom: ${(p) => getDensityPaddings(p.density)}px;
 
   margin-right: 0;
   margin-left: 0;
@@ -64,10 +64,10 @@ const StyledRow = styled(Flexbox).withConfig({
 `;
 
 const StyledExpandedRow = styled('div').withConfig({
-  shouldForwardProp: prop => !['separatorColor'].includes(prop),
+  shouldForwardProp: (prop) => !['separatorColor'].includes(prop),
 })<{ separatorColor: ColorFn }>`
-  border-left: ${p => p.theme.spacing.unit(0.5)}px solid ${p => p.theme.color.cta};
-  border-bottom: 1px solid ${p => p.separatorColor(p.theme)};
+  border-left: ${(p) => p.theme.spacing.unit(0.5)}px solid ${(p) => p.theme.color.cta};
+  border-bottom: 1px solid ${(p) => p.separatorColor(p.theme)};
 `;
 
 const Row: RowComponent = ({
@@ -78,7 +78,7 @@ const Row: RowComponent = ({
   hideSeparator = false,
   // If false means that it's a header
   isContent = true,
-  separatorColor = theme => theme.color.divider,
+  separatorColor = (theme) => theme.color.divider,
   onExpandToggle,
   expandChildren: expandChildrenXs,
   expandItems: expandItemsXs,
@@ -124,12 +124,18 @@ const Row: RowComponent = ({
         md={mdTable}
         lg={lgTable}
         xl={xlTable}
-        Container={({ density, columnDistance, expandable, children: component }) => (
+        Container={({
+          density,
+          columnDistance,
+          expandable,
+          children: component,
+          className: mediaClassName,
+        }) => (
           <StyledRow
+            className={mediaClassName ? `${className} ${mediaClassName}` : className}
             container
             alignItems="center"
             hoverHighlight={hoverHighlight}
-            className={className}
             hideSeparator={hideSeparator}
             role="row"
             // TODO: Remove type assertion when typescript is able to assert undefined from constants, in this case controlledExpand
@@ -169,8 +175,12 @@ const Row: RowComponent = ({
           md={md}
           lg={lg}
           xl={xl}
-          Container={({ children: component }) => (
-            <StyledExpandedRow role="row" separatorColor={separatorColor}>
+          Container={({ children: component, className: mediaClassName }) => (
+            <StyledExpandedRow
+              className={mediaClassName}
+              role="row"
+              separatorColor={separatorColor}
+            >
               {component}
             </StyledExpandedRow>
           )}

--- a/src/Molecules/FlexTable/Row/components/ExpandItems/ExpandItem.tsx
+++ b/src/Molecules/FlexTable/Row/components/ExpandItems/ExpandItem.tsx
@@ -16,8 +16,8 @@ const StyledOverflowItem = styled(Flexbox)<{ textAlign?: string }>`
 `;
 
 const StyledFlexboxItem = styled(Flexbox)<FlexBoxProps>`
-  max-width: ${p => p.theme.spacing.unit(75)}px;
-  padding-bottom: ${p => p.theme.spacing.unit(5)}px;
+  max-width: ${(p) => p.theme.spacing.unit(75)}px;
+  padding-bottom: ${(p) => p.theme.spacing.unit(5)}px;
 `;
 
 const ExpandRenderer: React.FC<{
@@ -37,7 +37,7 @@ const ExpandRenderer: React.FC<{
   );
 };
 
-const MobileItem: React.FC<{ item: ExpandItemProps; fontSize: FontSize }> = ({
+const MobileItem: React.FC<{ className?: string; item: ExpandItemProps; fontSize: FontSize }> = ({
   item,
   fontSize,
 }) => (
@@ -53,7 +53,7 @@ const MobileItem: React.FC<{ item: ExpandItemProps; fontSize: FontSize }> = ({
   </Flexbox>
 );
 
-const DesktopItem: React.FC<{ item: ExpandItemProps; fontSize: FontSize }> = ({
+const DesktopItem: React.FC<{ className?: string; item: ExpandItemProps; fontSize: FontSize }> = ({
   item,
   fontSize,
 }) => (
@@ -79,12 +79,12 @@ export const ExpandItem: ExpandItemComponent = ({ item }) => {
       md={{ ...md, mobileItem: false }}
       lg={lg}
       xl={xl}
-      Container={({ fontSize, mobileItem }) => {
+      Container={({ fontSize, mobileItem, className: mediaClassName }) => {
         if (mobileItem) {
-          return <MobileItem item={item} fontSize={fontSize} />;
+          return <MobileItem className={mediaClassName} item={item} fontSize={fontSize} />;
         }
 
-        return <DesktopItem item={item} fontSize={fontSize} />;
+        return <DesktopItem className={mediaClassName} item={item} fontSize={fontSize} />;
       }}
       Component={({ children }) => children}
     />

--- a/src/Molecules/FlexTable/shared/RenderForSizes/RenderForSizes.tsx
+++ b/src/Molecules/FlexTable/shared/RenderForSizes/RenderForSizes.tsx
@@ -16,7 +16,7 @@ export const getScreenMedia: GetScreenMedia = ({ xs, sm, md, lg, xl }) => {
     { size: 'lg' as ScreenSize, ...lg },
     { size: 'xl' as ScreenSize, ...xl },
   ]
-    .filter(media => Object.keys(media).length > 1)
+    .filter((media) => Object.keys(media).length > 1)
     .map((_, index, arr) => {
       const sizesUpToNow = arr.slice(0, index + 1);
       const screenSizeProps = sizesUpToNow.reduce<MediaPropsAndSize>(
@@ -59,15 +59,18 @@ export const RenderForSizes: RenderForSizesComponent = ({
         const { size } = props;
         const nextSize = arr[index + 1] ? arr[index + 1].size : null;
         const component = Component(props);
-        const container = Container({ children: component, ...props });
 
         if (size === 'xs' && !nextSize) {
+          const container = Container({ children: component, ...props });
           return <React.Fragment key={size}>{container}</React.Fragment>;
         }
 
-        const as = (() => container) as React.FC;
+        const as = (({ className }: { className?: string }) =>
+          Container({ children: component, className, ...props })) as React.FC;
 
-        return <IsomorphicMedia key={size} query={t => getMediaQuery(t, size, nextSize)} as={as} />;
+        return (
+          <IsomorphicMedia key={size} query={(t) => getMediaQuery(t, size, nextSize)} as={as} />
+        );
       })}
     </>
   );


### PR DESCRIPTION
The `className` that was attached by `StyledDiv` in `IsomorphicMedia` was never consumed by the `Container` component in `RenderForSizes`. Therefore all the media elements were displayed in SSR. Passing the `className` prop to the container component solved the double rendering issue in SSR.