### PR TITLE
fix: 🐛 flextable styling syntax error in row

### DIFF
--- a/src/Molecules/FlexTable/Row/Row.tsx
+++ b/src/Molecules/FlexTable/Row/Row.tsx
@@ -33,8 +33,8 @@ const getExpandableStyles = (
   &:first-child {
     padding-left: 0;
   }
-
   ${!p.expandable ? '&:nth-last-child(2) { padding-right: 0; }' : ''}
+ }
 `;
 
 type ScreenSizeConfigurableProps = { expandable: boolean };

--- a/src/Molecules/FlexTable/stories/__snapshots__/WithExpandableRows.stories.storyshot
+++ b/src/Molecules/FlexTable/stories/__snapshots__/WithExpandableRows.stories.storyshot
@@ -9176,33 +9176,33 @@ exports[`Storyshots Molecules / FlexTable / With expandable rows Only Expandable
 }
 
 @media (min-width:976px) {
-  .c2 > * {
+  .c2 {
     padding-left: 0px;
     border-left: 2px solid transparent;
     border-bottom: 1px solid #EBEBE8;
   }
 
-  .c2 > * > *:first-child {
+  .c2 > *:first-child {
     padding-left: 0;
   }
 
-  .c2 > * > *:nth-last-child(2) {
+  .c2 > *:nth-last-child(2) {
     padding-right: 0;
   }
 }
 
 @media (min-width:976px) {
-  .c13 > * {
+  .c13 {
     padding-left: 0px;
     border-left: 2px solid transparent;
     border-bottom: 1px solid #EBEBE8;
   }
 
-  .c13 > * > *:first-child {
+  .c13 > *:first-child {
     padding-left: 0;
   }
 
-  .c13 > * > *:nth-last-child(2) {
+  .c13 > *:nth-last-child(2) {
     padding-right: 0;
   }
 }

--- a/src/Molecules/FlexTable/stories/__snapshots__/WithLotsOfRows.stories.storyshot
+++ b/src/Molecules/FlexTable/stories/__snapshots__/WithLotsOfRows.stories.storyshot
@@ -468,33 +468,33 @@ exports[`Storyshots Molecules / FlexTable / With lots of rows Big Table 1`] = `
 }
 
 @media (min-width:976px) {
-  .c4 > * {
+  .c4 {
     padding-left: 0px;
     border-left: 2px solid transparent;
     border-bottom: 1px solid #EBEBE8;
   }
 
-  .c4 > * > *:first-child {
+  .c4 > *:first-child {
     padding-left: 0;
   }
 
-  .c4 > * > *:nth-last-child(2) {
+  .c4 > *:nth-last-child(2) {
     padding-right: 0;
   }
 }
 
 @media (min-width:976px) {
-  .c22 > * {
+  .c22 {
     padding-left: 0px;
     border-left: 2px solid transparent;
     border-bottom: 1px solid #EBEBE8;
   }
 
-  .c22 > * > *:first-child {
+  .c22 > *:first-child {
     padding-left: 0;
   }
 
-  .c22 > * > *:nth-last-child(2) {
+  .c22 > *:nth-last-child(2) {
     padding-right: 0;
   }
 }


### PR DESCRIPTION
A missing `}` in styles for row, caused a syntax error which meant that the styles were not generated correctly. Adding the missing `}` fixed a lot of things