### PR TITLE
Feature/datepicker fullscreen on mobile

### DIFF
--- a/src/Molecules/DatePicker/Single/DatePicker.tsx
+++ b/src/Molecules/DatePicker/Single/DatePicker.tsx
@@ -9,7 +9,7 @@ import { SingleDatePickerProps } from './DatePicker.types';
  * Imported separately because when imported in src/index.ts, Input will not have been imported yet and an error will be thrown
  */
 import Input from '../../Input';
-import { Box, DropdownBubble, Icon } from '../../..';
+import { Box, DropdownBubble, Icon, Modal, useMedia } from '../../..';
 import { assert, isUndefined } from '../../../common/utils';
 import { useOnClickOutside } from '../../../common/Hooks';
 import {
@@ -31,6 +31,7 @@ const StyledDropdownBubble = styled(DropdownBubble)`
   max-width: ${({ theme }) => theme.spacing.unit(78)}px;
   z-index: ${({ theme }) => theme.zIndex.overlay};
   top: -10px;
+
   &:after,
   &:before {
     display: none;
@@ -61,6 +62,7 @@ const DatePicker = React.forwardRef<HTMLDivElement, SingleDatePickerProps>((prop
     width = DEFAULT_INPUT_WIDTH,
     yearSelectLength,
     inputSize,
+    fullScreenOnMobile = false,
   } = props;
 
   assert(Boolean(props.id), `DatePicker: "id" is required.`);
@@ -75,6 +77,8 @@ const DatePicker = React.forwardRef<HTMLDivElement, SingleDatePickerProps>((prop
   const theme = useTheme();
   const { locale } = useIntl();
   const dateFormat = getDateFormat(locale);
+  const isFullscreenMode =
+    useMedia((t) => t.media.lessThan(t.breakpoints.sm)) && fullScreenOnMobile;
 
   const options = useMemo(
     () => ({
@@ -364,7 +368,9 @@ const DatePicker = React.forwardRef<HTMLDivElement, SingleDatePickerProps>((prop
   const selfRef = useRef<HTMLDivElement>(null);
   useOnClickOutside(selfRef, () => {
     setFocused([null, null]);
-    setOpen(false);
+    if (!isFullscreenMode) {
+      setOpen(false);
+    }
   });
 
   return (
@@ -389,11 +395,16 @@ const DatePicker = React.forwardRef<HTMLDivElement, SingleDatePickerProps>((prop
         width={typeof width === 'string' ? width : `${theme.spacing.unit(width)}px`}
         autoComplete="off"
       />
-      {open ? (
+      {open && !isFullscreenMode && (
         <StyledDropdownBubbleWrapper data-testid="styled-dropdown-bubble-wrapper">
           <StyledDropdownBubble>{datepicker}</StyledDropdownBubble>
         </StyledDropdownBubbleWrapper>
-      ) : null}
+      )}
+      {open && isFullscreenMode && (
+        <Modal open={open} onClose={() => setOpen(false)} fullScreenMobile>
+          {datepicker}
+        </Modal>
+      )}
     </div>
   );
 });

--- a/src/Molecules/DatePicker/Single/DatePicker.tsx
+++ b/src/Molecules/DatePicker/Single/DatePicker.tsx
@@ -367,8 +367,8 @@ const DatePicker = React.forwardRef<HTMLDivElement, SingleDatePickerProps>((prop
 
   const selfRef = useRef<HTMLDivElement>(null);
   useOnClickOutside(selfRef, () => {
-    setFocused([null, null]);
     if (!isFullscreenMode) {
+      setFocused([null, null]);
       setOpen(false);
     }
   });

--- a/src/Molecules/DatePicker/Single/DatePicker.types.ts
+++ b/src/Molecules/DatePicker/Single/DatePicker.types.ts
@@ -22,4 +22,5 @@ export type SingleDatePickerProps = {
   width?: number | string;
   ref?: React.Ref<HTMLDivElement>;
   yearSelectLength?: number;
+  fullScreenOnMobile?: boolean;
 };

--- a/src/Molecules/DatePicker/Single/RangeDatePicker.stories.tsx
+++ b/src/Molecules/DatePicker/Single/RangeDatePicker.stories.tsx
@@ -85,3 +85,12 @@ export const AllowUpdateWhileTyping = () => {
     />
   );
 };
+
+export const FullscreenOnMobile = () => (
+  <DatePicker
+    id="fullscreen-on-mobile"
+    variant="RANGE"
+    label="FullscreenOnMobile"
+    fullScreenOnMobile
+  />
+);

--- a/src/Molecules/DatePicker/Single/RegularDatePicker.stories.tsx
+++ b/src/Molecules/DatePicker/Single/RegularDatePicker.stories.tsx
@@ -81,3 +81,12 @@ export const AllowUpdateWhileTyping = () => {
     />
   );
 };
+
+export const FullScreenOnMobile = () => (
+  <DatePicker
+    id="date-picker-with-fullscreen-on-mobile-behavior"
+    label="Fullscreen on mobile"
+    onChange={action('onChange regular')}
+    fullScreenOnMobile
+  />
+);

--- a/src/Molecules/DatePicker/Single/__snapshots__/RangeDatePicker.stories.storyshot
+++ b/src/Molecules/DatePicker/Single/__snapshots__/RangeDatePicker.stories.storyshot
@@ -1045,6 +1045,232 @@ exports[`Storyshots Molecules / DatePicker / DatePicker with range Disabled Inpu
 </div>
 `;
 
+exports[`Storyshots Molecules / DatePicker / DatePicker with range Fullscreen On Mobile 1`] = `
+.c4 {
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c8 {
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c2 {
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.c10 {
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  width: 24px;
+  height: 24px;
+  fill: #282823;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  display: block;
+}
+
+.c3 {
+  font-family: 'Nordnet Sans Mono',-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
+  color: #6E6E69;
+  margin: 0;
+  font-weight: 400;
+  font-size: 14px;
+  line-height: 1.4285714285714286;
+}
+
+.c5 {
+  font-family: 'Nordnet Sans Mono',-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
+  color: #282823;
+  margin: 0;
+  font-weight: 400;
+  font-size: 14px;
+  line-height: 1.4285714285714286;
+}
+
+.c9 {
+  width: 32px;
+  top: 0;
+  height: 100%;
+  padding-left: 4px;
+  padding-right: 4px;
+  position: absolute;
+  right: 4px;
+}
+
+.c7 {
+  font-family: inherit;
+  font-size: 100%;
+  line-height: 1.15;
+  margin: 0;
+  overflow: visible;
+  border: 0;
+  width: 100%;
+  padding: 8px;
+  margin: 0;
+  line-height: inherit;
+  box-sizing: border-box;
+  height: 40px;
+  border: solid;
+  border-color: #BCBCB6;
+  border-width: 1px;
+  position: relative;
+  background-color: #FFFFFF;
+  padding-right: 40px;
+}
+
+.c7:focus {
+  border-width: 1px;
+}
+
+.c7:hover {
+  border-color: #4B4B46;
+}
+
+.c7:focus {
+  border-color: #0046FF;
+}
+
+.c7::-webkit-input-placeholder {
+  color: #6E6E69;
+  line-height: inherit;
+  opacity: 1;
+}
+
+.c7::-moz-placeholder {
+  color: #6E6E69;
+  line-height: inherit;
+  opacity: 1;
+}
+
+.c7:-ms-input-placeholder {
+  color: #6E6E69;
+  line-height: inherit;
+  opacity: 1;
+}
+
+.c7::placeholder {
+  color: #6E6E69;
+  line-height: inherit;
+  opacity: 1;
+}
+
+.c7:disabled::-webkit-input-placeholder {
+  color: #A0A09B;
+}
+
+.c7:disabled::-moz-placeholder {
+  color: #A0A09B;
+}
+
+.c7:disabled:-ms-input-placeholder {
+  color: #A0A09B;
+}
+
+.c7:disabled::placeholder {
+  color: #A0A09B;
+}
+
+.c6 {
+  position: relative;
+  padding: 0px 0;
+}
+
+.c1 {
+  z-index: 1;
+}
+
+.c0 {
+  width: 312px;
+  display: inline-block;
+}
+
+<div>
+  <div
+    className="c0 c1"
+  >
+    <label
+      className="c2"
+      hidden={false}
+    >
+      <span
+        className="c3"
+      >
+        <div
+          className="c4"
+        >
+          FullscreenOnMobile 
+        </div>
+        <span
+          className="c5"
+        >
+          <div
+            className="c6"
+          >
+            <input
+              autoComplete="off"
+              className="NormalizedInput__Input-sc-1m4kmh9-0 c7"
+              data-testid="datepicker-input"
+              id="fullscreen-on-mobile"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              placeholder="dd/mm/yyyy - dd/mm/yyyy"
+              type="text"
+              value=""
+              variant="normal"
+            />
+            <div
+              className="c8 c9"
+              position="right"
+              variant="normal"
+            >
+              <svg
+                aria-hidden="true"
+                className="c10"
+                focusable="false"
+                preserveAspectRatio="xMidYMid meet"
+                role="presentation"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M8 3v2h8V3h2v2h4v16H2V5h4V3h2zm12 7H4v9h16v-9zM7 15v2H5v-2h2zm3 0v2H8v-2h2zm3 0v2h-2v-2h2zm3 0v2h-2v-2h2zm3 0v2h-2v-2h2zM7 12v2H5v-2h2zm3 0v2H8v-2h2zm3 0v2h-2v-2h2zm3 0v2h-2v-2h2zm3 0v2h-2v-2h2zm1-5H4v1h16V7z"
+                />
+              </svg>
+            </div>
+          </div>
+        </span>
+      </span>
+    </label>
+  </div>
+</div>
+`;
+
 exports[`Storyshots Molecules / DatePicker / DatePicker with range Same Week Disabled 1`] = `
 .c4 {
   box-sizing: border-box;

--- a/src/Molecules/DatePicker/Single/__snapshots__/RegularDatePicker.stories.storyshot
+++ b/src/Molecules/DatePicker/Single/__snapshots__/RegularDatePicker.stories.storyshot
@@ -997,6 +997,232 @@ exports[`Storyshots Molecules / DatePicker / DatePicker Disabled Input 1`] = `
 </div>
 `;
 
+exports[`Storyshots Molecules / DatePicker / DatePicker Full Screen On Mobile 1`] = `
+.c4 {
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c8 {
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c2 {
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.c10 {
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  width: 24px;
+  height: 24px;
+  fill: #282823;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  display: block;
+}
+
+.c3 {
+  font-family: 'Nordnet Sans Mono',-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
+  color: #6E6E69;
+  margin: 0;
+  font-weight: 400;
+  font-size: 14px;
+  line-height: 1.4285714285714286;
+}
+
+.c5 {
+  font-family: 'Nordnet Sans Mono',-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
+  color: #282823;
+  margin: 0;
+  font-weight: 400;
+  font-size: 14px;
+  line-height: 1.4285714285714286;
+}
+
+.c9 {
+  width: 32px;
+  top: 0;
+  height: 100%;
+  padding-left: 4px;
+  padding-right: 4px;
+  position: absolute;
+  right: 4px;
+}
+
+.c7 {
+  font-family: inherit;
+  font-size: 100%;
+  line-height: 1.15;
+  margin: 0;
+  overflow: visible;
+  border: 0;
+  width: 100%;
+  padding: 8px;
+  margin: 0;
+  line-height: inherit;
+  box-sizing: border-box;
+  height: 40px;
+  border: solid;
+  border-color: #BCBCB6;
+  border-width: 1px;
+  position: relative;
+  background-color: #FFFFFF;
+  padding-right: 40px;
+}
+
+.c7:focus {
+  border-width: 1px;
+}
+
+.c7:hover {
+  border-color: #4B4B46;
+}
+
+.c7:focus {
+  border-color: #0046FF;
+}
+
+.c7::-webkit-input-placeholder {
+  color: #6E6E69;
+  line-height: inherit;
+  opacity: 1;
+}
+
+.c7::-moz-placeholder {
+  color: #6E6E69;
+  line-height: inherit;
+  opacity: 1;
+}
+
+.c7:-ms-input-placeholder {
+  color: #6E6E69;
+  line-height: inherit;
+  opacity: 1;
+}
+
+.c7::placeholder {
+  color: #6E6E69;
+  line-height: inherit;
+  opacity: 1;
+}
+
+.c7:disabled::-webkit-input-placeholder {
+  color: #A0A09B;
+}
+
+.c7:disabled::-moz-placeholder {
+  color: #A0A09B;
+}
+
+.c7:disabled:-ms-input-placeholder {
+  color: #A0A09B;
+}
+
+.c7:disabled::placeholder {
+  color: #A0A09B;
+}
+
+.c6 {
+  position: relative;
+  padding: 0px 0;
+}
+
+.c1 {
+  z-index: 1;
+}
+
+.c0 {
+  width: 312px;
+  display: inline-block;
+}
+
+<div>
+  <div
+    className="c0 c1"
+  >
+    <label
+      className="c2"
+      hidden={false}
+    >
+      <span
+        className="c3"
+      >
+        <div
+          className="c4"
+        >
+          Fullscreen on mobile 
+        </div>
+        <span
+          className="c5"
+        >
+          <div
+            className="c6"
+          >
+            <input
+              autoComplete="off"
+              className="NormalizedInput__Input-sc-1m4kmh9-0 c7"
+              data-testid="datepicker-input"
+              id="date-picker-with-fullscreen-on-mobile-behavior"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              placeholder="dd/mm/yyyy"
+              type="text"
+              value=""
+              variant="normal"
+            />
+            <div
+              className="c8 c9"
+              position="right"
+              variant="normal"
+            >
+              <svg
+                aria-hidden="true"
+                className="c10"
+                focusable="false"
+                preserveAspectRatio="xMidYMid meet"
+                role="presentation"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M8 3v2h8V3h2v2h4v16H2V5h4V3h2zm12 7H4v9h16v-9zM7 15v2H5v-2h2zm3 0v2H8v-2h2zm3 0v2h-2v-2h2zm3 0v2h-2v-2h2zm3 0v2h-2v-2h2zM7 12v2H5v-2h2zm3 0v2H8v-2h2zm3 0v2h-2v-2h2zm3 0v2h-2v-2h2zm3 0v2h-2v-2h2zm1-5H4v1h16V7z"
+                />
+              </svg>
+            </div>
+          </div>
+        </span>
+      </span>
+    </label>
+  </div>
+</div>
+`;
+
 exports[`Storyshots Molecules / DatePicker / DatePicker Full Width Input 1`] = `
 .c4 {
   box-sizing: border-box;

--- a/src/Molecules/Input/Select/lib/wrappers/SelectedValue.tsx
+++ b/src/Molecules/Input/Select/lib/wrappers/SelectedValue.tsx
@@ -63,6 +63,7 @@ export const SelectedValueWrapper = React.forwardRef<any, any>(
       value.length > 0 ? `${label}: ${screenReaderTextSelection}` : `${label}: ${placeholder}`;
 
     const handleClick: React.MouseEventHandler = (e) => {
+      console.log({ e });
       e.preventDefault();
       send({ type: 'TOGGLE' });
     };


### PR DESCRIPTION
Makes default and range date pickers render in a full screen modal on mobile sized screens if fullScreenOnMobile prop is passed. Double Date Picker is not part of this feature right now, as far as I can tell it should not be used on small screens. 