### PR TITLE
Feat/drawer avoid close on element data

### DIFF
--- a/src/Molecules/Drawer/Drawer.stories.tsx
+++ b/src/Molecules/Drawer/Drawer.stories.tsx
@@ -1,6 +1,8 @@
 import React, { useState } from 'react';
 import { action } from '@storybook/addon-actions';
+import styled from 'styled-components';
 import { Drawer, Typography, Icon, Flexbox, FadedScroll } from '../../index';
+import Box from '../../Atoms/Box';
 
 export default {
   title: 'Molecules / Drawer',
@@ -220,6 +222,65 @@ export const WithoutCloseOnClickOutside = () => {
 
 WithoutCloseOnClickOutside.story = {
   name: 'Without closing the drawer when clicking outside',
+};
+
+export const WithoutCloseOnSpecificElementClick = () => {
+  const StyledBox = styled(Box)`
+    background: ${(p) => p.theme.color.paletteBlue[3]};
+  `;
+  const Example = () => {
+    const [open, setOpen] = useState(true);
+
+    const toggle = () => {
+      setOpen(!open);
+    };
+
+    const onClose = () => {
+      setOpen(false);
+    };
+
+    return (
+      <div>
+        <Box>
+          <button type="button" onClick={toggle}>
+            Toggle drawer (Buggy with close on click outside)
+          </button>
+        </Box>
+        <Box>
+          <button type="button" onClick={toggle} data-drawer-dont-close-on-click-outside>
+            Toggle drawer (Drawer click outside disabled on this element)
+          </button>
+        </Box>
+        <Box>
+          <button type="button">Random button</button>
+        </Box>
+        <StyledBox data-drawer-dont-close-on-click-outside p={8}>
+          <div>
+            <Typography type="title3">Random area</Typography>
+          </div>
+          <div>
+            <Typography type="primary">Clicking anywhere here does not close the drawer</Typography>
+          </div>
+          <Box>
+            <button type="button">Random button</button>
+          </Box>
+        </StyledBox>
+
+        <Drawer onClose={onClose} title="Drawer title" open={open}>
+          <Typography>
+            Certain elements on this page has a &quot;data-drawer-dont-close-on-click-outside&quot;
+            prop, which is an opt-out from drawer close. Try clicking on those elements and compare
+            with clicking somewhere else.
+          </Typography>
+        </Drawer>
+      </div>
+    );
+  };
+  return <Example />;
+};
+
+WithoutCloseOnSpecificElementClick.story = {
+  name: 'Without closing the drawer when clicking outside on specified elements',
 };
 
 export const noInitialAnimationStory = () => {

--- a/src/Molecules/Drawer/Drawer.stories.tsx
+++ b/src/Molecules/Drawer/Drawer.stories.tsx
@@ -225,9 +225,13 @@ WithoutCloseOnClickOutside.story = {
 };
 
 export const WithoutCloseOnSpecificElementClick = () => {
-  const StyledBox = styled(Box)`
+  const StyledBoxBlue = styled(Box)`
     background: ${(p) => p.theme.color.paletteBlue[3]};
   `;
+  const StyledBoxGreen = styled(Box)`
+    background: ${(p) => p.theme.color.paletteGreen[4]};
+  `;
+
   const Example = () => {
     const [open, setOpen] = useState(true);
 
@@ -254,22 +258,50 @@ export const WithoutCloseOnSpecificElementClick = () => {
         <Box>
           <button type="button">Random button</button>
         </Box>
-        drawerPreventOnClickOutside
-        <StyledBox data-drawer-prevent-click-outside p={8}>
+        <StyledBoxBlue data-drawer-prevent-click-outside p={8}>
           <div>
             <Typography type="title3">Random area</Typography>
           </div>
           <div>
-            <Typography type="primary">Clicking anywhere here does not close the drawer</Typography>
+            <Typography type="primary">
+              Clicking anywhere here does not close the drawer, using the default
+              &quot;data-drawer-prevent-click-outside&quot;-attribute.
+            </Typography>
           </div>
           <Box>
             <button type="button">Random button</button>
           </Box>
-        </StyledBox>
-        <Drawer onClose={onClose} title="Drawer title" open={open}>
+        </StyledBoxBlue>
+        <StyledBoxGreen data-custom-prevent-click-outside p={8}>
+          <div>
+            <Typography type="title3">Another random area</Typography>
+          </div>
+          <div>
+            <Typography type="primary">
+              Clicking anywhere here does not close the drawer as well. But this area uses a custom
+              &quot;data-custom-prevent-click-outside&quot;-attribute, which is passed to the Drawer
+              to recognize it.
+            </Typography>
+            <Box my={4}>
+              <Typography type="primary">
+                Useful for when multiple drawers might be open but only one should remain open while
+                clicking this area.
+              </Typography>
+            </Box>
+          </div>
+          <Box>
+            <input placeholder="Random text input" />
+          </Box>
+        </StyledBoxGreen>
+        <Drawer
+          onClose={onClose}
+          title="Drawer title"
+          open={open}
+          preventOnClickOutsideDataAttributes={['data-custom-prevent-click-outside']}
+        >
           <Typography>
-            Certain elements on this page has a &quot;data-drawer-prevent-click-outside&quot; prop,
-            which is an opt-out from drawer close. Try clicking on those elements and compare with
+            Certain elements on this page has special data-attributes attached to them, which
+            prevents the Drawer from closing. Try clicking on those elements and compare with
             clicking somewhere else.
           </Typography>
         </Drawer>

--- a/src/Molecules/Drawer/Drawer.stories.tsx
+++ b/src/Molecules/Drawer/Drawer.stories.tsx
@@ -224,14 +224,14 @@ WithoutCloseOnClickOutside.story = {
   name: 'Without closing the drawer when clicking outside',
 };
 
-export const WithoutCloseOnSpecificElementClick = () => {
-  const StyledBoxBlue = styled(Box)`
-    background: ${(p) => p.theme.color.paletteBlue[3]};
-  `;
-  const StyledBoxGreen = styled(Box)`
-    background: ${(p) => p.theme.color.paletteGreen[4]};
-  `;
+const StyledBoxBlue = styled(Box)`
+  background: ${(p) => p.theme.color.paletteBlue[3]};
+`;
+const StyledBoxGreen = styled(Box)`
+  background: ${(p) => p.theme.color.paletteGreen[4]};
+`;
 
+export const WithoutCloseOnSpecificElementClick = () => {
   const Example = () => {
     const [open, setOpen] = useState(true);
 
@@ -263,12 +263,15 @@ export const WithoutCloseOnSpecificElementClick = () => {
             <Typography type="title3">Random area</Typography>
           </div>
           <div>
-            <Typography type="primary">
-              Clicking anywhere here does not close the drawer, using the default
-              &quot;data-drawer-prevent-click-outside&quot;-attribute.
-            </Typography>
+            <Box>
+              <Typography type="primary">
+                Clicking anywhere here does not close the drawer, using the default{' '}
+                <Typography weight="bold">&quot;data-drawer-prevent-click-outside&quot;</Typography>
+                -attribute.
+              </Typography>
+            </Box>
           </div>
-          <Box>
+          <Box mt={4}>
             <button type="button">Random button</button>
           </Box>
         </StyledBoxBlue>
@@ -282,14 +285,14 @@ export const WithoutCloseOnSpecificElementClick = () => {
               &quot;data-custom-prevent-click-outside&quot;-attribute, which is passed to the Drawer
               to recognize it.
             </Typography>
-            <Box my={4}>
+            <Box mt={4}>
               <Typography type="primary">
                 Useful for when multiple drawers might be open but only one should remain open while
                 clicking this area.
               </Typography>
             </Box>
           </div>
-          <Box>
+          <Box mt={4}>
             <input placeholder="Random text input" />
           </Box>
         </StyledBoxGreen>
@@ -299,11 +302,20 @@ export const WithoutCloseOnSpecificElementClick = () => {
           open={open}
           preventOnClickOutsideDataAttributes={['data-custom-prevent-click-outside']}
         >
-          <Typography>
-            Certain elements on this page has special data-attributes attached to them, which
-            prevents the Drawer from closing. Try clicking on those elements and compare with
-            clicking somewhere else.
-          </Typography>
+          <Box>
+            <Typography>
+              Certain elements on this page has special data-attributes attached to them, which
+              prevents the Drawer from closing. Try clicking on those elements and compare with
+              clicking somewhere else.
+            </Typography>
+          </Box>
+          <Box mt={4}>
+            <Typography type="primary">
+              Observe that ALL drawers&apos; remain open when clicking on elements with the default
+              attribute (
+              <Typography weight="bold">&quot;data-drawer-prevent-click-outside&quot;</Typography>).
+            </Typography>
+          </Box>
         </Drawer>
       </div>
     );

--- a/src/Molecules/Drawer/Drawer.stories.tsx
+++ b/src/Molecules/Drawer/Drawer.stories.tsx
@@ -247,14 +247,15 @@ export const WithoutCloseOnSpecificElementClick = () => {
           </button>
         </Box>
         <Box>
-          <button type="button" onClick={toggle} data-drawer-dont-close-on-click-outside>
+          <button type="button" onClick={toggle} data-drawer-prevent-click-outside>
             Toggle drawer (Drawer click outside disabled on this element)
           </button>
         </Box>
         <Box>
           <button type="button">Random button</button>
         </Box>
-        <StyledBox data-drawer-dont-close-on-click-outside p={8}>
+        drawerPreventOnClickOutside
+        <StyledBox data-drawer-prevent-click-outside p={8}>
           <div>
             <Typography type="title3">Random area</Typography>
           </div>
@@ -265,12 +266,11 @@ export const WithoutCloseOnSpecificElementClick = () => {
             <button type="button">Random button</button>
           </Box>
         </StyledBox>
-
         <Drawer onClose={onClose} title="Drawer title" open={open}>
           <Typography>
-            Certain elements on this page has a &quot;data-drawer-dont-close-on-click-outside&quot;
-            prop, which is an opt-out from drawer close. Try clicking on those elements and compare
-            with clicking somewhere else.
+            Certain elements on this page has a &quot;data-drawer-prevent-click-outside&quot; prop,
+            which is an opt-out from drawer close. Try clicking on those elements and compare with
+            clicking somewhere else.
           </Typography>
         </Drawer>
       </div>

--- a/src/Molecules/Drawer/Drawer.tsx
+++ b/src/Molecules/Drawer/Drawer.tsx
@@ -158,15 +158,13 @@ export const Drawer = (React.forwardRef<HTMLDivElement, Props>(
       handleClose();
     }, [handleClose]);
 
-    // TODO: cleanup, fix typescript
     useOnClickOutside(drawerRef, (e) => {
-      const drawerDontCloseOnClickOutside = e.path.some(
-        (target) =>
-          target.dataset?.hasOwnProperty('drawerDontCloseOnClickOutside') &&
-          target.dataset?.drawerDontCloseOnClickOutside,
+      const drawerPreventOnClickOutside = e.nativeEvent.composedPath().some(
+        // to avoid click event target being window or document (= no dataset), check if target is HTMLElement
+        (target) => target instanceof HTMLElement && target.dataset?.drawerPreventOnClickOutside,
       );
 
-      if (closeOnClickOutside && !drawerDontCloseOnClickOutside) {
+      if (closeOnClickOutside && !drawerPreventOnClickOutside) {
         handleClose();
       }
     });

--- a/src/Molecules/Drawer/Drawer.tsx
+++ b/src/Molecules/Drawer/Drawer.tsx
@@ -158,8 +158,15 @@ export const Drawer = (React.forwardRef<HTMLDivElement, Props>(
       handleClose();
     }, [handleClose]);
 
-    useOnClickOutside(drawerRef, () => {
-      if (closeOnClickOutside) {
+    // TODO: cleanup, fix typescript
+    useOnClickOutside(drawerRef, (e) => {
+      const drawerDontCloseOnClickOutside = e.path.some(
+        (target) =>
+          target.dataset?.hasOwnProperty('drawerDontCloseOnClickOutside') &&
+          target.dataset?.drawerDontCloseOnClickOutside,
+      );
+
+      if (closeOnClickOutside && !drawerDontCloseOnClickOutside) {
         handleClose();
       }
     });

--- a/src/Molecules/Drawer/Drawer.tsx
+++ b/src/Molecules/Drawer/Drawer.tsx
@@ -5,13 +5,14 @@ import FocusLock from 'react-focus-lock';
 import { RemoveScroll } from 'react-remove-scroll';
 import { motion, useDragControls, AnimatePresence } from 'framer-motion';
 import { Props, TitleProps } from './Drawer.types';
-import { isBoolean, isElement } from '../../common/utils';
+import { isBoolean, isElement, fromKebabToCamelCase } from '../../common/utils';
 import { useOnClickOutside } from '../../common/Hooks';
 import { Typography, Icon, useKeyPress, Portal, useMedia, Button } from '../..';
 
 const CROSS_SIZE = 5;
 const PADDING = 5;
 const displayName = 'Drawer';
+const PREVENT_CLICK_OUTSIDE_ATTRIBUTE = 'drawerPreventClickOutside';
 
 const Container = styled(motion.div)`
   box-sizing: border-box;
@@ -123,6 +124,7 @@ export const Drawer = (React.forwardRef<HTMLDivElement, Props>(
       onExitAnimationComplete,
       onAnimationComplete,
       disableInitialAnimation,
+      preventOnClickOutsideDataAttributes,
     },
     ref,
   ) => {
@@ -159,12 +161,26 @@ export const Drawer = (React.forwardRef<HTMLDivElement, Props>(
     }, [handleClose]);
 
     useOnClickOutside(drawerRef, (e) => {
-      const drawerPreventOnClickOutside = e.nativeEvent.composedPath().some(
-        // to avoid click event target being window or document (= no dataset), check if target is HTMLElement
-        (target) => target instanceof HTMLElement && target.dataset?.drawerPreventOnClickOutside,
-      );
+      const preventingDataAttributes = [
+        PREVENT_CLICK_OUTSIDE_ATTRIBUTE,
+        ...(preventOnClickOutsideDataAttributes || []),
+      ];
 
-      if (closeOnClickOutside && !drawerPreventOnClickOutside) {
+      // look for data attributes in all elements above the clicked one to see if any prevents click outside
+      const preventOnClickOutside =
+        e instanceof Event && // e.composedPath() is not available in MouseEvent for some reason
+        e.composedPath().some((target) => {
+          // avoid click event target being window or document (= no dataset)
+          if (!(target instanceof HTMLElement)) return false;
+
+          return preventingDataAttributes.some((dataAttribute) => {
+            // remove data-prefix and camelcase attributes to match them to dataset keys
+            const formattedDataAttribute = fromKebabToCamelCase(dataAttribute.replace('data-', ''));
+            return target.dataset?.[formattedDataAttribute];
+          });
+        });
+
+      if (closeOnClickOutside && !preventOnClickOutside) {
         handleClose();
       }
     });

--- a/src/Molecules/Drawer/Drawer.tsx
+++ b/src/Molecules/Drawer/Drawer.tsx
@@ -161,6 +161,8 @@ export const Drawer = (React.forwardRef<HTMLDivElement, Props>(
     }, [handleClose]);
 
     useOnClickOutside(drawerRef, (e) => {
+      if (!closeOnClickOutside) return;
+
       const preventingDataAttributes = [
         PREVENT_CLICK_OUTSIDE_ATTRIBUTE,
         ...(preventOnClickOutsideDataAttributes || []),
@@ -180,9 +182,7 @@ export const Drawer = (React.forwardRef<HTMLDivElement, Props>(
           });
         });
 
-      if (closeOnClickOutside && !preventOnClickOutside) {
-        handleClose();
-      }
+      if (!preventOnClickOutside) handleClose();
     });
 
     useEffect(() => {

--- a/src/Molecules/Drawer/Drawer.types.ts
+++ b/src/Molecules/Drawer/Drawer.types.ts
@@ -12,6 +12,7 @@ export type Props = {
   onExitAnimationComplete?: () => void;
   onAnimationComplete?: () => void;
   disableInitialAnimation?: boolean;
+  preventOnClickOutsideDataAttributes?: string[];
 };
 
 export type TitleProps = {

--- a/src/Molecules/Drawer/__snapshots__/Drawer.stories.storyshot
+++ b/src/Molecules/Drawer/__snapshots__/Drawer.stories.storyshot
@@ -859,7 +859,7 @@ exports[`Storyshots Molecules / Drawer No initial animation 1`] = `
             onTouchStart={[Function]}
           >
             <span
-              id="16val-Drawer"
+              id="17val-Drawer"
             >
               <h2
                 className="c1 c2"
@@ -1670,7 +1670,7 @@ exports[`Storyshots Molecules / Drawer With on animation complete 1`] = `
             onTouchStart={[Function]}
           >
             <span
-              id="17val-Drawer"
+              id="18val-Drawer"
             >
               <h2
                 className="c1 c2"
@@ -2020,7 +2020,12 @@ exports[`Storyshots Molecules / Drawer Without closing the drawer when clicking 
   padding: 32px;
 }
 
-.c10 {
+.c5 {
+  margin-top: 16px;
+  margin-bottom: 16px;
+}
+
+.c12 {
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -2052,7 +2057,7 @@ exports[`Storyshots Molecules / Drawer Without closing the drawer when clicking 
   line-height: 1.5;
 }
 
-.c6 {
+.c8 {
   font-family: 'Nordnet Sans Mono',-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
   color: #282823;
   margin: 0;
@@ -2061,7 +2066,7 @@ exports[`Storyshots Molecules / Drawer Without closing the drawer when clicking 
   line-height: 1.2;
 }
 
-.c9 {
+.c11 {
   font-family: 'Nordnet Sans Mono',-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
   color: inherit;
   margin: 0;
@@ -2070,7 +2075,7 @@ exports[`Storyshots Molecules / Drawer Without closing the drawer when clicking 
   line-height: 1.4285714285714286;
 }
 
-.c7 {
+.c9 {
   font-family: inherit;
   font-size: 100%;
   line-height: 1.15;
@@ -2099,46 +2104,46 @@ exports[`Storyshots Molecules / Drawer Without closing the drawer when clicking 
   cursor: pointer;
 }
 
-.c7,
-.c7[type='button'],
-.c7[type='reset'],
-.c7[type='submit'] {
+.c9,
+.c9[type='button'],
+.c9[type='reset'],
+.c9[type='submit'] {
   -webkit-appearance: button;
 }
 
-.c7::-moz-focus-inner,
-.c7[type='button']::-moz-focus-inner,
-.c7[type='reset']::-moz-focus-inner,
-.c7[type='submit']::-moz-focus-inner {
+.c9::-moz-focus-inner,
+.c9[type='button']::-moz-focus-inner,
+.c9[type='reset']::-moz-focus-inner,
+.c9[type='submit']::-moz-focus-inner {
   border-style: none;
   padding: 0;
 }
 
-.c7:-moz-focusring,
-.c7[type='button']:-moz-focusring,
-.c7[type='reset']:-moz-focusring,
-.c7[type='submit']:-moz-focusring {
+.c9:-moz-focusring,
+.c9[type='button']:-moz-focusring,
+.c9[type='reset']:-moz-focusring,
+.c9[type='submit']:-moz-focusring {
   outline: 1px dotted ButtonText;
 }
 
-.c8 {
+.c10 {
   position: absolute;
   top: 20px;
   right: 20px;
 }
 
-.c11 {
+.c13 {
   overflow-y: auto;
   overflow-x: hidden;
   margin-bottom: 20px;
   padding: 0 20px;
 }
 
-.c5 {
+.c7 {
   padding-right: 16px;
 }
 
-.c4 {
+.c6 {
   padding: 20px 20px 0 20px;
   margin-bottom: 8px;
   min-height: 20px;
@@ -2151,6 +2156,10 @@ exports[`Storyshots Molecules / Drawer Without closing the drawer when clicking 
   background: #00F0E1;
 }
 
+.c4 {
+  background: #009195;
+}
+
 @media (min-width:760px) {
   .c2 {
     font-size: 20px;
@@ -2159,7 +2168,7 @@ exports[`Storyshots Molecules / Drawer Without closing the drawer when clicking 
 }
 
 @media (min-width:760px) {
-  .c6 {
+  .c8 {
     font-size: 24px;
     line-height: 1.1666666666666667;
   }
@@ -2204,7 +2213,6 @@ exports[`Storyshots Molecules / Drawer Without closing the drawer when clicking 
       Random button
     </button>
   </div>
-  drawerPreventOnClickOutside
   <div
     className="c0 c1"
     data-drawer-prevent-click-outside={true}
@@ -2220,7 +2228,7 @@ exports[`Storyshots Molecules / Drawer Without closing the drawer when clicking 
       <span
         className="c3"
       >
-        Clicking anywhere here does not close the drawer
+        Clicking anywhere here does not close the drawer, using the default "data-drawer-prevent-click-outside"-attribute.
       </span>
     </div>
     <div
@@ -2231,6 +2239,41 @@ exports[`Storyshots Molecules / Drawer Without closing the drawer when clicking 
       >
         Random button
       </button>
+    </div>
+  </div>
+  <div
+    className="c0 c4"
+    data-custom-prevent-click-outside={true}
+  >
+    <div>
+      <span
+        className="c2"
+      >
+        Another random area
+      </span>
+    </div>
+    <div>
+      <span
+        className="c3"
+      >
+        Clicking anywhere here does not close the drawer as well. But this area uses a custom "data-custom-prevent-click-outside"-attribute, which is passed to the Drawer to recognize it.
+      </span>
+      <div
+        className="c5"
+      >
+        <span
+          className="c3"
+        >
+          Useful for when multiple drawers might be open but only one should remain open while clicking this area.
+        </span>
+      </div>
+    </div>
+    <div
+      className=""
+    >
+      <input
+        placeholder="Random text input"
+      />
     </div>
   </div>
   <portal-dummy>
@@ -2276,29 +2319,29 @@ exports[`Storyshots Molecules / Drawer Without closing the drawer when clicking 
       >
         <div>
           <div
-            className="c4"
+            className="c6"
             onTouchStart={[Function]}
           >
             <span
               id="16val-Drawer"
             >
               <h2
-                className="c5 c6"
+                className="c7 c8"
               >
                 Drawer title
               </h2>
             </span>
             <button
-              className="NormalizedButton__Button-ey7f5x-0 c7 c8"
+              className="NormalizedButton__Button-ey7f5x-0 c9 c10"
               onClick={[Function]}
               type="button"
             >
               <span
-                className="c9"
+                className="c11"
               >
                 <svg
                   aria-hidden="false"
-                  className="c10"
+                  className="c12"
                   focusable="false"
                   preserveAspectRatio="xMidYMid meet"
                   role="img"
@@ -2316,12 +2359,12 @@ exports[`Storyshots Molecules / Drawer Without closing the drawer when clicking 
             </button>
           </div>
           <div
-            className="c11"
+            className="c13"
           >
             <span
               className="c3"
             >
-              Certain elements on this page has a "data-drawer-prevent-click-outside" prop, which is an opt-out from drawer close. Try clicking on those elements and compare with clicking somewhere else.
+              Certain elements on this page has special data-attributes attached to them, which prevents the Drawer from closing. Try clicking on those elements and compare with clicking somewhere else.
             </span>
           </div>
         </div>

--- a/src/Molecules/Drawer/__snapshots__/Drawer.stories.storyshot
+++ b/src/Molecules/Drawer/__snapshots__/Drawer.stories.storyshot
@@ -2014,3 +2014,334 @@ exports[`Storyshots Molecules / Drawer Without closing the drawer when clicking 
   </portal-dummy>
 </div>
 `;
+
+exports[`Storyshots Molecules / Drawer Without closing the drawer when clicking outside on specified elements 1`] = `
+.c0 {
+  padding: 32px;
+}
+
+.c10 {
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  width: 16px;
+  height: 16px;
+  fill: #282823;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  display: block;
+}
+
+.c2 {
+  font-family: 'Nordnet Sans Mono',-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
+  color: #282823;
+  margin: 0;
+  font-weight: 800;
+  font-size: 18px;
+  line-height: 1.3333333333333333;
+}
+
+.c3 {
+  font-family: 'Nordnet Sans Mono',-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
+  color: #282823;
+  margin: 0;
+  font-weight: 400;
+  font-size: 16px;
+  line-height: 1.5;
+}
+
+.c6 {
+  font-family: 'Nordnet Sans Mono',-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
+  color: #282823;
+  margin: 0;
+  font-weight: 800;
+  font-size: 20px;
+  line-height: 1.2;
+}
+
+.c9 {
+  font-family: 'Nordnet Sans Mono',-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
+  color: inherit;
+  margin: 0;
+  font-weight: 700;
+  font-size: 14px;
+  line-height: 1.4285714285714286;
+}
+
+.c7 {
+  font-family: inherit;
+  font-size: 100%;
+  line-height: 1.15;
+  margin: 0;
+  overflow: visible;
+  text-transform: none;
+  position: relative;
+  box-sizing: border-box;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  padding: 0;
+  background-color: transparent;
+  color: #282823;
+  border: none;
+  border-radius: 0;
+  cursor: pointer;
+}
+
+.c7,
+.c7[type='button'],
+.c7[type='reset'],
+.c7[type='submit'] {
+  -webkit-appearance: button;
+}
+
+.c7::-moz-focus-inner,
+.c7[type='button']::-moz-focus-inner,
+.c7[type='reset']::-moz-focus-inner,
+.c7[type='submit']::-moz-focus-inner {
+  border-style: none;
+  padding: 0;
+}
+
+.c7:-moz-focusring,
+.c7[type='button']:-moz-focusring,
+.c7[type='reset']:-moz-focusring,
+.c7[type='submit']:-moz-focusring {
+  outline: 1px dotted ButtonText;
+}
+
+.c8 {
+  position: absolute;
+  top: 20px;
+  right: 20px;
+}
+
+.c11 {
+  overflow-y: auto;
+  overflow-x: hidden;
+  margin-bottom: 20px;
+  padding: 0 20px;
+}
+
+.c5 {
+  padding-right: 16px;
+}
+
+.c4 {
+  padding: 20px 20px 0 20px;
+  margin-bottom: 8px;
+  min-height: 20px;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+}
+
+.c1 {
+  background: #00F0E1;
+}
+
+@media (min-width:760px) {
+  .c2 {
+    font-size: 20px;
+    line-height: 1.2;
+  }
+}
+
+@media (min-width:760px) {
+  .c6 {
+    font-size: 24px;
+    line-height: 1.1666666666666667;
+  }
+}
+
+@media (min-width:760px) {
+
+}
+
+@media (min-width:1600px) {
+
+}
+
+<div>
+  <div
+    className=""
+  >
+    <button
+      onClick={[Function]}
+      type="button"
+    >
+      Toggle drawer (Buggy with close on click outside)
+    </button>
+  </div>
+  <div
+    className=""
+  >
+    <button
+      data-drawer-prevent-click-outside={true}
+      onClick={[Function]}
+      type="button"
+    >
+      Toggle drawer (Drawer click outside disabled on this element)
+    </button>
+  </div>
+  <div
+    className=""
+  >
+    <button
+      type="button"
+    >
+      Random button
+    </button>
+  </div>
+  drawerPreventOnClickOutside
+  <div
+    className="c0 c1"
+    data-drawer-prevent-click-outside={true}
+  >
+    <div>
+      <span
+        className="c2"
+      >
+        Random area
+      </span>
+    </div>
+    <div>
+      <span
+        className="c3"
+      >
+        Clicking anywhere here does not close the drawer
+      </span>
+    </div>
+    <div
+      className=""
+    >
+      <button
+        type="button"
+      >
+        Random button
+      </button>
+    </div>
+  </div>
+  <portal-dummy>
+    <div
+      data-focus-guard={true}
+      style={
+        Object {
+          "height": "0px",
+          "left": "1px",
+          "overflow": "hidden",
+          "padding": 0,
+          "position": "fixed",
+          "top": "1px",
+          "width": "1px",
+        }
+      }
+      tabIndex={0}
+    />
+    <div
+      data-focus-guard={true}
+      style={
+        Object {
+          "height": "0px",
+          "left": "1px",
+          "overflow": "hidden",
+          "padding": 0,
+          "position": "fixed",
+          "top": "1px",
+          "width": "1px",
+        }
+      }
+      tabIndex={1}
+    />
+    <div
+      data-focus-lock-disabled={false}
+      onBlur={[Function]}
+      onFocus={[Function]}
+    >
+      <div
+        onScrollCapture={[Function]}
+        onTouchMoveCapture={[Function]}
+        onWheelCapture={[Function]}
+      >
+        <div>
+          <div
+            className="c4"
+            onTouchStart={[Function]}
+          >
+            <span
+              id="16val-Drawer"
+            >
+              <h2
+                className="c5 c6"
+              >
+                Drawer title
+              </h2>
+            </span>
+            <button
+              className="NormalizedButton__Button-ey7f5x-0 c7 c8"
+              onClick={[Function]}
+              type="button"
+            >
+              <span
+                className="c9"
+              >
+                <svg
+                  aria-hidden="false"
+                  className="c10"
+                  focusable="false"
+                  preserveAspectRatio="xMidYMid meet"
+                  role="img"
+                  viewBox="0 0 16 16"
+                >
+                  <path
+                    d="M6.857 8L0 1.143 1.143 0 8 6.857 14.857 0 16 1.143 9.143 8 16 14.857 14.857 16 8 9.143 1.143 16 0 14.857z"
+                    fillRule="evenodd"
+                  />
+                  <title>
+                    Close this drawer
+                  </title>
+                </svg>
+              </span>
+            </button>
+          </div>
+          <div
+            className="c11"
+          >
+            <span
+              className="c3"
+            >
+              Certain elements on this page has a "data-drawer-prevent-click-outside" prop, which is an opt-out from drawer close. Try clicking on those elements and compare with clicking somewhere else.
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      data-focus-guard={true}
+      style={
+        Object {
+          "height": "0px",
+          "left": "1px",
+          "overflow": "hidden",
+          "padding": 0,
+          "position": "fixed",
+          "top": "1px",
+          "width": "1px",
+        }
+      }
+      tabIndex={0}
+    />
+  </portal-dummy>
+</div>
+`;

--- a/src/Molecules/Drawer/__snapshots__/Drawer.stories.storyshot
+++ b/src/Molecules/Drawer/__snapshots__/Drawer.stories.storyshot
@@ -2022,10 +2022,9 @@ exports[`Storyshots Molecules / Drawer Without closing the drawer when clicking 
 
 .c5 {
   margin-top: 16px;
-  margin-bottom: 16px;
 }
 
-.c12 {
+.c13 {
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -2057,7 +2056,16 @@ exports[`Storyshots Molecules / Drawer Without closing the drawer when clicking 
   line-height: 1.5;
 }
 
-.c8 {
+.c4 {
+  font-family: 'Nordnet Sans Mono',-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
+  color: #282823;
+  margin: 0;
+  font-weight: 700;
+  font-size: 16px;
+  line-height: 1.5;
+}
+
+.c9 {
   font-family: 'Nordnet Sans Mono',-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
   color: #282823;
   margin: 0;
@@ -2066,7 +2074,7 @@ exports[`Storyshots Molecules / Drawer Without closing the drawer when clicking 
   line-height: 1.2;
 }
 
-.c11 {
+.c12 {
   font-family: 'Nordnet Sans Mono',-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
   color: inherit;
   margin: 0;
@@ -2075,7 +2083,7 @@ exports[`Storyshots Molecules / Drawer Without closing the drawer when clicking 
   line-height: 1.4285714285714286;
 }
 
-.c9 {
+.c10 {
   font-family: inherit;
   font-size: 100%;
   line-height: 1.15;
@@ -2104,46 +2112,46 @@ exports[`Storyshots Molecules / Drawer Without closing the drawer when clicking 
   cursor: pointer;
 }
 
-.c9,
-.c9[type='button'],
-.c9[type='reset'],
-.c9[type='submit'] {
+.c10,
+.c10[type='button'],
+.c10[type='reset'],
+.c10[type='submit'] {
   -webkit-appearance: button;
 }
 
-.c9::-moz-focus-inner,
-.c9[type='button']::-moz-focus-inner,
-.c9[type='reset']::-moz-focus-inner,
-.c9[type='submit']::-moz-focus-inner {
+.c10::-moz-focus-inner,
+.c10[type='button']::-moz-focus-inner,
+.c10[type='reset']::-moz-focus-inner,
+.c10[type='submit']::-moz-focus-inner {
   border-style: none;
   padding: 0;
 }
 
-.c9:-moz-focusring,
-.c9[type='button']:-moz-focusring,
-.c9[type='reset']:-moz-focusring,
-.c9[type='submit']:-moz-focusring {
+.c10:-moz-focusring,
+.c10[type='button']:-moz-focusring,
+.c10[type='reset']:-moz-focusring,
+.c10[type='submit']:-moz-focusring {
   outline: 1px dotted ButtonText;
 }
 
-.c10 {
+.c11 {
   position: absolute;
   top: 20px;
   right: 20px;
 }
 
-.c13 {
+.c14 {
   overflow-y: auto;
   overflow-x: hidden;
   margin-bottom: 20px;
   padding: 0 20px;
 }
 
-.c7 {
+.c8 {
   padding-right: 16px;
 }
 
-.c6 {
+.c7 {
   padding: 20px 20px 0 20px;
   margin-bottom: 8px;
   min-height: 20px;
@@ -2156,7 +2164,7 @@ exports[`Storyshots Molecules / Drawer Without closing the drawer when clicking 
   background: #00F0E1;
 }
 
-.c4 {
+.c6 {
   background: #009195;
 }
 
@@ -2168,7 +2176,7 @@ exports[`Storyshots Molecules / Drawer Without closing the drawer when clicking 
 }
 
 @media (min-width:760px) {
-  .c8 {
+  .c9 {
     font-size: 24px;
     line-height: 1.1666666666666667;
   }
@@ -2225,14 +2233,25 @@ exports[`Storyshots Molecules / Drawer Without closing the drawer when clicking 
       </span>
     </div>
     <div>
-      <span
-        className="c3"
+      <div
+        className=""
       >
-        Clicking anywhere here does not close the drawer, using the default "data-drawer-prevent-click-outside"-attribute.
-      </span>
+        <span
+          className="c3"
+        >
+          Clicking anywhere here does not close the drawer, using the default
+           
+          <span
+            className="c4"
+          >
+            "data-drawer-prevent-click-outside"
+          </span>
+          -attribute.
+        </span>
+      </div>
     </div>
     <div
-      className=""
+      className="c5"
     >
       <button
         type="button"
@@ -2242,7 +2261,7 @@ exports[`Storyshots Molecules / Drawer Without closing the drawer when clicking 
     </div>
   </div>
   <div
-    className="c0 c4"
+    className="c0 c6"
     data-custom-prevent-click-outside={true}
   >
     <div>
@@ -2269,7 +2288,7 @@ exports[`Storyshots Molecules / Drawer Without closing the drawer when clicking 
       </div>
     </div>
     <div
-      className=""
+      className="c5"
     >
       <input
         placeholder="Random text input"
@@ -2319,29 +2338,29 @@ exports[`Storyshots Molecules / Drawer Without closing the drawer when clicking 
       >
         <div>
           <div
-            className="c6"
+            className="c7"
             onTouchStart={[Function]}
           >
             <span
               id="16val-Drawer"
             >
               <h2
-                className="c7 c8"
+                className="c8 c9"
               >
                 Drawer title
               </h2>
             </span>
             <button
-              className="NormalizedButton__Button-ey7f5x-0 c9 c10"
+              className="NormalizedButton__Button-ey7f5x-0 c10 c11"
               onClick={[Function]}
               type="button"
             >
               <span
-                className="c11"
+                className="c12"
               >
                 <svg
                   aria-hidden="false"
-                  className="c12"
+                  className="c13"
                   focusable="false"
                   preserveAspectRatio="xMidYMid meet"
                   role="img"
@@ -2359,13 +2378,32 @@ exports[`Storyshots Molecules / Drawer Without closing the drawer when clicking 
             </button>
           </div>
           <div
-            className="c13"
+            className="c14"
           >
-            <span
-              className="c3"
+            <div
+              className=""
             >
-              Certain elements on this page has special data-attributes attached to them, which prevents the Drawer from closing. Try clicking on those elements and compare with clicking somewhere else.
-            </span>
+              <span
+                className="c3"
+              >
+                Certain elements on this page has special data-attributes attached to them, which prevents the Drawer from closing. Try clicking on those elements and compare with clicking somewhere else.
+              </span>
+            </div>
+            <div
+              className="c5"
+            >
+              <span
+                className="c3"
+              >
+                Observe that ALL drawers' remain open when clicking on elements with the default attribute (
+                <span
+                  className="c4"
+                >
+                  "data-drawer-prevent-click-outside"
+                </span>
+                ).
+              </span>
+            </div>
           </div>
         </div>
       </div>

--- a/src/Molecules/Modal/__snapshots__/Modal.stories.storyshot
+++ b/src/Molecules/Modal/__snapshots__/Modal.stories.storyshot
@@ -221,7 +221,7 @@ exports[`Storyshots Molecules / Modal Animation Complete 1`] = `
               className="c3"
             >
               <span
-                id="56val-ModalTitle"
+                id="57val-ModalTitle"
               >
                 <h2
                   className="c4 c5"
@@ -513,7 +513,7 @@ exports[`Storyshots Molecules / Modal Close On Backdrop Click Story 1`] = `
               className="c3"
             >
               <span
-                id="32val-ModalTitle"
+                id="33val-ModalTitle"
               >
                 <h2
                   className="c4 c5"
@@ -832,7 +832,7 @@ exports[`Storyshots Molecules / Modal Default 1`] = `
               className="c3"
             >
               <span
-                id="20val-ModalTitle"
+                id="21val-ModalTitle"
               >
                 <h2
                   className="c4 c5"
@@ -1084,7 +1084,7 @@ exports[`Storyshots Molecules / Modal Hide Close button 1`] = `
               className="c3"
             >
               <span
-                id="28val-ModalTitle"
+                id="29val-ModalTitle"
               >
                 <h2
                   className="c4 c5"
@@ -1535,7 +1535,7 @@ exports[`Storyshots Molecules / Modal Integration: Modal with a footer and Butto
               className="c3"
             >
               <span
-                id="22val-ModalTitle"
+                id="23val-ModalTitle"
               >
                 <h2
                   className="c4 c5"
@@ -2122,7 +2122,7 @@ exports[`Storyshots Molecules / Modal Modal Standard Large 1`] = `
             className="c2"
           >
             <span
-              id="40val-ModalTitle"
+              id="41val-ModalTitle"
             >
               <h2
                 className="c3 c4"
@@ -2807,7 +2807,7 @@ exports[`Storyshots Molecules / Modal Modal Standard Large with scroll 1`] = `
               className="c3"
             >
               <span
-                id="42val-ModalTitle"
+                id="43val-ModalTitle"
               >
                 <h2
                   className="c4 c5"
@@ -3429,7 +3429,7 @@ exports[`Storyshots Molecules / Modal Modal Standard Medium 1`] = `
             className="c2"
           >
             <span
-              id="38val-ModalTitle"
+              id="39val-ModalTitle"
             >
               <h2
                 className="c3 c4"
@@ -3991,7 +3991,7 @@ exports[`Storyshots Molecules / Modal Modal Standard Mobile With Scroll, One But
               className="c3"
             >
               <span
-                id="54val-ModalTitle"
+                id="55val-ModalTitle"
               >
                 <h2
                   className="c4 c5"
@@ -4656,7 +4656,7 @@ exports[`Storyshots Molecules / Modal Modal Standard Mobile with scroll, Fullscr
               className="c3"
             >
               <span
-                id="52val-ModalTitle"
+                id="53val-ModalTitle"
               >
                 <h2
                   className="c4 c5"
@@ -5143,7 +5143,7 @@ exports[`Storyshots Molecules / Modal Modal Standard Mobile, 1 Button, Fullscree
               className="c3"
             >
               <span
-                id="46val-ModalTitle"
+                id="47val-ModalTitle"
               >
                 <h2
                   className="c4 c5"
@@ -5572,7 +5572,7 @@ exports[`Storyshots Molecules / Modal Modal Standard Mobile, 1 Button, Small 1`]
               className="c3"
             >
               <span
-                id="50val-ModalTitle"
+                id="51val-ModalTitle"
               >
                 <h2
                   className="c4 c5"
@@ -6088,7 +6088,7 @@ exports[`Storyshots Molecules / Modal Modal Standard Mobile, 2 Buttons, Fullscre
               className="c3"
             >
               <span
-                id="44val-ModalTitle"
+                id="45val-ModalTitle"
               >
                 <h2
                   className="c4 c5"
@@ -6625,7 +6625,7 @@ exports[`Storyshots Molecules / Modal Modal Standard Mobile, 2 Buttons, Small 1`
               className="c3"
             >
               <span
-                id="48val-ModalTitle"
+                id="49val-ModalTitle"
               >
                 <h2
                   className="c4 c5"
@@ -7186,7 +7186,7 @@ exports[`Storyshots Molecules / Modal Modal Standard Small 1`] = `
               className="c3"
             >
               <span
-                id="36val-ModalTitle"
+                id="37val-ModalTitle"
               >
                 <h2
                   className="c4 c5"
@@ -7559,7 +7559,7 @@ exports[`Storyshots Molecules / Modal Node as Title 1`] = `
               className="c3"
             >
               <span
-                id="30val-ModalTitle"
+                id="31val-ModalTitle"
               >
                 <div
                   className="c4"
@@ -8086,7 +8086,7 @@ exports[`Storyshots Molecules / Modal Not full screen mobile 1`] = `
               className="c3"
             >
               <span
-                id="34val-ModalTitle"
+                id="35val-ModalTitle"
               >
                 <h2
                   className="c4 c5"
@@ -8410,7 +8410,7 @@ exports[`Storyshots Molecules / Modal Uncontrolled behavior 1`] = `
               className="c3"
             >
               <span
-                id="26val-ModalTitle"
+                id="27val-ModalTitle"
               >
                 <h2
                   className="c4 c5"

--- a/src/Molecules/ShowMoreButton/__snapshots__/ShowMoreButton.stories.storyshot
+++ b/src/Molecules/ShowMoreButton/__snapshots__/ShowMoreButton.stories.storyshot
@@ -493,7 +493,7 @@ exports[`Storyshots Molecules / ShowMoreButton Loading 1`] = `
       >
         <defs>
           <linearGradient
-            id="spinner-65val-Spinner-1"
+            id="spinner-66val-Spinner-1"
             x1="50%"
             x2="50%"
             y1="0%"
@@ -511,7 +511,7 @@ exports[`Storyshots Molecules / ShowMoreButton Loading 1`] = `
             />
           </linearGradient>
           <linearGradient
-            id="spinner-65val-Spinner-2"
+            id="spinner-66val-Spinner-2"
             x1="50%"
             x2="50%"
             y1="0%"
@@ -534,11 +534,11 @@ exports[`Storyshots Molecules / ShowMoreButton Loading 1`] = `
         >
           <path
             d="M12,0 C18.627417,0 24,5.372583 24,12 C24,18.627417 18.627417,24 12,24 M12,21 C16.9705627,21 21,16.9705627 21,12 C21,7.02943725 16.9705627,3 12,3"
-            fill="url(#spinner-65val-Spinner-1)"
+            fill="url(#spinner-66val-Spinner-1)"
           />
           <path
             d="M0,0 C6.627417,0 12,5.372583 12,12 C12,18.627417 6.627417,24 0,24 M0,21 C4.97056275,21 9,16.9705627 9,12 C9,7.02943725 4.97056275,3 0,3"
-            fill="url(#spinner-65val-Spinner-2)"
+            fill="url(#spinner-66val-Spinner-2)"
             transform="rotate(-180 6 12)"
           />
         </g>

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -95,3 +95,6 @@ export function wrapEvent<EventType extends React.SyntheticEvent | Event>(
     }
   };
 }
+
+export const fromKebabToCamelCase = (str: string) =>
+  str.replace(/-./g, (match) => match[1].toUpperCase());


### PR DESCRIPTION
Prevents Drawer's close handler on click outside from triggering if element (or parent element) has a specific data-attribute (one default + custom).