### PR TITLE
fix: 🐛 ensure all input types use the correct background color

### DIFF
--- a/src/Molecules/Fieldset/__snapshots__/Fieldset.stories.storyshot
+++ b/src/Molecules/Fieldset/__snapshots__/Fieldset.stories.storyshot
@@ -90,6 +90,7 @@ exports[`Storyshots Molecules / Fieldset Default 1`] = `
   width: 20px;
   height: 20px;
   border: 1px solid #BCBCB6;
+  background: #FFFFFF;
   position: relative;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;

--- a/src/Molecules/Input/Checkbox/Checkbox.stories.tsx
+++ b/src/Molecules/Input/Checkbox/Checkbox.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { actions } from '@storybook/addon-actions';
-import { Input, Flexbox, FormField, Typography } from '../../..';
+import { Input, Flexbox, FormField, Typography, Box } from '../../..';
 import { Display } from '../../../common/Display';
 
 const handlers = actions(
@@ -327,4 +327,14 @@ export const withDifferentSizes = () => {
 
 withDifferentSizes.story = {
   name: 'Checkboxes with different size',
+};
+
+export const onAColouredBackground = () => (
+  <Box p={5} backgroundColor={(t) => t.color.disabledBackground}>
+    <Input.Checkbox name="background" value="background" label="On a colored background" />
+  </Box>
+);
+
+onAColouredBackground.story = {
+  name: 'On a coloured background',
 };

--- a/src/Molecules/Input/Checkbox/Checkbox.tsx
+++ b/src/Molecules/Input/Checkbox/Checkbox.tsx
@@ -29,6 +29,7 @@ const CheckmarkBox = styled(Flexbox)<{ size: number }>`
   width: ${(p) => p.theme.spacing.unit(p.size)}px;
   height: ${(p) => p.theme.spacing.unit(p.size)}px;
   border: 1px solid ${(p) => p.theme.color.inputBorder};
+  background: ${(p) => p.theme.color.backgroundInput};
   position: relative;
   flex-shrink: 0;
 

--- a/src/Molecules/Input/Checkbox/__snapshots__/Checkbox.stories.storyshot
+++ b/src/Molecules/Input/Checkbox/__snapshots__/Checkbox.stories.storyshot
@@ -86,6 +86,7 @@ exports[`Storyshots Molecules / Input / Checkbox Checkboxes with different size 
   width: 16px;
   height: 16px;
   border: 1px solid #BCBCB6;
+  background: #FFFFFF;
   position: relative;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
@@ -110,6 +111,7 @@ exports[`Storyshots Molecules / Input / Checkbox Checkboxes with different size 
   width: 20px;
   height: 20px;
   border: 1px solid #BCBCB6;
+  background: #FFFFFF;
   position: relative;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
@@ -387,6 +389,7 @@ exports[`Storyshots Molecules / Input / Checkbox Default 1`] = `
   width: 20px;
   height: 20px;
   border: 1px solid #BCBCB6;
+  background: #FFFFFF;
   position: relative;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
@@ -599,6 +602,7 @@ Array [
   width: 20px;
   height: 20px;
   border: 1px solid #BCBCB6;
+  background: #FFFFFF;
   position: relative;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
@@ -843,6 +847,7 @@ Array [
   width: 20px;
   height: 20px;
   border: 1px solid #BCBCB6;
+  background: #FFFFFF;
   position: relative;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
@@ -1085,6 +1090,7 @@ exports[`Storyshots Molecules / Input / Checkbox Default with tooltip 1`] = `
   width: 20px;
   height: 20px;
   border: 1px solid #BCBCB6;
+  background: #FFFFFF;
   position: relative;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
@@ -1326,6 +1332,7 @@ exports[`Storyshots Molecules / Input / Checkbox Default with tooltip with a lon
   width: 20px;
   height: 20px;
   border: 1px solid #BCBCB6;
+  background: #FFFFFF;
   position: relative;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
@@ -1574,6 +1581,7 @@ Array [
   width: 20px;
   height: 20px;
   border: 1px solid #BCBCB6;
+  background: #FFFFFF;
   position: relative;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
@@ -1918,6 +1926,7 @@ exports[`Storyshots Molecules / Input / Checkbox Element as label 1`] = `
   width: 20px;
   height: 20px;
   border: 1px solid #BCBCB6;
+  background: #FFFFFF;
   position: relative;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
@@ -2142,6 +2151,7 @@ exports[`Storyshots Molecules / Input / Checkbox In a group 1`] = `
   width: 20px;
   height: 20px;
   border: 1px solid #BCBCB6;
+  background: #FFFFFF;
   position: relative;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
@@ -2502,6 +2512,7 @@ Array [
   width: 20px;
   height: 20px;
   border: 1px solid #BCBCB6;
+  background: #FFFFFF;
   position: relative;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
@@ -2896,6 +2907,7 @@ exports[`Storyshots Molecules / Input / Checkbox In a group with a label tooltip
   width: 20px;
   height: 20px;
   border: 1px solid #BCBCB6;
+  background: #FFFFFF;
   position: relative;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
@@ -3289,6 +3301,7 @@ exports[`Storyshots Molecules / Input / Checkbox In a group with error 1`] = `
   width: 20px;
   height: 20px;
   border: 1px solid #BCBCB6;
+  background: #FFFFFF;
   position: relative;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
@@ -3550,6 +3563,201 @@ exports[`Storyshots Molecules / Input / Checkbox In a group with error 1`] = `
 </div>
 `;
 
+exports[`Storyshots Molecules / Input / Checkbox On a coloured background 1`] = `
+.c0 {
+  padding: 20px;
+  background-color: #EBEBE8;
+}
+
+.c5 {
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c7 {
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c2 {
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.c10 {
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  width: 12px;
+  height: 12px;
+  fill: transparent;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  display: block;
+}
+
+.c4 {
+  font-family: 'Nordnet Sans Mono',-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
+  color: #6E6E69;
+  margin: 0;
+  font-weight: 400;
+  font-size: 14px;
+  line-height: 1.4285714285714286;
+}
+
+.c11 {
+  font-family: 'Nordnet Sans Mono',-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
+  color: #282823;
+  margin: 0;
+  font-weight: 400;
+  font-size: 14px;
+  line-height: 1.4285714285714286;
+}
+
+.c9 {
+  width: 20px;
+  height: 20px;
+  border: 1px solid #BCBCB6;
+  background: #FFFFFF;
+  position: relative;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c9::before {
+  content: '';
+  display: block;
+  padding: 2px;
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  -webkit-transform: translate(-50%,-50%);
+  -ms-transform: translate(-50%,-50%);
+  transform: translate(-50%,-50%);
+}
+
+.c3 {
+  position: relative;
+}
+
+.c3:hover .c8 {
+  border-color: #4B4B46;
+}
+
+.c6 {
+  position: absolute;
+  opacity: 0;
+  height: 0;
+  width: 0;
+  cursor: pointer;
+}
+
+.c6:checked + .c8 {
+  border-color: #0046FF;
+  background: #0046FF;
+}
+
+.c6:checked + .c8 svg {
+  fill: #FFFFFF;
+}
+
+.c6[disabled] + .c8 {
+  border-color: #EBEBE8;
+}
+
+.c6:checked[disabled] + .c8 {
+  border-color: #EBEBE8;
+  background: #EBEBE8;
+}
+
+.c6:focus + .c8::before {
+  border: 1px solid #0046FF;
+}
+
+.c12 {
+  padding-left: 8px;
+  white-space: initial;
+}
+
+.c1 {
+  width: auto;
+  display: inline-block;
+}
+
+<div
+  className="c0"
+>
+  <div
+    className="c1"
+  >
+    <label
+      className="c2 c3"
+      hidden={false}
+    >
+      <span
+        className="c4"
+      >
+        <div
+          className="c5"
+        >
+          <input
+            className="c6"
+            name="background"
+            type="checkbox"
+            value="background"
+          />
+          <div
+            className="c7 c8 c9"
+          >
+            <svg
+              aria-hidden="true"
+              className="c10"
+              focusable="false"
+              preserveAspectRatio="xMidYMid meet"
+              role="presentation"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M8.76083729 16.4144594L2.20525972 9.86336213 0 12.2093109 8.79670106 21 24 5.30897552 21.7583339 3z"
+              />
+            </svg>
+          </div>
+          <span
+            className="c11 c12"
+          >
+            On a colored background
+          </span>
+        </div>
+      </span>
+    </label>
+  </div>
+</div>
+`;
+
 exports[`Storyshots Molecules / Input / Checkbox Required 1`] = `
 Array [
   .c0 {
@@ -3652,6 +3860,7 @@ Array [
   width: 20px;
   height: 20px;
   border: 1px solid #BCBCB6;
+  background: #FFFFFF;
   position: relative;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
@@ -3986,6 +4195,7 @@ exports[`Storyshots Molecules / Input / Checkbox With all actions 1`] = `
   width: 20px;
   height: 20px;
   border: 1px solid #BCBCB6;
+  background: #FFFFFF;
   position: relative;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
@@ -4196,6 +4406,7 @@ exports[`Storyshots Molecules / Input / Checkbox With an error if not checked 1`
   width: 20px;
   height: 20px;
   border: 1px solid #BCBCB6;
+  background: #FFFFFF;
   position: relative;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
@@ -4399,6 +4610,7 @@ exports[`Storyshots Molecules / Input / Checkbox With auto focus 1`] = `
   width: 20px;
   height: 20px;
   border: 1px solid #BCBCB6;
+  background: #FFFFFF;
   position: relative;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
@@ -4586,6 +4798,7 @@ Array [
   width: 20px;
   height: 20px;
   border: 1px solid #BCBCB6;
+  background: #FFFFFF;
   position: relative;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
@@ -4780,6 +4993,7 @@ exports[`Storyshots Molecules / Input / Checkbox With default checked 1`] = `
   width: 20px;
   height: 20px;
   border: 1px solid #BCBCB6;
+  background: #FFFFFF;
   position: relative;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;

--- a/src/Molecules/Input/Number/Number.stories.tsx
+++ b/src/Molecules/Input/Number/Number.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { action, actions } from '@storybook/addon-actions';
-import { Icon, Input } from '../../..';
+import { Icon, Input, Box } from '../../..';
 import { Display } from '../../../common/Display';
 
 const handlers = actions(
@@ -453,4 +453,14 @@ export const quietNumber = () => (
 );
 quietNumber.story = {
   name: 'Quiet',
+};
+
+export const onAColouredBackground = () => (
+  <Box p={5} backgroundColor={(t) => t.color.disabledBackground}>
+    <Input.Number id="unique-id-for-coloured-background" label="On a coloured background" />
+  </Box>
+);
+
+onAColouredBackground.story = {
+  name: 'On a coloured background',
 };

--- a/src/Molecules/Input/Number/__snapshots__/Number.stories.storyshot
+++ b/src/Molecules/Input/Number/__snapshots__/Number.stories.storyshot
@@ -609,6 +609,323 @@ exports[`Storyshots Molecules / Input / Number Disabled 1`] = `
 </div>
 `;
 
+exports[`Storyshots Molecules / Input / Number On a coloured background 1`] = `
+.c0 {
+  padding: 20px;
+  background-color: #EBEBE8;
+}
+
+.c4 {
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c6 {
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+.c10 {
+  position: absolute;
+  height: 1px;
+  width: 1px;
+  overflow: hidden;
+  -webkit-clip: rect(1px,1px,1px,1px);
+  clip: rect(1px,1px,1px,1px);
+}
+
+.c2 {
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.c11 {
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  width: 12px;
+  height: 12px;
+  fill: #282823;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  display: block;
+}
+
+.c3 {
+  font-family: 'Nordnet Sans Mono',-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
+  color: #6E6E69;
+  margin: 0;
+  font-weight: 400;
+  font-size: 14px;
+  line-height: 1.4285714285714286;
+}
+
+.c5 {
+  font-family: 'Nordnet Sans Mono',-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
+  color: #282823;
+  margin: 0;
+  font-weight: 400;
+  font-size: 14px;
+  line-height: 1.4285714285714286;
+}
+
+.c7 {
+  position: relative;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.03);
+}
+
+.c9 {
+  width: 40px;
+  height: 40px;
+  background-color: #FFFFFF;
+  outline: none;
+  border: 1px solid #BCBCB6;
+  position: relative;
+  border-width: 1px;
+  padding: 0;
+  cursor: pointer;
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+}
+
+.c9:hover {
+  border-color: #4B4B46;
+  z-index: 2;
+}
+
+.c9:focus {
+  border-color: #0046FF;
+  z-index: 3;
+}
+
+.c9:focus {
+  border-width: 1px;
+}
+
+.c9:first-of-type {
+  -webkit-order: -1;
+  -ms-flex-order: -1;
+  order: -1;
+}
+
+.c9:active:enabled {
+  background-color: #0046FF;
+}
+
+.c9:active:enabled svg {
+  fill: #FFFFFF;
+}
+
+.c8 {
+  font-family: inherit;
+  font-size: 100%;
+  line-height: 1.15;
+  margin: 0;
+  overflow: visible;
+  background-color: #FFFFFF;
+  outline: none;
+  border: 1px solid #BCBCB6;
+  position: relative;
+  border-width: 1px;
+  height: 40px;
+  padding: 8px;
+  width: 100%;
+  text-align: center;
+  box-sizing: border-box;
+  margin: 0 -1px;
+  min-width: 0;
+  z-index: 1;
+}
+
+.c8:hover {
+  border-color: #4B4B46;
+  z-index: 2;
+}
+
+.c8:focus {
+  border-color: #0046FF;
+  z-index: 3;
+}
+
+.c8:focus {
+  border-width: 1px;
+}
+
+.c8::-webkit-input-placeholder {
+  color: #6E6E69;
+  line-height: inherit;
+  opacity: 1;
+}
+
+.c8::-moz-placeholder {
+  color: #6E6E69;
+  line-height: inherit;
+  opacity: 1;
+}
+
+.c8:-ms-input-placeholder {
+  color: #6E6E69;
+  line-height: inherit;
+  opacity: 1;
+}
+
+.c8::placeholder {
+  color: #6E6E69;
+  line-height: inherit;
+  opacity: 1;
+}
+
+.c8:disabled::-webkit-input-placeholder {
+  color: #A0A09B;
+}
+
+.c8:disabled::-moz-placeholder {
+  color: #A0A09B;
+}
+
+.c8:disabled:-ms-input-placeholder {
+  color: #A0A09B;
+}
+
+.c8:disabled::placeholder {
+  color: #A0A09B;
+}
+
+.c1 {
+  width: 200px;
+  display: inline-block;
+}
+
+<div
+  className="c0"
+>
+  <div
+    className="c1"
+  >
+    <label
+      className="c2"
+      hidden={false}
+      htmlFor="unique-id-for-coloured-background"
+    >
+      <span
+        className="c3"
+      >
+        <div
+          className="c4"
+        >
+          On a coloured background 
+        </div>
+      </span>
+    </label>
+    <span
+      className="c5"
+    >
+      <div
+        className="c6 c7"
+      >
+        <input
+          className="NormalizedInput__Input-sc-1m4kmh9-0 c8"
+          id="unique-id-for-coloured-background"
+          inputMode="decimal"
+          min={0}
+          onChange={[Function]}
+          onKeyDown={[Function]}
+          step={1}
+          type="text"
+          value=""
+          variant="normal"
+        />
+        <button
+          className="c9"
+          onClick={[Function]}
+          type="button"
+        >
+          <div
+            className="c10"
+          >
+            decrease number by 
+            1
+          </div>
+          <svg
+            aria-hidden="true"
+            className="c11"
+            focusable="false"
+            preserveAspectRatio="xMidYMid meet"
+            role="presentation"
+            viewBox="0 0 12 2"
+          >
+            <path
+              d="M12.166 0v2h-12V0z"
+              fillRule="evenodd"
+            />
+          </svg>
+        </button>
+        <button
+          className="c9"
+          onClick={[Function]}
+          type="button"
+        >
+          <div
+            className="c10"
+          >
+            increase number by 
+            1
+          </div>
+          <svg
+            aria-hidden="true"
+            className="c11"
+            focusable="false"
+            preserveAspectRatio="xMidYMid meet"
+            role="presentation"
+            viewBox="0 0 12 12"
+          >
+            <path
+              d="M7.166 0v5h5v2h-5v5h-2V6.999L.166 7V5l5-.001V0h2z"
+              fillRule="evenodd"
+            />
+          </svg>
+        </button>
+      </div>
+    </span>
+  </div>
+</div>
+`;
+
 exports[`Storyshots Molecules / Input / Number Quiet 1`] = `
 Array [
   .c0 {

--- a/src/Molecules/Input/Radio/Radio.stories.tsx
+++ b/src/Molecules/Input/Radio/Radio.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { actions } from '@storybook/addon-actions';
-import { Input, Flexbox, FormField } from '../../..';
+import { Input, Flexbox, FormField, Box } from '../../..';
 import { Display } from '../../../common/Display';
 
 const handlers = actions(
@@ -243,4 +243,14 @@ export const withAllActions = () => (
 
 withAllActions.story = {
   name: 'With all actions',
+};
+
+export const onAColouredBackground = () => (
+  <Box p={5} backgroundColor={(t) => t.color.disabledBackground}>
+    <Input.Radio name="background" value="background" label="On a colored background" />
+  </Box>
+);
+
+onAColouredBackground.story = {
+  name: 'On a coloured background',
 };

--- a/src/Molecules/Input/Radio/__snapshots__/Radio.stories.storyshot
+++ b/src/Molecules/Input/Radio/__snapshots__/Radio.stories.storyshot
@@ -1744,6 +1744,167 @@ exports[`Storyshots Molecules / Input / Radio In a group with tooltip 1`] = `
 </div>
 `;
 
+exports[`Storyshots Molecules / Input / Radio On a coloured background 1`] = `
+.c0 {
+  padding: 20px;
+  background-color: #EBEBE8;
+}
+
+.c5 {
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c2 {
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.c4 {
+  font-family: 'Nordnet Sans Mono',-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
+  color: #6E6E69;
+  margin: 0;
+  font-weight: 400;
+  font-size: 14px;
+  line-height: 1.4285714285714286;
+}
+
+.c9 {
+  font-family: 'Nordnet Sans Mono',-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
+  color: #282823;
+  margin: 0;
+  font-weight: 400;
+  font-size: 14px;
+  line-height: 1.4285714285714286;
+}
+
+.c8 {
+  width: 18px;
+  height: 18px;
+  border: 1px solid #BCBCB6;
+  background-color: #FFFFFF;
+  position: relative;
+  border-radius: 50%;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c8::before,
+.c8::after {
+  content: '';
+  display: block;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  border-radius: 50%;
+  -webkit-transform: translate(-50%,-50%);
+  -ms-transform: translate(-50%,-50%);
+  transform: translate(-50%,-50%);
+}
+
+.c8::before {
+  width: 100%;
+  height: 100%;
+  padding: 2px;
+}
+
+.c8::after {
+  width: 11px;
+  height: 11px;
+}
+
+.c3 {
+  position: relative;
+}
+
+.c3:hover .c7 {
+  border-color: #4B4B46;
+}
+
+.c6 {
+  position: absolute;
+  opacity: 0;
+  height: 0;
+  width: 0;
+  cursor: pointer;
+}
+
+.c6:checked + .c7::after {
+  background: #0046FF;
+}
+
+.c6[disabled] + .c7 {
+  border-color: #EBEBE8;
+}
+
+.c6:checked[disabled] + .c7 {
+  border-color: #EBEBE8;
+}
+
+.c6:checked[disabled] + .c7::after {
+  background: #EBEBE8;
+}
+
+.c6:focus + .c7::before {
+  border: 1px solid #0046FF;
+}
+
+.c10 {
+  padding-left: 8px;
+  white-space: initial;
+}
+
+.c1 {
+  width: auto;
+  display: inline-block;
+}
+
+<div
+  className="c0"
+>
+  <div
+    className="c1"
+  >
+    <label
+      className="c2 c3"
+      hidden={false}
+    >
+      <span
+        className="c4"
+      >
+        <div
+          className="c5"
+        >
+          <input
+            className="c6"
+            name="background"
+            type="radio"
+            value="background"
+          />
+          <div
+            className="c7 c8"
+          />
+          <span
+            className="c9 c10"
+          >
+            On a colored background
+          </span>
+        </div>
+      </span>
+    </label>
+  </div>
+</div>
+`;
+
 exports[`Storyshots Molecules / Input / Radio Required 1`] = `
 Array [
   .c0 {

--- a/src/Molecules/Input/Select/Select.stories.tsx
+++ b/src/Molecules/Input/Select/Select.stories.tsx
@@ -1357,6 +1357,20 @@ export const groupedOptions = () => {
   );
 };
 
+export const onAColouredBackground = () => (
+  <Box p={5} backgroundColor={(t) => t.color.disabledBackground}>
+    <Input.Select
+      id="input-on-coloured-background"
+      label="On a colored background"
+      placeholder="Select an option"
+      options={[
+        { label: 'foo', value: 1 },
+        { label: 'bar', value: 2 },
+      ]}
+    />
+  </Box>
+);
+
 export default {
   title: 'Molecules / Input / Select',
   parameters: {

--- a/src/Molecules/Input/Select/__snapshots__/Select.stories.storyshot
+++ b/src/Molecules/Input/Select/__snapshots__/Select.stories.storyshot
@@ -124,6 +124,7 @@ exports[`Storyshots Molecules / Input / Select Accessible From Document Forms 1`
   outline: none;
   border: 1px solid #BCBCB6;
   position: relative;
+  background: #FFFFFF;
   box-sizing: border-box;
   position: relative;
 }
@@ -439,6 +440,7 @@ exports[`Storyshots Molecules / Input / Select Actions 1`] = `
   outline: none;
   border: 1px solid #BCBCB6;
   position: relative;
+  background: #FFFFFF;
   box-sizing: border-box;
   position: relative;
 }
@@ -746,6 +748,7 @@ exports[`Storyshots Molecules / Input / Select Actions And Empty Option List 1`]
   outline: none;
   border: 1px solid #BCBCB6;
   position: relative;
+  background: #FFFFFF;
   box-sizing: border-box;
   position: relative;
 }
@@ -1041,6 +1044,7 @@ exports[`Storyshots Molecules / Input / Select Auto Focus 1`] = `
   outline: none;
   border: 1px solid #BCBCB6;
   position: relative;
+  background: #FFFFFF;
   box-sizing: border-box;
   position: relative;
 }
@@ -1348,6 +1352,7 @@ exports[`Storyshots Molecules / Input / Select Auto Placement 1`] = `
   outline: none;
   border: 1px solid #BCBCB6;
   position: relative;
+  background: #FFFFFF;
   box-sizing: border-box;
   position: relative;
 }
@@ -1732,6 +1737,7 @@ Array [
   outline: none;
   border: 1px solid #BCBCB6;
   position: relative;
+  background: #FFFFFF;
   box-sizing: border-box;
   position: relative;
 }
@@ -2040,6 +2046,7 @@ exports[`Storyshots Molecules / Input / Select Controlled behaviour 1`] = `
   outline: none;
   border: 1px solid #BCBCB6;
   position: relative;
+  background: #FFFFFF;
   box-sizing: border-box;
   position: relative;
 }
@@ -2348,6 +2355,7 @@ exports[`Storyshots Molecules / Input / Select Custom Renderers 1`] = `
   outline: none;
   border: 1px solid #BCBCB6;
   position: relative;
+  background: #FFFFFF;
   box-sizing: border-box;
   position: relative;
 }
@@ -2646,6 +2654,7 @@ exports[`Storyshots Molecules / Input / Select Default Story 1`] = `
   outline: none;
   border: 1px solid #BCBCB6;
   position: relative;
+  background: #FFFFFF;
   box-sizing: border-box;
   position: relative;
 }
@@ -2980,6 +2989,7 @@ exports[`Storyshots Molecules / Input / Select Default variations 1`] = `
   outline: none;
   border: 1px solid #BCBCB6;
   position: relative;
+  background: #FFFFFF;
   box-sizing: border-box;
   position: relative;
 }
@@ -2997,6 +3007,7 @@ exports[`Storyshots Molecules / Input / Select Default variations 1`] = `
   outline: none;
   border: 1px solid #FF1900;
   position: relative;
+  background: #FFFFFF;
   box-sizing: border-box;
   position: relative;
 }
@@ -3018,6 +3029,7 @@ exports[`Storyshots Molecules / Input / Select Default variations 1`] = `
   outline: none;
   border: 1px solid #BCBCB6;
   position: relative;
+  background: #FFFFFF;
   box-sizing: border-box;
   position: relative;
 }
@@ -3039,6 +3051,7 @@ exports[`Storyshots Molecules / Input / Select Default variations 1`] = `
   outline: none;
   border: 1px solid #00D200;
   position: relative;
+  background: #FFFFFF;
   box-sizing: border-box;
   position: relative;
 }
@@ -3818,6 +3831,7 @@ exports[`Storyshots Molecules / Input / Select Disabled Items 1`] = `
   outline: none;
   border: 1px solid #BCBCB6;
   position: relative;
+  background: #FFFFFF;
   box-sizing: border-box;
   position: relative;
 }
@@ -4151,6 +4165,7 @@ Array [
   outline: none;
   border: 1px solid #BCBCB6;
   position: relative;
+  background: #FFFFFF;
   box-sizing: border-box;
   position: relative;
 }
@@ -4474,6 +4489,7 @@ exports[`Storyshots Molecules / Input / Select Full Width 1`] = `
   outline: none;
   border: 1px solid #BCBCB6;
   position: relative;
+  background: #FFFFFF;
   box-sizing: border-box;
   position: relative;
 }
@@ -4781,6 +4797,7 @@ exports[`Storyshots Molecules / Input / Select Fully Empty 1`] = `
   outline: none;
   border: 1px solid #BCBCB6;
   position: relative;
+  background: #FFFFFF;
   box-sizing: border-box;
   position: relative;
 }
@@ -5076,6 +5093,7 @@ exports[`Storyshots Molecules / Input / Select Grouped Options 1`] = `
   outline: none;
   border: 1px solid #BCBCB6;
   position: relative;
+  background: #FFFFFF;
   box-sizing: border-box;
   position: relative;
 }
@@ -5467,6 +5485,7 @@ exports[`Storyshots Molecules / Input / Select Hide Label 1`] = `
   outline: none;
   border: 1px solid #BCBCB6;
   position: relative;
+  background: #FFFFFF;
   box-sizing: border-box;
   position: relative;
 }
@@ -5790,6 +5809,7 @@ exports[`Storyshots Molecules / Input / Select Inside Modal 1`] = `
   outline: none;
   border: 1px solid #BCBCB6;
   position: relative;
+  background: #FFFFFF;
   box-sizing: border-box;
   position: relative;
 }
@@ -7667,6 +7687,7 @@ exports[`Storyshots Molecules / Input / Select Multi Select Uncontrolled 1`] = `
   outline: none;
   border: 1px solid #BCBCB6;
   position: relative;
+  background: #FFFFFF;
   box-sizing: border-box;
   position: relative;
 }
@@ -7971,6 +7992,7 @@ exports[`Storyshots Molecules / Input / Select Multiselect 1`] = `
   outline: none;
   border: 1px solid #BCBCB6;
   position: relative;
+  background: #FFFFFF;
   box-sizing: border-box;
   position: relative;
 }
@@ -8275,6 +8297,7 @@ exports[`Storyshots Molecules / Input / Select Multiselect Actions 1`] = `
   outline: none;
   border: 1px solid #BCBCB6;
   position: relative;
+  background: #FFFFFF;
   box-sizing: border-box;
   position: relative;
 }
@@ -8579,6 +8602,7 @@ exports[`Storyshots Molecules / Input / Select Multiselect Select All 1`] = `
   outline: none;
   border: 1px solid #BCBCB6;
   position: relative;
+  background: #FFFFFF;
   box-sizing: border-box;
   position: relative;
 }
@@ -8766,6 +8790,319 @@ exports[`Storyshots Molecules / Input / Select Multiselect Select All 1`] = `
 </div>
 `;
 
+exports[`Storyshots Molecules / Input / Select On A Coloured Background 1`] = `
+.c0 {
+  padding: 20px;
+  background-color: #EBEBE8;
+}
+
+.c13 {
+  padding-left: 8px;
+  padding-right: 8px;
+  background-color: transparent;
+}
+
+.c3 {
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c11 {
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c5 {
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.c16 {
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  width: 20px;
+  height: 20px;
+  fill: #282823;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  display: block;
+}
+
+.c9 {
+  font-family: inherit;
+  font-size: 100%;
+  line-height: 1.15;
+  margin: 0;
+  overflow: visible;
+  text-transform: none;
+}
+
+.c9,
+.c9[type='button'],
+.c9[type='reset'],
+.c9[type='submit'] {
+  -webkit-appearance: button;
+}
+
+.c9::-moz-focus-inner,
+.c9[type='button']::-moz-focus-inner,
+.c9[type='reset']::-moz-focus-inner,
+.c9[type='submit']::-moz-focus-inner {
+  border-style: none;
+  padding: 0;
+}
+
+.c9:-moz-focusring,
+.c9[type='button']:-moz-focusring,
+.c9[type='reset']:-moz-focusring,
+.c9[type='submit']:-moz-focusring {
+  outline: 1px dotted ButtonText;
+}
+
+.c6 {
+  font-family: 'Nordnet Sans Mono',-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
+  color: #6E6E69;
+  margin: 0;
+  font-weight: 400;
+  font-size: 14px;
+  line-height: 1.4285714285714286;
+}
+
+.c8 {
+  font-family: 'Nordnet Sans Mono',-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
+  color: #282823;
+  margin: 0;
+  font-weight: 400;
+  font-size: 14px;
+  line-height: 1.4285714285714286;
+}
+
+.c17 {
+  -webkit-transform: translateY(-50%) rotate(0);
+  -ms-transform: translateY(-50%) rotate(0);
+  transform: translateY(-50%) rotate(0);
+  -webkit-transform-origin: center center;
+  -ms-transform-origin: center center;
+  transform-origin: center center;
+  -webkit-transition: -webkit-transform 0.16s ease-out;
+  -webkit-transition: transform 0.16s ease-out;
+  transition: transform 0.16s ease-out;
+  position: absolute;
+  height: 8px;
+  top: 50%;
+  right: 4px;
+  pointer-events: none;
+}
+
+.c2 {
+  position: relative;
+  display: block;
+  width: auto;
+}
+
+.c7 {
+  height: 40px;
+  outline: none;
+  border: 1px solid #BCBCB6;
+  position: relative;
+  background: #FFFFFF;
+  box-sizing: border-box;
+  position: relative;
+}
+
+.c7:hover {
+  border-color: #4B4B46;
+}
+
+.c7:focus-within {
+  border-color: #0046FF;
+}
+
+.c7.focus-within {
+  border-color: #0046FF;
+}
+
+.c12 {
+  height: 100%;
+  width: 100%;
+}
+
+.c10 {
+  background: transparent;
+  width: 100%;
+  height: 100%;
+  cursor: pointer;
+  padding: 0;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  border: 0;
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  outline: 0;
+  text-align: initial;
+}
+
+.c10:active {
+  color: inherit;
+}
+
+.c15 {
+  width: 100%;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+  text-align: left;
+}
+
+.c14 {
+  width: calc(100% - 20px - 4px);
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c1 {
+  display: none;
+}
+
+.c4 {
+  width: 200px;
+  display: inline-block;
+}
+
+<div
+  className="c0"
+>
+  <div>
+    <select
+      aria-hidden="true"
+      className="c1"
+      disabled={false}
+      onChange={[Function]}
+    >
+      <option
+        label="Select an option"
+        value=""
+      />
+      <option
+        label="foo"
+        value={1}
+      />
+      <option
+        label="bar"
+        value={2}
+      />
+    </select>
+    <div
+      className="c2"
+    >
+      <div
+        className="c3"
+      >
+        <div
+          className="c4"
+        >
+          <label
+            className="c5"
+            hidden={false}
+            htmlFor="input-on-coloured-background"
+          >
+            <span
+              className="c6"
+            >
+              <div
+                className="c3"
+              >
+                On a colored background 
+              </div>
+            </span>
+          </label>
+          <div
+            className="c7"
+            disabled={false}
+            label="On a colored background"
+            onBlur={[Function]}
+            onFocus={[Function]}
+            tabIndex={0}
+          >
+            <span
+              className="c8"
+            >
+              <button
+                aria-expanded="false"
+                aria-haspopup="listbox"
+                aria-label="On a colored background: Select an option"
+                className="c9 c10"
+                data-testid="input-select-button"
+                disabled={false}
+                form=""
+                id="input-on-coloured-background"
+                onClick={[Function]}
+                tabIndex={0}
+                type="button"
+              >
+                <div
+                  aria-hidden="true"
+                  className="c11 c12"
+                >
+                  <div
+                    className="c13 c14"
+                  >
+                    <span
+                      className="c15"
+                    >
+                      Select an option
+                    </span>
+                  </div>
+                </div>
+              </button>
+            </span>
+            <svg
+              aria-hidden="true"
+              className="c16 c17"
+              focusable="false"
+              open={false}
+              preserveAspectRatio="xMidYMid meet"
+              role="presentation"
+              viewBox="0 0 24 24"
+            >
+              <polygon
+                points="19.969 4 24 8.027 12 20 0 8.027 4.031 4 12 11.952"
+              />
+            </svg>
+          </div>
+          
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Storyshots Molecules / Input / Select On Blur And On Focus 1`] = `
 .c12 {
   padding-left: 8px;
@@ -8890,6 +9227,7 @@ exports[`Storyshots Molecules / Input / Select On Blur And On Focus 1`] = `
   outline: none;
   border: 1px solid #BCBCB6;
   position: relative;
+  background: #FFFFFF;
   box-sizing: border-box;
   position: relative;
 }
@@ -9197,6 +9535,7 @@ exports[`Storyshots Molecules / Input / Select On Search Query Change 1`] = `
   outline: none;
   border: 1px solid #00D200;
   position: relative;
+  background: #FFFFFF;
   box-sizing: border-box;
   position: relative;
 }
@@ -9504,6 +9843,7 @@ exports[`Storyshots Molecules / Input / Select Overflow Story 1`] = `
   outline: none;
   border: 1px solid #BCBCB6;
   position: relative;
+  background: #FFFFFF;
   box-sizing: border-box;
   position: relative;
 }
@@ -10204,6 +10544,7 @@ exports[`Storyshots Molecules / Input / Select Placement Top 1`] = `
   outline: none;
   border: 1px solid #BCBCB6;
   position: relative;
+  background: #FFFFFF;
   box-sizing: border-box;
   position: relative;
 }
@@ -10515,6 +10856,7 @@ exports[`Storyshots Molecules / Input / Select Preselected Options 1`] = `
   outline: none;
   border: 1px solid #BCBCB6;
   position: relative;
+  background: #FFFFFF;
   box-sizing: border-box;
   position: relative;
 }
@@ -10824,6 +11166,7 @@ exports[`Storyshots Molecules / Input / Select Search Story 1`] = `
   outline: none;
   border: 1px solid #BCBCB6;
   position: relative;
+  background: #FFFFFF;
   box-sizing: border-box;
   position: relative;
 }
@@ -11174,6 +11517,7 @@ exports[`Storyshots Molecules / Input / Select Size S 1`] = `
   outline: none;
   border: 1px solid #BCBCB6;
   position: relative;
+  background: #FFFFFF;
   box-sizing: border-box;
   position: relative;
 }
@@ -11191,6 +11535,7 @@ exports[`Storyshots Molecules / Input / Select Size S 1`] = `
   outline: none;
   border: 1px solid #FF1900;
   position: relative;
+  background: #FFFFFF;
   box-sizing: border-box;
   position: relative;
 }
@@ -11212,6 +11557,7 @@ exports[`Storyshots Molecules / Input / Select Size S 1`] = `
   outline: none;
   border: 1px solid #BCBCB6;
   position: relative;
+  background: #FFFFFF;
   box-sizing: border-box;
   position: relative;
 }
@@ -11233,6 +11579,7 @@ exports[`Storyshots Molecules / Input / Select Size S 1`] = `
   outline: none;
   border: 1px solid #00D200;
   position: relative;
+  background: #FFFFFF;
   box-sizing: border-box;
   position: relative;
 }
@@ -12016,6 +12363,7 @@ exports[`Storyshots Molecules / Input / Select Tracking 1`] = `
   outline: none;
   border: 1px solid #BCBCB6;
   position: relative;
+  background: #FFFFFF;
   box-sizing: border-box;
   position: relative;
 }
@@ -12324,6 +12672,7 @@ Array [
   outline: none;
   border: 1px solid #BCBCB6;
   position: relative;
+  background: #FFFFFF;
   box-sizing: border-box;
   position: relative;
 }
@@ -12628,6 +12977,7 @@ Array [
   outline: none;
   border: 1px solid #BCBCB6;
   position: relative;
+  background: #FFFFFF;
   box-sizing: border-box;
   position: relative;
 }
@@ -12954,6 +13304,7 @@ exports[`Storyshots Molecules / Input / Select With Label Tooltip 1`] = `
   outline: none;
   border: 1px solid #BCBCB6;
   position: relative;
+  background: #FFFFFF;
   box-sizing: border-box;
   position: relative;
 }
@@ -13314,6 +13665,7 @@ Array [
   outline: none;
   border: 1px solid #BCBCB6;
   position: relative;
+  background: #FFFFFF;
   box-sizing: border-box;
   position: relative;
 }

--- a/src/Molecules/Input/Select/lib/MultiSelectList/__snapshots__/MultiSelectList.stories.storyshot
+++ b/src/Molecules/Input/Select/lib/MultiSelectList/__snapshots__/MultiSelectList.stories.storyshot
@@ -125,6 +125,7 @@ exports[`Storyshots Molecules / Input / Select / MultiSelectList Item default 1`
   width: 20px;
   height: 20px;
   border: 1px solid #BCBCB6;
+  background: #FFFFFF;
   position: relative;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
@@ -434,6 +435,7 @@ exports[`Storyshots Molecules / Input / Select / MultiSelectList Item disabled 1
   width: 20px;
   height: 20px;
   border: 1px solid #BCBCB6;
+  background: #FFFFFF;
   position: relative;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
@@ -728,6 +730,7 @@ exports[`Storyshots Molecules / Input / Select / MultiSelectList Item selected 1
   width: 20px;
   height: 20px;
   border: 1px solid #BCBCB6;
+  background: #FFFFFF;
   position: relative;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
@@ -1134,6 +1137,7 @@ exports[`Storyshots Molecules / Input / Select / MultiSelectList List with diffe
   width: 20px;
   height: 20px;
   border: 1px solid #BCBCB6;
+  background: #FFFFFF;
   position: relative;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;

--- a/src/Molecules/Input/Select/lib/wrappers/FormFieldOrFragment.tsx
+++ b/src/Molecules/Input/Select/lib/wrappers/FormFieldOrFragment.tsx
@@ -62,6 +62,7 @@ const borderStyles = css<Pick<Props, 'error' | 'success'>>`
 const SelectWrapper = styled.div`
   ${height}
   ${borderStyles}
+  background: ${(p) => p.theme.color.backgroundInput};
   box-sizing: border-box;
   position: relative;
 `;

--- a/src/Molecules/Input/Text/Text.stories.tsx
+++ b/src/Molecules/Input/Text/Text.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { actions } from '@storybook/addon-actions';
-import { Input, Icon, Flexbox, Button } from '../../..';
+import { Input, Icon, Flexbox, Button, Box } from '../../..';
 import { Display } from '../../../common/Display';
 
 // A bit laggy for now, let's optimize later
@@ -427,3 +427,13 @@ export const alternatingTypes = () => (
     </div>
   </form>
 );
+
+export const onAColouredBackground = () => (
+  <Box p={5} backgroundColor={(t) => t.color.disabledBackground}>
+    <Input.Text label="On a colored background" placeholder="Placeholder" />
+  </Box>
+);
+
+onAColouredBackground.story = {
+  name: 'On a coloured background',
+};

--- a/src/Molecules/Input/Text/__snapshots__/Text.stories.storyshot
+++ b/src/Molecules/Input/Text/__snapshots__/Text.stories.storyshot
@@ -2843,6 +2843,169 @@ exports[`Storyshots Molecules / Input / Text Hidden label 1`] = `
 </div>
 `;
 
+exports[`Storyshots Molecules / Input / Text On a coloured background 1`] = `
+.c0 {
+  padding: 20px;
+  background-color: #EBEBE8;
+}
+
+.c4 {
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c2 {
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.c3 {
+  font-family: 'Nordnet Sans Mono',-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
+  color: #6E6E69;
+  margin: 0;
+  font-weight: 400;
+  font-size: 14px;
+  line-height: 1.4285714285714286;
+}
+
+.c5 {
+  font-family: 'Nordnet Sans Mono',-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
+  color: #282823;
+  margin: 0;
+  font-weight: 400;
+  font-size: 14px;
+  line-height: 1.4285714285714286;
+}
+
+.c7 {
+  font-family: inherit;
+  font-size: 100%;
+  line-height: 1.15;
+  margin: 0;
+  overflow: visible;
+  border: 0;
+  width: 100%;
+  padding: 8px;
+  margin: 0;
+  line-height: inherit;
+  box-sizing: border-box;
+  height: 40px;
+  outline: none;
+  border: solid;
+  border-color: #BCBCB6;
+  border-width: 1px;
+  position: relative;
+  background-color: #FFFFFF;
+}
+
+.c7:focus {
+  border-width: 1px;
+}
+
+.c7:hover {
+  border-color: #4B4B46;
+}
+
+.c7:focus {
+  border-color: #0046FF;
+}
+
+.c7::-webkit-input-placeholder {
+  color: #6E6E69;
+  line-height: inherit;
+  opacity: 1;
+}
+
+.c7::-moz-placeholder {
+  color: #6E6E69;
+  line-height: inherit;
+  opacity: 1;
+}
+
+.c7:-ms-input-placeholder {
+  color: #6E6E69;
+  line-height: inherit;
+  opacity: 1;
+}
+
+.c7::placeholder {
+  color: #6E6E69;
+  line-height: inherit;
+  opacity: 1;
+}
+
+.c7:disabled::-webkit-input-placeholder {
+  color: #A0A09B;
+}
+
+.c7:disabled::-moz-placeholder {
+  color: #A0A09B;
+}
+
+.c7:disabled:-ms-input-placeholder {
+  color: #A0A09B;
+}
+
+.c7:disabled::placeholder {
+  color: #A0A09B;
+}
+
+.c6 {
+  position: relative;
+  padding: 0px 0;
+}
+
+.c1 {
+  width: 200px;
+  display: inline-block;
+}
+
+<div
+  className="c0"
+>
+  <div
+    className="c1"
+  >
+    <label
+      className="c2"
+      hidden={false}
+    >
+      <span
+        className="c3"
+      >
+        <div
+          className="c4"
+        >
+          On a colored background 
+        </div>
+        <span
+          className="c5"
+        >
+          <div
+            className="c6"
+          >
+            <input
+              className="NormalizedInput__Input-sc-1m4kmh9-0 c7"
+              placeholder="Placeholder"
+              type="text"
+              variant="normal"
+            />
+          </div>
+        </span>
+      </span>
+    </label>
+  </div>
+</div>
+`;
+
 exports[`Storyshots Molecules / Input / Text Quiet 1`] = `
 Array [
   .c0 {

--- a/src/Molecules/Input/Textarea/Textarea.stories.tsx
+++ b/src/Molecules/Input/Textarea/Textarea.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { actions } from '@storybook/addon-actions';
-import { Input } from '../../..';
+import { Input, Box } from '../../..';
 import { Display } from '../../../common/Display';
 
 // A bit laggy for now, let's optimize later
@@ -235,4 +235,14 @@ export const withLabelTooltipPositionTop = () => (
 
 withLabelTooltipPositionTop.story = {
   name: 'With tooltip (position top) as label addon',
+};
+
+export const onAColouredBackground = () => (
+  <Box p={5} backgroundColor={(t) => t.color.disabledBackground}>
+    <Input.Textarea label="On a colored background" placeholder="Placeholder" />
+  </Box>
+);
+
+onAColouredBackground.story = {
+  name: 'On a coloured background',
 };

--- a/src/Molecules/Input/Textarea/__snapshots__/Textarea.stories.storyshot
+++ b/src/Molecules/Input/Textarea/__snapshots__/Textarea.stories.storyshot
@@ -1475,6 +1475,154 @@ exports[`Storyshots Molecules / Input / Textarea Hidden label 1`] = `
 </div>
 `;
 
+exports[`Storyshots Molecules / Input / Textarea On a coloured background 1`] = `
+.c0 {
+  padding: 20px;
+  background-color: #EBEBE8;
+}
+
+.c4 {
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c2 {
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.c3 {
+  font-family: 'Nordnet Sans Mono',-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
+  color: #6E6E69;
+  margin: 0;
+  font-weight: 400;
+  font-size: 14px;
+  line-height: 1.4285714285714286;
+}
+
+.c5 {
+  font-family: 'Nordnet Sans Mono',-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
+  color: #282823;
+  margin: 0;
+  font-weight: 400;
+  font-size: 14px;
+  line-height: 1.4285714285714286;
+}
+
+.c6 {
+  font-family: inherit;
+  font-size: 100%;
+  line-height: 1.15;
+  margin: 0;
+  overflow: auto;
+  border: 0;
+  width: 100%;
+  padding: 8px;
+  margin: 0;
+  vertical-align: top;
+  box-sizing: border-box;
+  outline: none;
+  border: 1px solid #BCBCB6;
+  position: relative;
+  background-color: #FFFFFF;
+}
+
+.c6:hover {
+  border-color: #4B4B46;
+}
+
+.c6:focus {
+  border-color: #0046FF;
+}
+
+.c6::-webkit-input-placeholder {
+  color: #6E6E69;
+  line-height: inherit;
+  opacity: 1;
+}
+
+.c6::-moz-placeholder {
+  color: #6E6E69;
+  line-height: inherit;
+  opacity: 1;
+}
+
+.c6:-ms-input-placeholder {
+  color: #6E6E69;
+  line-height: inherit;
+  opacity: 1;
+}
+
+.c6::placeholder {
+  color: #6E6E69;
+  line-height: inherit;
+  opacity: 1;
+}
+
+.c6:disabled::-webkit-input-placeholder {
+  color: #A0A09B;
+}
+
+.c6:disabled::-moz-placeholder {
+  color: #A0A09B;
+}
+
+.c6:disabled:-ms-input-placeholder {
+  color: #A0A09B;
+}
+
+.c6:disabled::placeholder {
+  color: #A0A09B;
+}
+
+.c1 {
+  width: 200px;
+  display: inline-block;
+}
+
+<div
+  className="c0"
+>
+  <div
+    className="c1"
+  >
+    <label
+      className="c2"
+      hidden={false}
+    >
+      <span
+        className="c3"
+      >
+        <div
+          className="c4"
+        >
+          On a colored background 
+        </div>
+        <div>
+          <span
+            className="c5"
+          >
+            <textarea
+              className="NormalizedTextarea__Textarea-i5on9-0 c6"
+              placeholder="Placeholder"
+              rows={3}
+            />
+          </span>
+        </div>
+      </span>
+    </label>
+  </div>
+</div>
+`;
+
 exports[`Storyshots Molecules / Input / Textarea Required 1`] = `
 Array [
   .c0 {


### PR DESCRIPTION
adds stories rendering inputs on a coloured background, adds missing
background style to Checkbox and Select using
theme.color.backgroundInput