### PR TITLE
Feature/new link prop

### DIFF
--- a/src/Molecules/Button/Button.tsx
+++ b/src/Molecules/Button/Button.tsx
@@ -13,7 +13,7 @@ const isSecondary = (variant: ButtonProps['variant']) => variant === 'secondary'
 const isNeutral = (variant: ButtonProps['variant']) => variant === 'neutral';
 
 const StyledButton = styled(NormalizedElements.Button)<InnerProps>`
-  ${p => {
+  ${(p) => {
     if (isSecondary(p.$variant)) {
       return secondaryStyles;
     }
@@ -26,16 +26,16 @@ const StyledButton = styled(NormalizedElements.Button)<InnerProps>`
   }}
   border: none;
   border-radius: 0;
-  cursor: ${p => (p.disabled ? 'not-allowed' : 'pointer')};
+  cursor: ${(p) => (p.disabled ? 'not-allowed' : 'pointer')};
 `;
 
-const CleanLink: FC<RawLinkProps> = props => {
+const CleanLink: FC<RawLinkProps> = (props) => {
   const RawLink = useLink();
   return <RawLink {...props} />;
 };
 
 const StyledLink = styled(CleanLink)<InnerProps>`
-  ${p => {
+  ${(p) => {
     if (isSecondary(p.$variant)) {
       return secondaryStyles;
     }
@@ -71,6 +71,7 @@ export const Button: ButtonComponent = React.forwardRef<
     loading,
     external,
     cms,
+    fullServerRedirect,
     onMouseEnter,
     onMouseLeave,
     onMouseOver,
@@ -116,6 +117,12 @@ export const Button: ButtonComponent = React.forwardRef<
     },
   );
 
+  if (cms) {
+    assert(false, 'Link: the prop cms is deprecated, please use fullServerRedirect instead.', {
+      level: 'warn',
+    });
+  }
+
   assert(
     toAndDisabledAreNotPresentTogether,
     "You're using `to` prop together with `disabled` prop. `Disabled` prop won't be propagated to the dom node, because <a> element can't be disabled",
@@ -130,6 +137,7 @@ export const Button: ButtonComponent = React.forwardRef<
         innerRef={ref as React.Ref<HTMLAnchorElement>}
         external={external}
         cms={cms}
+        fullServerRedirect={fullServerRedirect}
         to={to}
         as={as}
         target={target}

--- a/src/Molecules/Button/Button.tsx
+++ b/src/Molecules/Button/Button.tsx
@@ -118,7 +118,7 @@ export const Button: ButtonComponent = React.forwardRef<
   );
 
   if (cms) {
-    assert(false, 'Link: the prop cms is deprecated, please use fullServerRedirect instead.', {
+    assert(false, 'Button: the prop cms is deprecated, please use fullServerRedirect instead.', {
       level: 'warn',
     });
   }

--- a/src/Molecules/Button/Button.types.ts
+++ b/src/Molecules/Button/Button.types.ts
@@ -23,7 +23,9 @@ export type ButtonProps = {
   type?: 'button' | 'reset' | 'submit';
   to?: any; // TODO define this, used to be LinkProps.to from 'react-router-dom' types.
   external?: boolean;
+  /** @deprecated use fullServerRedirect instead */
   cms?: boolean;
+  fullServerRedirect?: boolean;
   rel?: string;
   target?: '_blank' | '_self';
   colorFn?: ColorFn;

--- a/src/Molecules/Link/Link.stories.tsx
+++ b/src/Molecules/Link/Link.stories.tsx
@@ -63,7 +63,7 @@ export const externalLinkWithItsDefaultValues = () => (
   <Provider>
     <Typography type="secondary" weight="bold">
       <Link to="https://example.com" onClick={action('clicked')} external>
-        Example
+        Example external link
       </Link>
     </Typography>
   </Provider>
@@ -73,18 +73,18 @@ externalLinkWithItsDefaultValues.story = {
   name: 'External link with its default values',
 };
 
-export const cmsLinkWithItsDefaultValues = () => (
+export const fullServerRedirectLinkWithItsDefaultValues = () => (
   <Provider>
     <Typography type="secondary" weight="bold">
-      <Link to="https://example.com" onClick={action('clicked')} cms>
-        Example CMS
+      <Link to="https://example.com" onClick={action('clicked')} fullServerRedirect>
+        Example full server redirect link
       </Link>
     </Typography>
   </Provider>
 );
 
-cmsLinkWithItsDefaultValues.story = {
-  name: 'Cms link with its default values',
+fullServerRedirectLinkWithItsDefaultValues.story = {
+  name: 'Full server redirect link with its default values',
 };
 
 export const externalLinkWithRelAndTargetOverriden = () => (
@@ -97,7 +97,7 @@ export const externalLinkWithRelAndTargetOverriden = () => (
         target="_self"
         external
       >
-        Example CMS
+        Example external link
       </Link>
     </Typography>
   </Provider>

--- a/src/Molecules/Link/Link.tsx
+++ b/src/Molecules/Link/Link.tsx
@@ -2,7 +2,7 @@ import React, { useContext, FC } from 'react';
 import styled, { ThemedStyledProps } from 'styled-components';
 import { LinkComponent, LinkProps } from './Link.types';
 import { Theme } from '../../theme/theme.types';
-import { isUndefined } from '../../common/utils';
+import { isUndefined, assert } from '../../common/utils';
 import NormalizedElements from '../../common/NormalizedElements';
 import TrackingContext from '../../common/tracking';
 import { useLink, LinkProps as RawLinkProps } from '../../common/Links';
@@ -42,18 +42,18 @@ const getSharedStyle = (
   `;
 };
 
-const CleanLink: FC<RawLinkProps> = props => {
+const CleanLink: FC<RawLinkProps> = (props) => {
   const RawLink = useLink();
   return <RawLink {...props} />;
 };
 
 const StyledLink = styled(CleanLink)<LinkProps>`
-  ${p => getSharedStyle(p)}
+  ${(p) => getSharedStyle(p)}
   text-decoration: none;
 `;
 
 const StyledButton = styled(NormalizedElements.Button)<LinkProps>`
-  ${p => getSharedStyle(p)}
+  ${(p) => getSharedStyle(p)}
   /* resetting button styles */
   border: none;
   background: transparent;
@@ -62,7 +62,7 @@ const StyledButton = styled(NormalizedElements.Button)<LinkProps>`
   -webkit-appearance: none !important; /* stylelint-disable-line property-no-vendor-prefix */
   /* resetting button styles end */
 
-  cursor: ${p => (p.disabled ? 'not-allowed' : 'pointer')};
+  cursor: ${(p) => (p.disabled ? 'not-allowed' : 'pointer')};
 
   font-weight: inherit; /* remove when and if typography is handled inside the component */
 `;
@@ -77,6 +77,7 @@ export const Link: LinkComponent = React.forwardRef<any, LinkProps>((props, ref)
     onClick,
     external,
     cms,
+    fullServerRedirect,
     as, // FIXME Might have broken as functionallity, needs verification.
     color,
     onMouseEnter,
@@ -108,6 +109,12 @@ export const Link: LinkComponent = React.forwardRef<any, LinkProps>((props, ref)
     );
   }
 
+  if (cms) {
+    assert(false, 'Link: the prop cms is deprecated, please use fullServerRedirect instead.', {
+      level: 'warn',
+    });
+  }
+
   return (
     <StyledLink
       innerRef={ref}
@@ -116,6 +123,7 @@ export const Link: LinkComponent = React.forwardRef<any, LinkProps>((props, ref)
       to={to}
       external={external}
       cms={cms}
+      fullServerRedirect={fullServerRedirect}
       as={as}
       $color={color}
       $display={display}

--- a/src/Molecules/Link/Link.types.ts
+++ b/src/Molecules/Link/Link.types.ts
@@ -10,7 +10,9 @@ export type LinkProps = {
   target?: '_blank' | '_self';
   to?: any; // TODO define this, used to be LinkProps.to from 'react-router-dom' types.
   external?: boolean;
+  /** @deprecated use fullServerRedirect instead */
   cms?: boolean;
+  fullServerRedirect?: boolean;
   rel?: string;
   disabled?: boolean;
   as?: any;

--- a/src/Molecules/Link/__snapshots__/Link.stories.storyshot
+++ b/src/Molecules/Link/__snapshots__/Link.stories.storyshot
@@ -1,41 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Storyshots Molecules / Link Cms link with its default values 1`] = `
-.c0 {
-  font-family: 'Nordnet Sans Mono',-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
-  color: #282823;
-  margin: 0;
-  font-weight: 700;
-  font-size: 14px;
-  line-height: 1.4285714285714286;
-}
-
-.c1 {
-  display: inline;
-  padding: 0;
-  color: #0046FF;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-}
-
-.c1:hover {
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
-}
-
-<span
-  className="c0"
->
-  <a
-    className="c1"
-    href="https://example.com"
-    onClick={[Function]}
-  >
-    Example CMS
-  </a>
-</span>
-`;
-
 exports[`Storyshots Molecules / Link Default usage 1`] = `
 Array [
   .c0 {
@@ -140,7 +104,7 @@ exports[`Storyshots Molecules / Link External link with its default values 1`] =
     rel="noopener noreferrer nofollow"
     target="_blank"
   >
-    Example
+    Example external link
   </a>
 </span>
 `;
@@ -178,7 +142,43 @@ exports[`Storyshots Molecules / Link External link with rel and target overriden
     rel="nofollow"
     target="_self"
   >
-    Example CMS
+    Example external link
+  </a>
+</span>
+`;
+
+exports[`Storyshots Molecules / Link Full server redirect link with its default values 1`] = `
+.c0 {
+  font-family: 'Nordnet Sans Mono',-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
+  color: #282823;
+  margin: 0;
+  font-weight: 700;
+  font-size: 14px;
+  line-height: 1.4285714285714286;
+}
+
+.c1 {
+  display: inline;
+  padding: 0;
+  color: #0046FF;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c1:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+<span
+  className="c0"
+>
+  <a
+    className="c1"
+    href="https://example.com"
+    onClick={[Function]}
+  >
+    Example full server redirect link
   </a>
 </span>
 `;

--- a/src/common/Links/ReactRouterLinkHelper.tsx
+++ b/src/common/Links/ReactRouterLinkHelper.tsx
@@ -2,19 +2,20 @@ import React, { FC } from 'react';
 import { MemoryRouter, Link as RRLink } from 'react-router-dom';
 import { LinkProvider, LinkProps } from '.';
 
-export const RawLink: FC<LinkProps> = props => {
+export const RawLink: FC<LinkProps> = (props) => {
   const {
     innerRef,
     to,
     external,
     cms,
+    fullServerRedirect,
     children,
     className,
     target = external ? '_blank' : undefined,
     rel = external ? 'noopener noreferrer nofollow' : undefined,
     ...rest
   } = props;
-  if (cms || external) {
+  if (cms || fullServerRedirect || external) {
     return (
       <a href={to} ref={innerRef} target={target} rel={rel} className={className} {...rest}>
         {children}

--- a/src/common/Links/types.ts
+++ b/src/common/Links/types.ts
@@ -3,7 +3,9 @@ import { ReactNode, FC, Ref, HTMLProps } from 'react';
 export type LinkProps = Partial<HTMLProps<HTMLAnchorElement>> & {
   to: any;
   external?: boolean;
+  /** @deprecated use fullServerRedirect instead */
   cms?: boolean;
+  fullServerRedirect?: boolean;
   innerRef?: Ref<any>;
 };
 


### PR DESCRIPTION
This change adds the more descriptive `fullServerRedirect` prop intended for use in favour of the now deprecated `cms` prop.