### PR TITLE
fix: 🐛 remove unfinished arrow navigation for double datepicker

### DIFF
--- a/src/Molecules/DatePicker/Double/Calendar/DoubleCalendar.tsx
+++ b/src/Molecules/DatePicker/Double/Calendar/DoubleCalendar.tsx
@@ -15,7 +15,7 @@ import { FlexProps } from '../../../../Atoms/Flexbox/Flexbox.types';
 import { Props } from './DoubleCalendar.types';
 import {
   NUMBER_OF_VISIBLE_WEEKDAYS_SINGLE,
-  NUMBER_OF_VISIBLE_WEEKS_SINGLE,
+  // NUMBER_OF_VISIBLE_WEEKS_SINGLE,
   NUMBER_OF_VISIBLE_WEEKDAYS_DOUBLE,
   NUMBER_OF_VISIBLE_ROWS_DOUBLE,
   DOUBLE_CALENDAR_GUTTER,
@@ -77,7 +77,9 @@ const DoubleCalendar: React.FC<Props> = ({
 
   const handleKeyPress = (event: React.KeyboardEvent) => {
     event.stopPropagation();
-
+    // TODO: Implement arrow navigation. Re-implement tests.
+    // Arrow navigation is temporarilty removed as it is not completely finished yet.
+    /* 
     if (R.isNil(focusedWeek) || R.isNil(focusedDay)) {
       setFocused([0, 0]);
     } else {
@@ -121,6 +123,7 @@ const DoubleCalendar: React.FC<Props> = ({
           break;
       }
     }
+    */
   };
 
   useEffect(() => {

--- a/src/Molecules/DatePicker/Double/DoubleDatePicker.stories.tsx
+++ b/src/Molecules/DatePicker/Double/DoubleDatePicker.stories.tsx
@@ -1,7 +1,7 @@
 import { action } from '@storybook/addon-actions';
 import { add, isSameWeek } from 'date-fns';
 import React, { useState } from 'react';
-import { Button, Flexbox } from '../../..';
+import { Button, Flexbox, Typography } from '../../..';
 import DatePicker from '../DatePicker';
 
 export default {
@@ -14,13 +14,16 @@ export default {
 const dateNow = new Date();
 
 export const Default = () => (
-  <DatePicker
-    id="input-id"
-    labelFrom="Label"
-    labelTo=""
-    onChange={action('Range date')}
-    variant="DOUBLE"
-  />
+  <>
+    <Typography>Observe! Arrow navigation is yet to be implemented</Typography>
+    <DatePicker
+      id="input-id"
+      labelFrom="Label"
+      labelTo=""
+      onChange={action('Range date')}
+      variant="DOUBLE"
+    />
+  </>
 );
 
 export const SameWeekDisabled = () => {

--- a/src/Molecules/DatePicker/Double/__snapshots__/DoubleDatePicker.stories.storyshot
+++ b/src/Molecules/DatePicker/Double/__snapshots__/DoubleDatePicker.stories.storyshot
@@ -435,7 +435,22 @@ Array [
 `;
 
 exports[`Storyshots Molecules / DatePicker / Double DatePicker Default 1`] = `
-.c4 {
+Array [
+  .c0 {
+  font-family: 'Nordnet Sans Mono',-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
+  color: #282823;
+  margin: 0;
+  font-weight: 400;
+  font-size: 16px;
+  line-height: 1.5;
+}
+
+<span
+    className="c0"
+  >
+    Observe! Arrow navigation is yet to be implemented
+  </span>,
+  .c4 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -606,109 +621,110 @@ exports[`Storyshots Molecules / DatePicker / Double DatePicker Default 1`] = `
 }
 
 <div>
-  <div
-    className="c0 c1"
-  >
-    <label
-      className="c2"
-      hidden={false}
+    <div
+      className="c0 c1"
     >
-      <span
-        className="c3"
+      <label
+        className="c2"
+        hidden={false}
       >
-        <div
-          className="c4"
-        >
-          Label 
-        </div>
         <span
-          className="c5"
+          className="c3"
         >
           <div
-            className="c6"
+            className="c4"
           >
-            <input
-              autoComplete="off"
-              className="NormalizedInput__Input-sc-1m4kmh9-0 c7"
-              data-testid="datepicker-input-start"
-              id="input-id-start"
-              onBlur={[Function]}
-              onChange={[Function]}
-              onFocus={[Function]}
-              onKeyDown={[Function]}
-              placeholder="dd/mm/yyyy"
-              type="text"
-              value=""
-              variant="normal"
-            />
-            <div
-              className="c8 c9"
-              position="right"
-              variant="normal"
-            >
-              <svg
-                aria-hidden="true"
-                className="c10"
-                focusable="false"
-                preserveAspectRatio="xMidYMid meet"
-                role="presentation"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  d="M8 3v2h8V3h2v2h4v16H2V5h4V3h2zm12 7H4v9h16v-9zM7 15v2H5v-2h2zm3 0v2H8v-2h2zm3 0v2h-2v-2h2zm3 0v2h-2v-2h2zm3 0v2h-2v-2h2zM7 12v2H5v-2h2zm3 0v2H8v-2h2zm3 0v2h-2v-2h2zm3 0v2h-2v-2h2zm3 0v2h-2v-2h2zm1-5H4v1h16V7z"
-                />
-              </svg>
-            </div>
+            Label 
           </div>
-        </span>
-      </span>
-    </label>
-  </div>
-  <div
-    className="c0 c11"
-  >
-    <span
-      className="c5"
-    >
-      <div
-        className="c6"
-      >
-        <input
-          autoComplete="off"
-          className="NormalizedInput__Input-sc-1m4kmh9-0 c7"
-          data-testid="datepicker-input-end"
-          id="input-id-end"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          placeholder="dd/mm/yyyy"
-          type="text"
-          value=""
-          variant="normal"
-        />
-        <div
-          className="c8 c9"
-          position="right"
-          variant="normal"
-        >
-          <svg
-            aria-hidden="true"
-            className="c10"
-            focusable="false"
-            preserveAspectRatio="xMidYMid meet"
-            role="presentation"
-            viewBox="0 0 24 24"
+          <span
+            className="c5"
           >
-            <path
-              d="M8 3v2h8V3h2v2h4v16H2V5h4V3h2zm12 7H4v9h16v-9zM7 15v2H5v-2h2zm3 0v2H8v-2h2zm3 0v2h-2v-2h2zm3 0v2h-2v-2h2zm3 0v2h-2v-2h2zM7 12v2H5v-2h2zm3 0v2H8v-2h2zm3 0v2h-2v-2h2zm3 0v2h-2v-2h2zm3 0v2h-2v-2h2zm1-5H4v1h16V7z"
-            />
-          </svg>
+            <div
+              className="c6"
+            >
+              <input
+                autoComplete="off"
+                className="NormalizedInput__Input-sc-1m4kmh9-0 c7"
+                data-testid="datepicker-input-start"
+                id="input-id-start"
+                onBlur={[Function]}
+                onChange={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                placeholder="dd/mm/yyyy"
+                type="text"
+                value=""
+                variant="normal"
+              />
+              <div
+                className="c8 c9"
+                position="right"
+                variant="normal"
+              >
+                <svg
+                  aria-hidden="true"
+                  className="c10"
+                  focusable="false"
+                  preserveAspectRatio="xMidYMid meet"
+                  role="presentation"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M8 3v2h8V3h2v2h4v16H2V5h4V3h2zm12 7H4v9h16v-9zM7 15v2H5v-2h2zm3 0v2H8v-2h2zm3 0v2h-2v-2h2zm3 0v2h-2v-2h2zm3 0v2h-2v-2h2zM7 12v2H5v-2h2zm3 0v2H8v-2h2zm3 0v2h-2v-2h2zm3 0v2h-2v-2h2zm3 0v2h-2v-2h2zm1-5H4v1h16V7z"
+                  />
+                </svg>
+              </div>
+            </div>
+          </span>
+        </span>
+      </label>
+    </div>
+    <div
+      className="c0 c11"
+    >
+      <span
+        className="c5"
+      >
+        <div
+          className="c6"
+        >
+          <input
+            autoComplete="off"
+            className="NormalizedInput__Input-sc-1m4kmh9-0 c7"
+            data-testid="datepicker-input-end"
+            id="input-id-end"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            placeholder="dd/mm/yyyy"
+            type="text"
+            value=""
+            variant="normal"
+          />
+          <div
+            className="c8 c9"
+            position="right"
+            variant="normal"
+          >
+            <svg
+              aria-hidden="true"
+              className="c10"
+              focusable="false"
+              preserveAspectRatio="xMidYMid meet"
+              role="presentation"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M8 3v2h8V3h2v2h4v16H2V5h4V3h2zm12 7H4v9h16v-9zM7 15v2H5v-2h2zm3 0v2H8v-2h2zm3 0v2h-2v-2h2zm3 0v2h-2v-2h2zm3 0v2h-2v-2h2zM7 12v2H5v-2h2zm3 0v2H8v-2h2zm3 0v2h-2v-2h2zm3 0v2h-2v-2h2zm3 0v2h-2v-2h2zm1-5H4v1h16V7z"
+              />
+            </svg>
+          </div>
         </div>
-      </div>
-    </span>
-  </div>
-</div>
+      </span>
+    </div>
+  </div>,
+]
 `;
 
 exports[`Storyshots Molecules / DatePicker / Double DatePicker Disabled Input 1`] = `

--- a/src/Molecules/DatePicker/__tests__/DoubleDatePicker.test.tsx
+++ b/src/Molecules/DatePicker/__tests__/DoubleDatePicker.test.tsx
@@ -168,7 +168,8 @@ describe('Double date picker', () => {
     expect(onChange).toHaveLastReturnedWith([expectedStart, expectedEnd]);
   });
 
-  it('select a range by using arrowkeys', async () => {
+  // TODO: Re-implement this test when arrow navigation is added.
+  it.skip('select a range by using arrowkeys', async () => {
     const onChange = jest.fn((first: Date | null, second: Date | null) => {
       if (first && !second) return [format(first, 'MMMM d'), null];
       if (first && second) return [format(first, 'MMMM d'), format(second, 'MMMM d')];
@@ -242,7 +243,8 @@ describe('Double date picker', () => {
     expect(onChange).toHaveLastReturnedWith([expectedDate, expectedDate]);
   });
 
-  it('select a range of one day by using arrow keys', async () => {
+  // TODO: Re-implement this test when arrow navigation is added.
+  it.skip('select a range of one day by using arrow keys', async () => {
     const onChange = jest.fn((first: Date | null, second: Date | null) => {
       if (first && !second) return [format(first, 'MMMM d'), null];
       if (first && second) return [format(first, 'MMMM d'), format(second, 'MMMM d')];
@@ -348,7 +350,8 @@ describe('Double date picker', () => {
     expect(onChange).toHaveLastReturnedWith([expectedDate, null]);
   });
 
-  it('not select a range of one day by using arrow keys', async () => {
+  // TODO: Re-implement this test when arrow navigation is added.
+  it.skip('not select a range of one day by using arrow keys', async () => {
     const onChange = jest.fn((first: Date | null, second: Date | null) => {
       if (first && !second) return [format(first, 'MMMM d'), null];
       if (first && second) return [format(first, 'MMMM d'), format(second, 'MMMM d')];


### PR DESCRIPTION
Disable the arrow navigation for the double date picker until it has been fully implemented.

Authors: Robin Andersson, Marcus Hogler