### PR TITLE
feat: 🎸 add chevron style to accordion item

### DIFF
--- a/src/Molecules/Accordion/__snapshots__/Accordion.stories.storyshot
+++ b/src/Molecules/Accordion/__snapshots__/Accordion.stories.storyshot
@@ -49,8 +49,8 @@ Array [
   width: 100%;
   border: 0;
   padding-top: 12px;
-  padding-right: 0;
   padding-bottom: 12px;
+  padding-right: 0px;
   padding-left: 24px;
   background-color: transparent;
   cursor: pointer;
@@ -145,8 +145,8 @@ Array [
   width: 100%;
   border: 0;
   padding-top: 12px;
-  padding-right: 0;
   padding-bottom: 12px;
+  padding-right: 0px;
   padding-left: 24px;
   background-color: transparent;
   cursor: pointer;
@@ -246,8 +246,8 @@ Array [
   width: 100%;
   border: 0;
   padding-top: 12px;
-  padding-right: 0;
   padding-bottom: 12px;
+  padding-right: 0px;
   padding-left: 24px;
   background-color: transparent;
   cursor: pointer;
@@ -342,8 +342,8 @@ Array [
   width: 100%;
   border: 0;
   padding-top: 12px;
-  padding-right: 0;
   padding-bottom: 12px;
+  padding-right: 0px;
   padding-left: 24px;
   background-color: transparent;
   cursor: pointer;

--- a/src/Molecules/AccordionItem/AccordionItem.stories.tsx
+++ b/src/Molecules/AccordionItem/AccordionItem.stories.tsx
@@ -86,3 +86,9 @@ export const TextOnlyContentIsFormattedCorrect = () => (
     </AccordionItem>
   </>
 );
+
+export const withChevron = () => (
+  <AccordionItem withChevron title="How much risk are you willing to take?">
+    <ExampleContent />
+  </AccordionItem>
+);

--- a/src/Molecules/AccordionItem/AccordionItem.tsx
+++ b/src/Molecules/AccordionItem/AccordionItem.tsx
@@ -21,7 +21,7 @@ const Item = styled.div<{ $hasFocus: boolean }>`
     $hasFocus ? `${theme.color.background}` : 'transparent'};
 `;
 
-const Button = styled.button`
+const Button = styled.button<{ $withChevron?: boolean }>`
   font: inherit;
   box-sizing: border-box;
   position: relative;
@@ -29,18 +29,18 @@ const Button = styled.button`
   width: 100%;
   border: 0;
   padding-top: ${(p) => p.theme.spacing.unit(3)}px;
-  padding-right: 0;
   padding-bottom: ${(p) => p.theme.spacing.unit(3)}px;
-  padding-left: ${(p) => p.theme.spacing.unit(6)}px;
+  padding-right: ${(p) => p.theme.spacing.unit(p.$withChevron ? 6 : 0)}px;
+  padding-left: ${(p) => p.theme.spacing.unit(p.$withChevron ? 0 : 6)}px;
   background-color: transparent;
   cursor: pointer;
   text-align: start;
 `;
 
-const IconWrapper = styled.div`
+const IconWrapper = styled.div<{ $withChevron?: boolean }>`
   position: absolute;
   top: 15px;
-  left: 0;
+  ${(p) => (p.$withChevron ? 'right' : 'left')}: 0;
 `;
 
 export const AccordionItem: AccordionItemComponent = React.forwardRef(
@@ -54,6 +54,7 @@ export const AccordionItem: AccordionItemComponent = React.forwardRef(
       title,
       onClick,
       onToggle,
+      withChevron,
     },
     ref,
   ) => {
@@ -76,24 +77,32 @@ export const AccordionItem: AccordionItemComponent = React.forwardRef(
       }
     };
 
+    const icon = (
+      <IconWrapper $withChevron={withChevron}>
+        {(() => {
+          if (withChevron)
+            return <Icon.ThinChevron direction={expanded ? 'up' : 'down'} size={4} />;
+
+          if (expanded) return <Icon.Minus size={3} fill={(t) => t.color.cta} />;
+          return <Icon.Plus size={3} fill={(t) => t.color.cta} />;
+        })()}
+      </IconWrapper>
+    );
+
     return (
       <Item className={className} aria-expanded={expanded} $hasFocus={hasFocus}>
         <Typography as={as} type="secondary" weight="bold">
           <Button
+            $withChevron={withChevron}
             type="button"
             onClick={clickHandler}
             ref={ref}
             onFocus={() => setHasFocus(true)}
             onBlur={() => setHasFocus(false)}
           >
-            <IconWrapper>
-              {expanded ? (
-                <Icon.Minus size={3} fill={(t) => t.color.cta} />
-              ) : (
-                <Icon.Plus size={3} fill={(t) => t.color.cta} />
-              )}
-            </IconWrapper>
+            {!withChevron && icon}
             {title}
+            {withChevron && icon}
           </Button>
         </Typography>
         <AnimatePresence initial={false}>
@@ -108,7 +117,7 @@ export const AccordionItem: AccordionItemComponent = React.forwardRef(
               }}
               transition={{ duration: 0.16, ease: 'easeOut' }}
             >
-              <Box pt={1} pb={3} pl={6}>
+              <Box pt={1} pb={3} pl={withChevron ? 0 : 6} pr={withChevron ? 6 : 0}>
                 {isString(children) ? (
                   <Typography as="p" type="secondary" color={(t) => t.color.accordionText}>
                     {children}

--- a/src/Molecules/AccordionItem/AccordionItem.types.ts
+++ b/src/Molecules/AccordionItem/AccordionItem.types.ts
@@ -5,10 +5,11 @@ type Props = {
   /** Setting this prop makes the component controlled */
   expanded?: boolean;
   expandedInitial?: boolean;
-  title: string;
+  title: string | React.ReactNode;
   onClick?: React.MouseEventHandler;
   onToggle?: (expanded: boolean) => void;
   ref?: React.Ref<HTMLButtonElement>;
+  withChevron?: boolean;
 };
 
 export type AccordionItemComponent = React.FC<Props>;

--- a/src/Molecules/AccordionItem/__snapshots__/AccordionItem.stories.storyshot
+++ b/src/Molecules/AccordionItem/__snapshots__/AccordionItem.stories.storyshot
@@ -199,8 +199,8 @@ Array [
   width: 100%;
   border: 0;
   padding-top: 12px;
-  padding-right: 0;
   padding-bottom: 12px;
+  padding-right: 0px;
   padding-left: 24px;
   background-color: transparent;
   cursor: pointer;
@@ -295,8 +295,8 @@ Array [
   width: 100%;
   border: 0;
   padding-top: 12px;
-  padding-right: 0;
   padding-bottom: 12px;
+  padding-right: 0px;
   padding-left: 24px;
   background-color: transparent;
   cursor: pointer;
@@ -395,8 +395,8 @@ exports[`Storyshots Molecules / AccordionItem Default Collapsed 1`] = `
   width: 100%;
   border: 0;
   padding-top: 12px;
-  padding-right: 0;
   padding-bottom: 12px;
+  padding-right: 0px;
   padding-left: 24px;
   background-color: transparent;
   cursor: pointer;
@@ -450,6 +450,7 @@ exports[`Storyshots Molecules / AccordionItem Expanded 1`] = `
 .c6 {
   padding-left: 24px;
   padding-top: 4px;
+  padding-right: 0px;
   padding-bottom: 12px;
   background-color: transparent;
 }
@@ -510,8 +511,8 @@ exports[`Storyshots Molecules / AccordionItem Expanded 1`] = `
   width: 100%;
   border: 0;
   padding-top: 12px;
-  padding-right: 0;
   padding-bottom: 12px;
+  padding-right: 0px;
   padding-left: 24px;
   background-color: transparent;
   cursor: pointer;
@@ -621,8 +622,8 @@ Array [
   width: 100%;
   border: 0;
   padding-top: 12px;
-  padding-right: 0;
   padding-bottom: 12px;
+  padding-right: 0px;
   padding-left: 24px;
   background-color: transparent;
   cursor: pointer;
@@ -717,8 +718,8 @@ Array [
   width: 100%;
   border: 0;
   padding-top: 12px;
-  padding-right: 0;
   padding-bottom: 12px;
+  padding-right: 0px;
   padding-left: 24px;
   background-color: transparent;
   cursor: pointer;
@@ -767,4 +768,109 @@ Array [
     </h3>
   </div>,
 ]
+`;
+
+exports[`Storyshots Molecules / AccordionItem With Chevron 1`] = `
+.c5 {
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  width: 16px;
+  height: 16px;
+  fill: #282823;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  display: block;
+}
+
+.c6 {
+  -webkit-transform: rotate(0deg);
+  -ms-transform: rotate(0deg);
+  transform: rotate(0deg);
+}
+
+.c2 {
+  font-family: 'Nordnet Sans Mono',-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
+  color: #282823;
+  margin: 0;
+  font-weight: 700;
+  font-size: 14px;
+  line-height: 1.4285714285714286;
+}
+
+.c1 {
+  outline: none;
+  background-color: transparent;
+}
+
+.c1 + .c0 {
+  border-top: 1px solid #EBEBE8;
+}
+
+.c1:hover {
+  background-color: #F5F5F5;
+}
+
+.c3 {
+  font: inherit;
+  box-sizing: border-box;
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 100%;
+  border: 0;
+  padding-top: 12px;
+  padding-bottom: 12px;
+  padding-right: 24px;
+  padding-left: 0px;
+  background-color: transparent;
+  cursor: pointer;
+  text-align: start;
+}
+
+.c4 {
+  position: absolute;
+  top: 15px;
+  right: 0;
+}
+
+<div
+  aria-expanded={false}
+  className="c0 c1"
+>
+  <h3
+    className="c2"
+  >
+    <button
+      className="c3"
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      type="button"
+    >
+      How much risk are you willing to take?
+      <div
+        className="c4"
+      >
+        <svg
+          aria-hidden="true"
+          className="c5 c6"
+          direction="down"
+          focusable="false"
+          preserveAspectRatio="xMidYMid meet"
+          role="presentation"
+          viewBox="0 0 16 16"
+        >
+          <polygon
+            points="14.620 3.580, 16.000 5.020, 8.000 12.730, 0.000 5.030, 1.400 3.580, 8.000 9.96"
+          />
+        </svg>
+      </div>
+    </button>
+  </h3>
+</div>
 `;


### PR DESCRIPTION
Adds a prop `withChevron` that uses a chevron to the right instead of a plus/minus to the left as the expand icon in an accordion item. Also allows the title to be a React node instead of only a string.