### PR TITLE
fix: 🐛 make options group non-interactive

### DIFF
--- a/src/Molecules/Input/Select/Select.tsx
+++ b/src/Molecules/Input/Select/Select.tsx
@@ -324,7 +324,7 @@ const Select = (props: Props) => {
                   ref={setItemRef(index) as any}
                   option={x}
                   id={props.id}
-                  onClick={x.disabled ? noop : handleClickListItem(x)}
+                  onClick={x.disabled || x.options ? noop : handleClickListItem(x)}
                   component={ListItem}
                 />
               ))}

--- a/src/Molecules/Input/Select/lib/SingleSelectList/SingleSelectList.tsx
+++ b/src/Molecules/Input/Select/lib/SingleSelectList/SingleSelectList.tsx
@@ -187,6 +187,8 @@ const StyledOptgroup = styled(Typography)<{ index: number }>`
   padding-top: ${(p) => p.theme.spacing.unit(p.index === 0 ? 1 : 3)}px;
   padding-bottom: ${(p) => p.theme.spacing.unit(1)}px;
   color: ${(p) => p.theme.color.label};
+  pointer-events: none;
+  user-select: none;
 `;
 
 export const Optgroup: React.FC<{ index: number; label: string }> = ({ index, label }) => {


### PR DESCRIPTION
clicking the group label with an item in the list selected would cause
all children of the group to become selected