### PR TITLE
fix: 🐛 select from filtered options instead of all options

### DIFF
--- a/src/Molecules/Input/Select/Select.tsx
+++ b/src/Molecules/Input/Select/Select.tsx
@@ -322,7 +322,7 @@ const Select = (props: Props) => {
               maxHeight={props.listMaxHeight}
               width={props.width}
             >
-              {allOptions?.map((x: any, index: number) => (
+              {options?.map((x: any, index: number) => (
                 <ListItemWrapper
                   // eslint-disable-next-line react/no-array-index-key
                   key={index}


### PR DESCRIPTION
When searching options and selecting one of the filtered items, it still selected
from the unfiltered list based on index. This fixes that issue