### PR TITLE
Fix/safari input placeholder alignment

### DIFF
--- a/src/Molecules/DatePicker/SelectMonth/SelectMonth.tsx
+++ b/src/Molecules/DatePicker/SelectMonth/SelectMonth.tsx
@@ -44,6 +44,7 @@ const SelectMonth: React.FC<Props> = ({ id, locale, viewedDate, onChange }) => {
       SelectedValue: () => {
         const [state] = useSelectMachineFromContext();
         let icon = null;
+
         if ((state.value as any).open === 'on') {
           icon = <Icon.ChevronUp size={2} color={(t: any) => t.color.black} />;
         } else if (isHover) {
@@ -51,6 +52,7 @@ const SelectMonth: React.FC<Props> = ({ id, locale, viewedDate, onChange }) => {
         } else {
           icon = <Box px={1} />;
         }
+
         return (
           <Flexbox container data-testid="datepicker-select-month">
             <Flexbox item>

--- a/src/Molecules/DatePicker/SelectMonth/SelectMonth.tsx
+++ b/src/Molecules/DatePicker/SelectMonth/SelectMonth.tsx
@@ -43,15 +43,12 @@ const SelectMonth: React.FC<Props> = ({ id, locale, viewedDate, onChange }) => {
       // @ts-ignore
       SelectedValue: () => {
         const [state] = useSelectMachineFromContext();
-        let icon = null;
-
-        if ((state.value as any).open === 'on') {
-          icon = <Icon.ChevronUp size={2} color={(t: any) => t.color.black} />;
-        } else if (isHover) {
-          icon = <Icon.ChevronDown size={2} color={(t: any) => t.color.cta} />;
-        } else {
-          icon = <Box px={1} />;
-        }
+        const icon = (() => {
+          if ((state.value as any).open === 'on')
+            return <Icon.ChevronUp size={2} color={(t: any) => t.color.black} />;
+          if (isHover) return <Icon.ChevronDown size={2} color={(t: any) => t.color.cta} />;
+          return <Box px={1} />;
+        })();
 
         return (
           <Flexbox container data-testid="datepicker-select-month">

--- a/src/Molecules/DatePicker/SelectMonth/SelectMonth.tsx
+++ b/src/Molecules/DatePicker/SelectMonth/SelectMonth.tsx
@@ -43,13 +43,14 @@ const SelectMonth: React.FC<Props> = ({ id, locale, viewedDate, onChange }) => {
       // @ts-ignore
       SelectedValue: () => {
         const [state] = useSelectMachineFromContext();
-        const icon = (() => {
-          if ((state.value as any).open === 'on')
-            return <Icon.ChevronUp size={2} color={(t: any) => t.color.black} />;
-          if (isHover) return <Icon.ChevronDown size={2} color={(t: any) => t.color.cta} />;
-          return <Box px={1} />;
-        })();
-
+        let icon = null;
+        if ((state.value as any).open === 'on') {
+          icon = <Icon.ChevronUp size={2} color={(t: any) => t.color.black} />;
+        } else if (isHover) {
+          icon = <Icon.ChevronDown size={2} color={(t: any) => t.color.cta} />;
+        } else {
+          icon = <Box px={1} />;
+        }
         return (
           <Flexbox container data-testid="datepicker-select-month">
             <Flexbox item>

--- a/src/Molecules/DatePicker/__snapshots__/DatePicker.stories.storyshot
+++ b/src/Molecules/DatePicker/__snapshots__/DatePicker.stories.storyshot
@@ -181,7 +181,7 @@ Array [
   width: 100%;
   padding: 8px;
   margin: 0;
-  line-height: inherit;
+  line-height: 40px;
   box-sizing: border-box;
   height: 40px;
   outline: none;
@@ -396,7 +396,7 @@ exports[`Storyshots Molecules / DatePicker Default 1`] = `
   width: 100%;
   padding: 8px;
   margin: 0;
-  line-height: inherit;
+  line-height: 40px;
   box-sizing: border-box;
   height: 40px;
   outline: none;
@@ -610,7 +610,7 @@ exports[`Storyshots Molecules / DatePicker Disabled Input 1`] = `
   width: 100%;
   padding: 8px;
   margin: 0;
-  line-height: inherit;
+  line-height: 40px;
   box-sizing: border-box;
   height: 40px;
   outline: none;
@@ -821,7 +821,7 @@ exports[`Storyshots Molecules / DatePicker Same Week Disabled 1`] = `
   width: 100%;
   padding: 8px;
   margin: 0;
-  line-height: inherit;
+  line-height: 40px;
   box-sizing: border-box;
   height: 40px;
   outline: none;
@@ -1035,7 +1035,7 @@ exports[`Storyshots Molecules / DatePicker Same Week Enabled 1`] = `
   width: 100%;
   padding: 8px;
   margin: 0;
-  line-height: inherit;
+  line-height: 40px;
   box-sizing: border-box;
   height: 40px;
   outline: none;

--- a/src/Molecules/DatePicker/__snapshots__/DatePickerRange.stories.storyshot
+++ b/src/Molecules/DatePicker/__snapshots__/DatePickerRange.stories.storyshot
@@ -229,7 +229,7 @@ Array [
   width: 100%;
   padding: 8px;
   margin: 0;
-  line-height: inherit;
+  line-height: 40px;
   box-sizing: border-box;
   height: 40px;
   outline: none;
@@ -444,7 +444,7 @@ exports[`Storyshots Molecules / DatePicker / DatePicker with range Default 1`] =
   width: 100%;
   padding: 8px;
   margin: 0;
-  line-height: inherit;
+  line-height: 40px;
   box-sizing: border-box;
   height: 40px;
   outline: none;
@@ -658,7 +658,7 @@ exports[`Storyshots Molecules / DatePicker / DatePicker with range Disabled Inpu
   width: 100%;
   padding: 8px;
   margin: 0;
-  line-height: inherit;
+  line-height: 40px;
   box-sizing: border-box;
   height: 40px;
   outline: none;
@@ -869,7 +869,7 @@ exports[`Storyshots Molecules / DatePicker / DatePicker with range Same Week Dis
   width: 100%;
   padding: 8px;
   margin: 0;
-  line-height: inherit;
+  line-height: 40px;
   box-sizing: border-box;
   height: 40px;
   outline: none;
@@ -1083,7 +1083,7 @@ exports[`Storyshots Molecules / DatePicker / DatePicker with range Same Week Ena
   width: 100%;
   padding: 8px;
   margin: 0;
-  line-height: inherit;
+  line-height: 40px;
   box-sizing: border-box;
   height: 40px;
   outline: none;

--- a/src/Molecules/Input/Text/Text.tsx
+++ b/src/Molecules/Input/Text/Text.tsx
@@ -1,14 +1,18 @@
 import React from 'react';
-import styled, { css } from 'styled-components';
+import styled, { css, ThemedStyledProps } from 'styled-components';
 import * as R from 'ramda';
-import { Props, Variant } from './Text.types';
+import { Props, Variant, Size } from './Text.types';
 import { Flexbox, Typography, FormField } from '../../..';
 import NormalizedElements from '../../../common/NormalizedElements';
+import { Theme } from '../../../theme/theme.types';
 
 const hasError = (error?: Props['error']) => error && error !== '';
 
-const height = css<Pick<Props, 'size'>>`
-  height: ${(p) => (p.size === 's' ? p.theme.spacing.unit(8) : p.theme.spacing.unit(10))}px;
+const getHeight = (p: ThemedStyledProps<Size, Theme>) =>
+  p.size === 's' ? p.theme.spacing.unit(8) : p.theme.spacing.unit(10);
+
+const height = css<Size>`
+  height: ${getHeight}px;
 `;
 
 const background = css<Pick<Props, 'disabled' | 'variant'>>`
@@ -94,7 +98,7 @@ const Input = styled(NormalizedElements.Input).attrs((p) => ({ type: p.type || '
   width: 100%;
   padding: ${(p) => p.theme.spacing.unit(p.variant === 'quiet' ? 0 : 2)}px;
   margin: 0;
-  line-height: inherit;
+  line-height: ${getHeight}px;
   box-sizing: border-box;
   ${height}
   ${borderStyles}

--- a/src/Molecules/Input/Text/Text.types.ts
+++ b/src/Molecules/Input/Text/Text.types.ts
@@ -1,4 +1,5 @@
 export type Variant = 'normal' | 'quiet';
+export type Size = Pick<Props, 'size'>;
 
 export type Props = {
   className?: string;

--- a/src/Molecules/Input/Text/__snapshots__/Text.stories.storyshot
+++ b/src/Molecules/Input/Text/__snapshots__/Text.stories.storyshot
@@ -51,7 +51,7 @@ Array [
   width: 100%;
   padding: 8px;
   margin: 0;
-  line-height: inherit;
+  line-height: 40px;
   box-sizing: border-box;
   height: 40px;
   outline: none;
@@ -201,7 +201,7 @@ exports[`Storyshots Molecules / Input / Text Alternating Types 1`] = `
   width: 100%;
   padding: 8px;
   margin: 0;
-  line-height: inherit;
+  line-height: 40px;
   box-sizing: border-box;
   height: 40px;
   outline: none;
@@ -262,7 +262,7 @@ exports[`Storyshots Molecules / Input / Text Alternating Types 1`] = `
   width: 100%;
   padding: 8px;
   margin: 0;
-  line-height: inherit;
+  line-height: 40px;
   box-sizing: border-box;
   height: 40px;
   outline: none;
@@ -562,7 +562,7 @@ exports[`Storyshots Molecules / Input / Text Both addons 1`] = `
   width: 100%;
   padding: 8px;
   margin: 0;
-  line-height: inherit;
+  line-height: 40px;
   box-sizing: border-box;
   height: 40px;
   outline: none;
@@ -732,7 +732,7 @@ exports[`Storyshots Molecules / Input / Text Default 1`] = `
   width: 100%;
   padding: 8px;
   margin: 0;
-  line-height: inherit;
+  line-height: 40px;
   box-sizing: border-box;
   height: 40px;
   outline: none;
@@ -924,7 +924,7 @@ exports[`Storyshots Molecules / Input / Text Disabled +addon 1`] = `
   width: 100%;
   padding: 8px;
   margin: 0;
-  line-height: inherit;
+  line-height: 40px;
   box-sizing: border-box;
   height: 40px;
   outline: none;
@@ -1091,7 +1091,7 @@ exports[`Storyshots Molecules / Input / Text Disabled 1`] = `
   width: 100%;
   padding: 8px;
   margin: 0;
-  line-height: inherit;
+  line-height: 40px;
   box-sizing: border-box;
   height: 40px;
   outline: none;
@@ -1239,7 +1239,7 @@ exports[`Storyshots Molecules / Input / Text Edge cases 1`] = `
   width: 100%;
   padding: 8px;
   margin: 0;
-  line-height: inherit;
+  line-height: 40px;
   box-sizing: border-box;
   height: 40px;
   outline: none;
@@ -1531,7 +1531,7 @@ exports[`Storyshots Molecules / Input / Text Error if empty text 1`] = `
   width: 100%;
   padding: 8px;
   margin: 0;
-  line-height: inherit;
+  line-height: 40px;
   box-sizing: border-box;
   height: 40px;
   outline: none;
@@ -1696,7 +1696,7 @@ exports[`Storyshots Molecules / Input / Text Extra info below 1`] = `
   width: 100%;
   padding: 8px;
   margin: 0;
-  line-height: inherit;
+  line-height: 40px;
   box-sizing: border-box;
   height: 40px;
   outline: none;
@@ -1863,7 +1863,7 @@ exports[`Storyshots Molecules / Input / Text Extra info with error 1`] = `
   width: 100%;
   padding: 8px;
   margin: 0;
-  line-height: inherit;
+  line-height: 40px;
   box-sizing: border-box;
   height: 40px;
   outline: none;
@@ -2099,7 +2099,7 @@ Array [
   width: 100%;
   padding: 8px;
   margin: 0;
-  line-height: inherit;
+  line-height: 40px;
   box-sizing: border-box;
   height: 40px;
   outline: none;
@@ -2160,7 +2160,7 @@ Array [
   width: 100%;
   padding: 8px;
   margin: 0;
-  line-height: inherit;
+  line-height: 40px;
   box-sizing: border-box;
   height: 40px;
   outline: none;
@@ -2222,7 +2222,7 @@ Array [
   width: 100%;
   padding: 8px;
   margin: 0;
-  line-height: inherit;
+  line-height: 40px;
   box-sizing: border-box;
   height: 40px;
   outline: none;
@@ -2566,7 +2566,7 @@ exports[`Storyshots Molecules / Input / Text Hidden label 1`] = `
   width: 100%;
   padding: 8px;
   margin: 0;
-  line-height: inherit;
+  line-height: 40px;
   box-sizing: border-box;
   height: 40px;
   outline: none;
@@ -2748,7 +2748,7 @@ exports[`Storyshots Molecules / Input / Text Left addon 1`] = `
   width: 100%;
   padding: 8px;
   margin: 0;
-  line-height: inherit;
+  line-height: 40px;
   box-sizing: border-box;
   height: 40px;
   outline: none;
@@ -3047,7 +3047,7 @@ Array [
   width: 100%;
   padding: 0px;
   margin: 0;
-  line-height: inherit;
+  line-height: 40px;
   box-sizing: border-box;
   height: 40px;
   outline: none;
@@ -3120,7 +3120,7 @@ Array [
   width: 100%;
   padding: 0px;
   margin: 0;
-  line-height: inherit;
+  line-height: 40px;
   box-sizing: border-box;
   height: 40px;
   outline: none;
@@ -3190,7 +3190,7 @@ Array [
   width: 100%;
   padding: 0px;
   margin: 0;
-  line-height: inherit;
+  line-height: 40px;
   box-sizing: border-box;
   height: 40px;
   outline: none;
@@ -3263,7 +3263,7 @@ Array [
   width: 100%;
   padding: 0px;
   margin: 0;
-  line-height: inherit;
+  line-height: 40px;
   box-sizing: border-box;
   height: 40px;
   outline: none;
@@ -3336,7 +3336,7 @@ Array [
   width: 100%;
   padding: 0px;
   margin: 0;
-  line-height: inherit;
+  line-height: 40px;
   box-sizing: border-box;
   height: 40px;
   outline: none;
@@ -3410,7 +3410,7 @@ Array [
   width: 100%;
   padding: 0px;
   margin: 0;
-  line-height: inherit;
+  line-height: 40px;
   box-sizing: border-box;
   height: 40px;
   outline: none;
@@ -3998,7 +3998,7 @@ Array [
   width: 100%;
   padding: 8px;
   margin: 0;
-  line-height: inherit;
+  line-height: 40px;
   box-sizing: border-box;
   height: 40px;
   outline: none;
@@ -4302,7 +4302,7 @@ exports[`Storyshots Molecules / Input / Text Right addon 1`] = `
   width: 100%;
   padding: 8px;
   margin: 0;
-  line-height: inherit;
+  line-height: 40px;
   box-sizing: border-box;
   height: 40px;
   outline: none;
@@ -4617,7 +4617,7 @@ exports[`Storyshots Molecules / Input / Text Simple login form 1`] = `
   width: 100%;
   padding: 8px;
   margin: 0;
-  line-height: inherit;
+  line-height: 40px;
   box-sizing: border-box;
   height: 40px;
   outline: none;
@@ -4678,7 +4678,7 @@ exports[`Storyshots Molecules / Input / Text Simple login form 1`] = `
   width: 100%;
   padding: 8px;
   margin: 0;
-  line-height: inherit;
+  line-height: 40px;
   box-sizing: border-box;
   height: 40px;
   outline: none;
@@ -5003,7 +5003,7 @@ Array [
   width: 100%;
   padding: 8px;
   margin: 0;
-  line-height: inherit;
+  line-height: 32px;
   box-sizing: border-box;
   height: 32px;
   outline: none;
@@ -5064,7 +5064,7 @@ Array [
   width: 100%;
   padding: 8px;
   margin: 0;
-  line-height: inherit;
+  line-height: 32px;
   box-sizing: border-box;
   height: 32px;
   outline: none;
@@ -5125,7 +5125,7 @@ Array [
   width: 100%;
   padding: 8px;
   margin: 0;
-  line-height: inherit;
+  line-height: 32px;
   box-sizing: border-box;
   height: 32px;
   outline: none;
@@ -5187,7 +5187,7 @@ Array [
   width: 100%;
   padding: 8px;
   margin: 0;
-  line-height: inherit;
+  line-height: 32px;
   box-sizing: border-box;
   height: 32px;
   outline: none;
@@ -5640,7 +5640,7 @@ exports[`Storyshots Molecules / Input / Text Success 1`] = `
   width: 100%;
   padding: 8px;
   margin: 0;
-  line-height: inherit;
+  line-height: 40px;
   box-sizing: border-box;
   height: 40px;
   outline: none;
@@ -5783,7 +5783,7 @@ Array [
   width: 100%;
   padding: 8px;
   margin: 0;
-  line-height: inherit;
+  line-height: 40px;
   box-sizing: border-box;
   height: 40px;
   outline: none;
@@ -5923,7 +5923,7 @@ Array [
   width: 100%;
   padding: 8px;
   margin: 0;
-  line-height: inherit;
+  line-height: 40px;
   box-sizing: border-box;
   height: 40px;
   outline: none;
@@ -6063,7 +6063,7 @@ Array [
   width: 100%;
   padding: 8px;
   margin: 0;
-  line-height: inherit;
+  line-height: 40px;
   box-sizing: border-box;
   height: 40px;
   outline: none;
@@ -6207,7 +6207,7 @@ exports[`Storyshots Molecules / Input / Text With auto focus 1`] = `
   width: 100%;
   padding: 8px;
   margin: 0;
-  line-height: inherit;
+  line-height: 40px;
   box-sizing: border-box;
   height: 40px;
   outline: none;
@@ -6350,7 +6350,7 @@ exports[`Storyshots Molecules / Input / Text With default value (Uncontrolled be
   width: 100%;
   padding: 8px;
   margin: 0;
-  line-height: inherit;
+  line-height: 40px;
   box-sizing: border-box;
   height: 40px;
   outline: none;
@@ -6493,7 +6493,7 @@ exports[`Storyshots Molecules / Input / Text With maxLength 1`] = `
   width: 100%;
   padding: 8px;
   margin: 0;
-  line-height: inherit;
+  line-height: 40px;
   box-sizing: border-box;
   height: 40px;
   outline: none;
@@ -6657,7 +6657,7 @@ Array [
   width: 100%;
   padding: 8px;
   margin: 0;
-  line-height: inherit;
+  line-height: 40px;
   box-sizing: border-box;
   height: 40px;
   outline: none;
@@ -6855,7 +6855,7 @@ exports[`Storyshots Molecules / Input / Text With tooltip as label addon 1`] = `
   width: 100%;
   padding: 8px;
   margin: 0;
-  line-height: inherit;
+  line-height: 40px;
   box-sizing: border-box;
   height: 40px;
   outline: none;
@@ -7034,7 +7034,7 @@ exports[`Storyshots Molecules / Input / Text With value (Controlled behaviour) 1
   width: 100%;
   padding: 8px;
   margin: 0;
-  line-height: inherit;
+  line-height: 40px;
   box-sizing: border-box;
   height: 40px;
   outline: none;


### PR DESCRIPTION
This fixes the issue that the placeholder does not center vertically in Safari >14.0.


![Screenshot 2020-11-18 at 11 42 54](https://user-images.githubusercontent.com/31688213/99532868-4510be80-29a5-11eb-8b9c-88c61bbdd756.png)
![Screenshot 2020-11-18 at 13 55 15](https://user-images.githubusercontent.com/31688213/99533149-b3ee1780-29a5-11eb-8d71-3f32649f6985.png)

