### PR TITLE
fix: 🐛 update addon tab order

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -8,12 +8,12 @@ const storiesDir = process.env.STORYBOOK_DIRECTORY
 module.exports = {
   stories: ['../docs/**/*.stories.mdx', path.join(storiesDir, '**/*.stories.@(js|jsx|ts|tsx|mdx)')],
   addons: [
-    '@storybook/addon-a11y',
-    '@storybook/addon-actions',
-    '@storybook/addon-docs',
-    '@storybook/addon-knobs',
-    '@storybook/addon-links',
     '@storybook/addon-storysource',
+    '@storybook/addon-knobs',
+    '@storybook/addon-docs',
+    '@storybook/addon-actions',
+    '@storybook/addon-a11y',
+    '@storybook/addon-links',
     '@storybook/addon-viewport',
     'storybook-addon-intl',
   ],


### PR DESCRIPTION
Change the order of the addons that load our "tool-tabs" (i don't know the correct name of these).
I think it is more important to see the source code of the story first instead of the a11y inspection panel (also, running said inspection is quite heavy for SB which means larger stories might take longer to load if we instantly go to the a11y pane).