### PR TITLE
fix: 🐛 allow elements as checkbox labels

### DIFF
--- a/src/Molecules/Input/Checkbox/Checkbox.stories.tsx
+++ b/src/Molecules/Input/Checkbox/Checkbox.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { actions } from '@storybook/addon-actions';
-import { Input, Flexbox, FormField } from '../../..';
+import { Input, Flexbox, FormField, Typography } from '../../..';
 import { Display } from '../../../common/Display';
 
 const handlers = actions(
@@ -211,4 +211,22 @@ export const withAllActions = () => (
 
 withAllActions.story = {
   name: 'With all actions',
+};
+
+export const elementLabelStory = () => {
+  const label = (
+    <>
+      <Typography type="secondary" weight="bold">
+        The first part is bold,
+      </Typography>{' '}
+      <Typography type="secondary" weight="regular">
+        the second part is regular
+      </Typography>
+    </>
+  );
+  return <Input.Checkbox name="example" value="element" label={label} />;
+};
+
+elementLabelStory.story = {
+  name: 'Element as label',
 };

--- a/src/Molecules/Input/Checkbox/Checkbox.types.ts
+++ b/src/Molecules/Input/Checkbox/Checkbox.types.ts
@@ -6,7 +6,7 @@ export type Props = {
   disabled?: boolean;
   error?: string;
   hasError?: boolean;
-  label: string;
+  label: string | JSX.Element;
   name?: string;
   required?: boolean;
   value?: string;

--- a/src/Molecules/Input/Checkbox/__snapshots__/Checkbox.stories.storyshot
+++ b/src/Molecules/Input/Checkbox/__snapshots__/Checkbox.stories.storyshot
@@ -552,6 +552,211 @@ Array [
 ]
 `;
 
+exports[`Storyshots Molecules | Input / Checkbox Element as label 1`] = `
+.c4 {
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c6 {
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c1 {
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.c9 {
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  width: 12px;
+  height: 12px;
+  fill: transparent;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  display: block;
+}
+
+.c3 {
+  font-family: 'Nordnet Sans Mono',-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
+  color: #6E6E69;
+  margin: 0;
+  font-weight: 400;
+  font-size: 14px;
+  line-height: 1.4285714285714286;
+}
+
+.c10 {
+  font-family: 'Nordnet Sans Mono',-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
+  color: #282823;
+  margin: 0;
+  font-weight: 400;
+  font-size: 14px;
+  line-height: 1.4285714285714286;
+}
+
+.c12 {
+  font-family: 'Nordnet Sans Mono',-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
+  color: #282823;
+  margin: 0;
+  font-weight: 700;
+  font-size: 14px;
+  line-height: 1.4285714285714286;
+}
+
+.c0 {
+  width: auto;
+  display: inline-block;
+}
+
+.c8 {
+  width: 20px;
+  height: 20px;
+  border: 1px solid #BCBCB6;
+  position: relative;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c8::before {
+  content: '';
+  display: block;
+  padding: 2px;
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  -webkit-transform: translate(-50%,-50%);
+  -ms-transform: translate(-50%,-50%);
+  transform: translate(-50%,-50%);
+}
+
+.c2 {
+  position: relative;
+}
+
+.c2:hover .c7 {
+  border-color: #4B4B46;
+}
+
+.c5 {
+  position: absolute;
+  opacity: 0;
+  height: 0;
+  width: 0;
+  cursor: pointer;
+}
+
+.c5:checked + .c7 {
+  border-color: #0046FF;
+  background: #0046FF;
+}
+
+.c5:checked + .c7 svg {
+  fill: #FFFFFF;
+}
+
+.c5[disabled] + .c7 {
+  border-color: #EBEBE8;
+}
+
+.c5:checked[disabled] + .c7 {
+  border-color: #EBEBE8;
+  background: #EBEBE8;
+}
+
+.c5:focus + .c7::before {
+  border: 1px solid #0046FF;
+}
+
+.c11 {
+  padding-left: 8px;
+  white-space: initial;
+}
+
+<div
+  className="c0"
+  width="auto"
+>
+  <label
+    className="c1 c2"
+    hidden={false}
+  >
+    <span
+      className="c3"
+    >
+      <div
+        className="c4"
+      >
+        <input
+          className="c5"
+          name="example"
+          type="checkbox"
+          value="element"
+        />
+        <div
+          className="c6 c7 c8"
+        >
+          <svg
+            aria-hidden="true"
+            className="c9"
+            focusable="false"
+            preserveAspectRatio="xMidYMid meet"
+            role="presentation"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M8.76083729 16.4144594L2.20525972 9.86336213 0 12.2093109 8.79670106 21 24 5.30897552 21.7583339 3z"
+            />
+          </svg>
+        </div>
+        <span
+          className="c10 c11"
+        >
+          <span
+            className="c12"
+          >
+            The first part is bold,
+          </span>
+           
+          <span
+            className="c10"
+          >
+            the second part is regular
+          </span>
+        </span>
+      </div>
+    </span>
+  </label>
+</div>
+`;
+
 exports[`Storyshots Molecules | Input / Checkbox In a group 1`] = `
 .c2 {
   box-sizing: border-box;


### PR DESCRIPTION
### This is somewhat a proposal for a change to the types allowed for Checkboxes

The use case for us are the account type checkboxes in the onboarding:
![Screenshot 2020-09-07 at 19 58 57](https://user-images.githubusercontent.com/13475700/92410580-df05f080-f144-11ea-9d53-914ff498e9be.png)

As it currently works, supplying a label as an element (see `Checkbox.stories.tsx` for an example) gives a type violation:
```js
Type 'Element' is not assignable to type 'string'.
```