### PR TITLE
feat: 🎸 add custom expand element and title row padding props to CollapsibleCard

### DIFF
--- a/src/Molecules/CollapsibleCard/Collapsible.types.ts
+++ b/src/Molecules/CollapsibleCard/Collapsible.types.ts
@@ -1,12 +1,21 @@
+import React from 'react';
+
+type RenderFunc = (collapsed: boolean) => React.ReactNode;
+
 export type CollapsibleProps = {
   title: React.ReactNode;
   collapsedInitial?: boolean;
   heading?: 'h1' | 'h2' | 'h3';
   noIndicator?: boolean;
   onClick?: (e: React.MouseEvent | React.TouchEvent) => void;
+  expandElement?: React.ReactNode | RenderFunc;
+  titleRowPaddingY?: number;
+  titleRowPaddingX?: number;
 };
 
 export type IndicatorsProps = {
   $noIndicator: boolean;
   $collapsed: boolean;
+  $py: number;
+  $px: number;
 };

--- a/src/Molecules/CollapsibleCard/CollapsibleCard.stories.tsx
+++ b/src/Molecules/CollapsibleCard/CollapsibleCard.stories.tsx
@@ -98,3 +98,89 @@ export const collapsibleWithoutIndicator = () => {
 collapsibleWithoutIndicator.story = {
   name: 'Collapsible without indicator',
 };
+
+export const collapsibleWithCustomExpandElementAsAFunction = () => {
+  return (
+    <CollapsibleCard
+      title="Custom expand element (function)"
+      expandElement={(collapsed) => (
+        <Typography type="secondary">{collapsed ? 'Expand' : 'Close'}</Typography>
+      )}
+    >
+      <Typography type="primary" as={styledText}>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
+        labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco
+        laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in
+        voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+        cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+      </Typography>
+    </CollapsibleCard>
+  );
+};
+
+collapsibleWithCustomExpandElementAsAFunction.story = {
+  name: 'Collapsible with custom expand element as a function',
+};
+
+export const collapsibleWithCustomExpandElement = () => {
+  return (
+    <CollapsibleCard
+      title="Custom expand element (ReactNode)"
+      expandElement={<Typography type="secondary">Toggle expand</Typography>}
+    >
+      <Typography type="primary" as={styledText}>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
+        labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco
+        laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in
+        voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+        cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+      </Typography>
+    </CollapsibleCard>
+  );
+};
+
+collapsibleWithCustomExpandElement.story = {
+  name: 'Collapsible with custom expand element',
+};
+
+export const collapsibleCardWithNoPadding = () => {
+  return (
+    <CollapsibleCard
+      title="Collapsible card with no title row padding"
+      titleRowPaddingX={0}
+      titleRowPaddingY={0}
+      noIndicator
+    >
+      <Typography type="primary" as={styledText}>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
+        labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco
+        laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in
+        voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+        cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+      </Typography>
+    </CollapsibleCard>
+  );
+};
+
+collapsibleCardWithNoPadding.story = {
+  name: 'Collapsible card with no title row padding',
+};
+
+export const collapsibleCardWithLotsOfTopAndBottomPadding = () => (
+  <CollapsibleCard
+    title="Collapsible card with lots of top and bottom padding"
+    titleRowPaddingY={10}
+  >
+    <Typography type="primary" as={styledText}>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
+      labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco
+      laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in
+      voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat
+      non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+    </Typography>
+  </CollapsibleCard>
+);
+
+collapsibleCardWithLotsOfTopAndBottomPadding.story = {
+  name: 'Collapsible card with lots of top and bottom padding',
+};

--- a/src/Molecules/CollapsibleCard/CollapsibleCard.tsx
+++ b/src/Molecules/CollapsibleCard/CollapsibleCard.tsx
@@ -1,6 +1,7 @@
 import React, { useLayoutEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
 import { Card, Flexbox, Icon, Typography } from '../..';
+import { isElement, isFunction } from '../../common/utils';
 import { CollapsibleProps, IndicatorsProps } from './Collapsible.types';
 
 const StyledCollapsible = styled.div<{
@@ -24,7 +25,7 @@ const StyledButton = styled.button<IndicatorsProps>`
   cursor: pointer;
   display: block;
   width: 100%;
-  padding: ${(p) => p.theme.spacing.unit(5)}px ${(p) => p.theme.spacing.unit(5)}px;
+  padding: ${(p) => p.theme.spacing.unit(p.$py)}px ${(p) => p.theme.spacing.unit(p.$px)}px;
   border: 0;
 
   &::before {
@@ -41,7 +42,7 @@ const StyledButton = styled.button<IndicatorsProps>`
   }
 `;
 
-const AnimatedChevronUp = styled(Icon.ChevronUp)<IndicatorsProps>`
+const AnimatedChevronUp = styled(Icon.ChevronUp)<Pick<IndicatorsProps, '$collapsed'>>`
   transform: ${(p) => (p.$collapsed ? 'rotate(180deg)' : 'rotate(0)')};
   transform-origin: center center;
   transition: transform 0.16s ease-out;
@@ -54,6 +55,9 @@ export const CollapsibleCard: React.FC<CollapsibleProps> = ({
   heading = 'h2',
   noIndicator = false,
   onClick = () => {},
+  expandElement,
+  titleRowPaddingX = 5,
+  titleRowPaddingY = 5,
 }) => {
   const [collapsed, setCollapsed] = useState(collapsedInitial);
   const [collapsing, setCollapsing] = useState(false);
@@ -151,6 +155,8 @@ export const CollapsibleCard: React.FC<CollapsibleProps> = ({
         $collapsed={collapsed}
         $noIndicator={noIndicator}
         aria-expanded={!collapsed}
+        $py={titleRowPaddingY}
+        $px={titleRowPaddingX}
       >
         <Flexbox container gutter={4} alignItems="center" justifyContent="space-between">
           <Flexbox item>
@@ -159,7 +165,11 @@ export const CollapsibleCard: React.FC<CollapsibleProps> = ({
             </Typography>
           </Flexbox>
           <Flexbox item>
-            <AnimatedChevronUp size={2} $collapsed={collapsed} $noIndicator={noIndicator} />
+            {(() => {
+              if (isFunction(expandElement)) return expandElement(collapsed);
+              if (isElement(expandElement)) return expandElement;
+              return <AnimatedChevronUp size={2} $collapsed={collapsed} />;
+            })()}
           </Flexbox>
         </Flexbox>
       </StyledButton>

--- a/src/Molecules/CollapsibleCard/__snapshots__/CollapsibleCard.stories.storyshot
+++ b/src/Molecules/CollapsibleCard/__snapshots__/CollapsibleCard.stories.storyshot
@@ -184,6 +184,374 @@ exports[`Storyshots Molecules / CollapsibleCard Collapsed initially 1`] = `
 </div>
 `;
 
+exports[`Storyshots Molecules / CollapsibleCard Collapsible card with lots of top and bottom padding 1`] = `
+.c0 {
+  background: #FFFFFF;
+  box-shadow: 0 2px 2px 0 rgba(0,0,0,0.03);
+}
+
+.c2 {
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  margin-left: -8px;
+  margin-right: -8px;
+}
+
+.c2 > * {
+  padding-left: 8px;
+  padding-right: 8px;
+}
+
+.c2 > *:not(:first-child) {
+  padding-top: 0;
+}
+
+.c3 {
+  box-sizing: border-box;
+}
+
+.c5 {
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  width: 8px;
+  height: 8px;
+  fill: #282823;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  display: block;
+}
+
+.c4 {
+  font-family: 'Nordnet Sans Mono',-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
+  color: #282823;
+  margin: 0;
+  font-weight: 800;
+  font-size: 18px;
+  line-height: 1.3333333333333333;
+}
+
+.c9 {
+  font-family: 'Nordnet Sans Mono',-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
+  color: #282823;
+  margin: 0;
+  font-weight: 400;
+  font-size: 16px;
+  line-height: 1.5;
+}
+
+.c7 {
+  overflow: hidden;
+  will-change: height;
+  height: auto;
+  -webkit-transition: height 0.16s ease-out;
+  transition: height 0.16s ease-out;
+}
+
+.c7[hidden] {
+  display: none;
+}
+
+.c1 {
+  touch-action: none;
+  position: relative;
+  background: none;
+  cursor: pointer;
+  display: block;
+  width: 100%;
+  padding: 40px 20px;
+  border: 0;
+}
+
+.c1::before {
+  content: '';
+  display: block;
+  background: #0046FF;
+  width: 2px;
+  height: 100%;
+  position: absolute;
+  top: 0;
+  left: 0;
+  -webkit-transition: opacity 0.16s ease-out;
+  transition: opacity 0.16s ease-out;
+  opacity: 0;
+}
+
+.c6 {
+  -webkit-transform: rotate(0);
+  -ms-transform: rotate(0);
+  transform: rotate(0);
+  -webkit-transform-origin: center center;
+  -ms-transform-origin: center center;
+  transform-origin: center center;
+  -webkit-transition: -webkit-transform 0.16s ease-out;
+  -webkit-transition: transform 0.16s ease-out;
+  transition: transform 0.16s ease-out;
+}
+
+.c8 {
+  margin: 0;
+}
+
+@media (min-width:760px) {
+  .c4 {
+    font-size: 20px;
+    line-height: 1.2;
+  }
+}
+
+<div
+  className="c0"
+>
+  <button
+    aria-expanded={true}
+    className="c1"
+    onClick={[Function]}
+    type="button"
+  >
+    <div
+      className="c2"
+    >
+      <div
+        className="c3"
+      >
+        <h2
+          className="c4"
+        >
+          Collapsible card with lots of top and bottom padding
+        </h2>
+      </div>
+      <div
+        className="c3"
+      >
+        <svg
+          aria-hidden="true"
+          className="c5 c6"
+          focusable="false"
+          preserveAspectRatio="xMidYMid meet"
+          role="presentation"
+          viewBox="0 0 24 24"
+        >
+          <polygon
+            points="19.969 4 24 8.027 12 20 0 8.027 4.031 4 12 11.952"
+            transform="rotate(-180 12 12)"
+          />
+        </svg>
+      </div>
+    </div>
+  </button>
+  <div
+    className="c7"
+    height={null}
+    hidden={false}
+    onTransitionEnd={[Function]}
+  >
+    <p
+      className="c8 c9"
+    >
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+    </p>
+  </div>
+</div>
+`;
+
+exports[`Storyshots Molecules / CollapsibleCard Collapsible card with no title row padding 1`] = `
+.c0 {
+  background: #FFFFFF;
+  box-shadow: 0 2px 2px 0 rgba(0,0,0,0.03);
+}
+
+.c2 {
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  margin-left: -8px;
+  margin-right: -8px;
+}
+
+.c2 > * {
+  padding-left: 8px;
+  padding-right: 8px;
+}
+
+.c2 > *:not(:first-child) {
+  padding-top: 0;
+}
+
+.c3 {
+  box-sizing: border-box;
+}
+
+.c5 {
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  width: 8px;
+  height: 8px;
+  fill: #282823;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  display: block;
+}
+
+.c4 {
+  font-family: 'Nordnet Sans Mono',-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
+  color: #282823;
+  margin: 0;
+  font-weight: 800;
+  font-size: 18px;
+  line-height: 1.3333333333333333;
+}
+
+.c9 {
+  font-family: 'Nordnet Sans Mono',-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
+  color: #282823;
+  margin: 0;
+  font-weight: 400;
+  font-size: 16px;
+  line-height: 1.5;
+}
+
+.c7 {
+  overflow: hidden;
+  will-change: height;
+  height: auto;
+  -webkit-transition: height 0.16s ease-out;
+  transition: height 0.16s ease-out;
+}
+
+.c7[hidden] {
+  display: none;
+}
+
+.c1 {
+  touch-action: none;
+  position: relative;
+  background: none;
+  cursor: pointer;
+  display: block;
+  width: 100%;
+  padding: 0px 0px;
+  border: 0;
+}
+
+.c1::before {
+  content: '';
+  display: block;
+  background: #0046FF;
+  width: 2px;
+  height: 100%;
+  position: absolute;
+  top: 0;
+  left: 0;
+  -webkit-transition: opacity 0.16s ease-out;
+  transition: opacity 0.16s ease-out;
+  opacity: 0;
+}
+
+.c6 {
+  -webkit-transform: rotate(0);
+  -ms-transform: rotate(0);
+  transform: rotate(0);
+  -webkit-transform-origin: center center;
+  -ms-transform-origin: center center;
+  transform-origin: center center;
+  -webkit-transition: -webkit-transform 0.16s ease-out;
+  -webkit-transition: transform 0.16s ease-out;
+  transition: transform 0.16s ease-out;
+}
+
+.c8 {
+  margin: 0;
+}
+
+@media (min-width:760px) {
+  .c4 {
+    font-size: 20px;
+    line-height: 1.2;
+  }
+}
+
+<div
+  className="c0"
+>
+  <button
+    aria-expanded={true}
+    className="c1"
+    onClick={[Function]}
+    type="button"
+  >
+    <div
+      className="c2"
+    >
+      <div
+        className="c3"
+      >
+        <h2
+          className="c4"
+        >
+          Collapsible card with no title row padding
+        </h2>
+      </div>
+      <div
+        className="c3"
+      >
+        <svg
+          aria-hidden="true"
+          className="c5 c6"
+          focusable="false"
+          preserveAspectRatio="xMidYMid meet"
+          role="presentation"
+          viewBox="0 0 24 24"
+        >
+          <polygon
+            points="19.969 4 24 8.027 12 20 0 8.027 4.031 4 12 11.952"
+            transform="rotate(-180 12 12)"
+          />
+        </svg>
+      </div>
+    </div>
+  </button>
+  <div
+    className="c7"
+    height={null}
+    hidden={false}
+    onTransitionEnd={[Function]}
+  >
+    <p
+      className="c8 c9"
+    >
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+    </p>
+  </div>
+</div>
+`;
+
 exports[`Storyshots Molecules / CollapsibleCard Collapsible with custom component as title 1`] = `
 .c0 {
   background: #FFFFFF;
@@ -363,6 +731,324 @@ exports[`Storyshots Molecules / CollapsibleCard Collapsible with custom componen
       className="c8 c9"
     >
       Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+    </p>
+  </div>
+</div>
+`;
+
+exports[`Storyshots Molecules / CollapsibleCard Collapsible with custom expand element 1`] = `
+.c0 {
+  background: #FFFFFF;
+  box-shadow: 0 2px 2px 0 rgba(0,0,0,0.03);
+}
+
+.c2 {
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  margin-left: -8px;
+  margin-right: -8px;
+}
+
+.c2 > * {
+  padding-left: 8px;
+  padding-right: 8px;
+}
+
+.c2 > *:not(:first-child) {
+  padding-top: 0;
+}
+
+.c3 {
+  box-sizing: border-box;
+}
+
+.c4 {
+  font-family: 'Nordnet Sans Mono',-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
+  color: #282823;
+  margin: 0;
+  font-weight: 800;
+  font-size: 18px;
+  line-height: 1.3333333333333333;
+}
+
+.c5 {
+  font-family: 'Nordnet Sans Mono',-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
+  color: #282823;
+  margin: 0;
+  font-weight: 400;
+  font-size: 14px;
+  line-height: 1.4285714285714286;
+}
+
+.c8 {
+  font-family: 'Nordnet Sans Mono',-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
+  color: #282823;
+  margin: 0;
+  font-weight: 400;
+  font-size: 16px;
+  line-height: 1.5;
+}
+
+.c6 {
+  overflow: hidden;
+  will-change: height;
+  height: auto;
+  -webkit-transition: height 0.16s ease-out;
+  transition: height 0.16s ease-out;
+}
+
+.c6[hidden] {
+  display: none;
+}
+
+.c1 {
+  touch-action: none;
+  position: relative;
+  background: none;
+  cursor: pointer;
+  display: block;
+  width: 100%;
+  padding: 20px 20px;
+  border: 0;
+}
+
+.c1::before {
+  content: '';
+  display: block;
+  background: #0046FF;
+  width: 2px;
+  height: 100%;
+  position: absolute;
+  top: 0;
+  left: 0;
+  -webkit-transition: opacity 0.16s ease-out;
+  transition: opacity 0.16s ease-out;
+  opacity: 0;
+}
+
+.c7 {
+  margin: 0;
+}
+
+@media (min-width:760px) {
+  .c4 {
+    font-size: 20px;
+    line-height: 1.2;
+  }
+}
+
+<div
+  className="c0"
+>
+  <button
+    aria-expanded={true}
+    className="c1"
+    onClick={[Function]}
+    type="button"
+  >
+    <div
+      className="c2"
+    >
+      <div
+        className="c3"
+      >
+        <h2
+          className="c4"
+        >
+          Custom expand element (ReactNode)
+        </h2>
+      </div>
+      <div
+        className="c3"
+      >
+        <span
+          className="c5"
+        >
+          Toggle expand
+        </span>
+      </div>
+    </div>
+  </button>
+  <div
+    className="c6"
+    height={null}
+    hidden={false}
+    onTransitionEnd={[Function]}
+  >
+    <p
+      className="c7 c8"
+    >
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+    </p>
+  </div>
+</div>
+`;
+
+exports[`Storyshots Molecules / CollapsibleCard Collapsible with custom expand element as a function 1`] = `
+.c0 {
+  background: #FFFFFF;
+  box-shadow: 0 2px 2px 0 rgba(0,0,0,0.03);
+}
+
+.c2 {
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  margin-left: -8px;
+  margin-right: -8px;
+}
+
+.c2 > * {
+  padding-left: 8px;
+  padding-right: 8px;
+}
+
+.c2 > *:not(:first-child) {
+  padding-top: 0;
+}
+
+.c3 {
+  box-sizing: border-box;
+}
+
+.c4 {
+  font-family: 'Nordnet Sans Mono',-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
+  color: #282823;
+  margin: 0;
+  font-weight: 800;
+  font-size: 18px;
+  line-height: 1.3333333333333333;
+}
+
+.c5 {
+  font-family: 'Nordnet Sans Mono',-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
+  color: #282823;
+  margin: 0;
+  font-weight: 400;
+  font-size: 14px;
+  line-height: 1.4285714285714286;
+}
+
+.c8 {
+  font-family: 'Nordnet Sans Mono',-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
+  color: #282823;
+  margin: 0;
+  font-weight: 400;
+  font-size: 16px;
+  line-height: 1.5;
+}
+
+.c6 {
+  overflow: hidden;
+  will-change: height;
+  height: auto;
+  -webkit-transition: height 0.16s ease-out;
+  transition: height 0.16s ease-out;
+}
+
+.c6[hidden] {
+  display: none;
+}
+
+.c1 {
+  touch-action: none;
+  position: relative;
+  background: none;
+  cursor: pointer;
+  display: block;
+  width: 100%;
+  padding: 20px 20px;
+  border: 0;
+}
+
+.c1::before {
+  content: '';
+  display: block;
+  background: #0046FF;
+  width: 2px;
+  height: 100%;
+  position: absolute;
+  top: 0;
+  left: 0;
+  -webkit-transition: opacity 0.16s ease-out;
+  transition: opacity 0.16s ease-out;
+  opacity: 0;
+}
+
+.c7 {
+  margin: 0;
+}
+
+@media (min-width:760px) {
+  .c4 {
+    font-size: 20px;
+    line-height: 1.2;
+  }
+}
+
+<div
+  className="c0"
+>
+  <button
+    aria-expanded={true}
+    className="c1"
+    onClick={[Function]}
+    type="button"
+  >
+    <div
+      className="c2"
+    >
+      <div
+        className="c3"
+      >
+        <h2
+          className="c4"
+        >
+          Custom expand element (function)
+        </h2>
+      </div>
+      <div
+        className="c3"
+      >
+        <span
+          className="c5"
+        >
+          Close
+        </span>
+      </div>
+    </div>
+  </button>
+  <div
+    className="c6"
+    height={null}
+    hidden={false}
+    onTransitionEnd={[Function]}
+  >
+    <p
+      className="c7 c8"
+    >
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
     </p>
   </div>
 </div>


### PR DESCRIPTION
Add `expandElement`, `titleRowPaddingX` and `titleRowPaddingY` props to CollapsibleCard to make it possible to override the default expand element and title paddings