### PR TITLE
Fix/input select placeholder color

### DIFF
--- a/src/Molecules/Input/Select/Select.stories.tsx
+++ b/src/Molecules/Input/Select/Select.stories.tsx
@@ -625,7 +625,10 @@ export const multiselect = () =>
         const selectedCount = machineState.context.selectedItems.length;
         return (
           <FlexedBox px={2}>
-            <Typography type="secondary">
+            <Typography
+              type="secondary"
+              color={selectedCount === 0 ? (t) => t.color.placeholderText : undefined}
+            >
               {selectedCount === 0 ? machineState.context.placeholder : `${selectedCount} selected`}
             </Typography>
           </FlexedBox>
@@ -660,7 +663,10 @@ export const multiselectActions = () =>
         const selectedCount = machineState.context.selectedItems.length;
         return (
           <FlexedBox px={2}>
-            <Typography type="secondary">
+            <Typography
+              type="secondary"
+              color={selectedCount === 0 ? (t) => t.color.placeholderText : undefined}
+            >
               {selectedCount === 0 ? machineState.context.placeholder : `${selectedCount} selected`}
             </Typography>
           </FlexedBox>
@@ -727,7 +733,12 @@ export const multiselectSelectAll = () =>
       }
       return (
         <FlexedBox px={2}>
-          <Typography type="secondary">{label}</Typography>
+          <Typography
+            type="secondary"
+            color={selectedCount === 0 ? (t) => t.color.placeholderText : undefined}
+          >
+            {label}
+          </Typography>
         </FlexedBox>
       );
     }, []);
@@ -770,7 +781,12 @@ export const multiselectSelectAllWithFullScreenOnMobile = () =>
       }
       return (
         <FlexedBox px={2}>
-          <Typography type="secondary">{label}</Typography>
+          <Typography
+            type="secondary"
+            color={selectedCount === 0 ? (t) => t.color.placeholderText : undefined}
+          >
+            {label}
+          </Typography>
         </FlexedBox>
       );
     }, []);
@@ -1642,7 +1658,10 @@ export const GroupedOptionsMultiselect = () => {
 
     return (
       <FlexedBox px={2}>
-        <Typography type="secondary">
+        <Typography
+          type="secondary"
+          color={selectedCount === 0 ? (t) => t.color.placeholderText : undefined}
+        >
           {selectedCount === 0 ? machineState.context.placeholder : `${selectedCount} selected`}
         </Typography>
       </FlexedBox>
@@ -1702,7 +1721,12 @@ export const GroupedOptionsMultiselectControlled = () => {
 
     return (
       <FlexedBox px={2}>
-        <Typography type="secondary">{label}</Typography>
+        <Typography
+          type="secondary"
+          color={selectedCount === 0 ? (t) => t.color.placeholderText : undefined}
+        >
+          {label}
+        </Typography>
       </FlexedBox>
     );
   };

--- a/src/Molecules/Input/Select/__snapshots__/Select.stories.storyshot
+++ b/src/Molecules/Input/Select/__snapshots__/Select.stories.storyshot
@@ -6331,7 +6331,7 @@ exports[`Storyshots Molecules / Input / Select Grouped Options Multiselect 1`] =
                   className="c12 c13"
                 >
                   <span
-                    className="c7"
+                    className="c5"
                   >
                     Select options
                   </span>
@@ -6715,7 +6715,7 @@ exports[`Storyshots Molecules / Input / Select Grouped Options Multiselect Contr
                   className="c12 c13"
                 >
                   <span
-                    className="c7"
+                    className="c5"
                   >
                     Select account
                   </span>
@@ -10708,7 +10708,7 @@ exports[`Storyshots Molecules / Input / Select Multiselect 1`] = `
                   className="c12 c13"
                 >
                   <span
-                    className="c7"
+                    className="c5"
                   >
                     Select account
                   </span>
@@ -11048,7 +11048,7 @@ exports[`Storyshots Molecules / Input / Select Multiselect Actions 1`] = `
                   className="c12 c13"
                 >
                   <span
-                    className="c7"
+                    className="c5"
                   >
                     Select account
                   </span>
@@ -11395,7 +11395,7 @@ exports[`Storyshots Molecules / Input / Select Multiselect Select All 1`] = `
                   className="c12 c13"
                 >
                   <span
-                    className="c7"
+                    className="c5"
                   >
                     Select account
                   </span>
@@ -11754,7 +11754,7 @@ exports[`Storyshots Molecules / Input / Select Multiselect Select All With Full 
                   className="c12 c13"
                 >
                   <span
-                    className="c7"
+                    className="c5"
                   >
                     Select account
                   </span>

--- a/src/Molecules/Input/Select/__snapshots__/Select.stories.storyshot
+++ b/src/Molecules/Input/Select/__snapshots__/Select.stories.storyshot
@@ -175,6 +175,7 @@ exports[`Storyshots Molecules / Input / Select Accessible From Document Forms 1`
   white-space: nowrap;
   overflow: hidden;
   text-align: left;
+  color: #6E6E69;
 }
 
 .c13 {
@@ -526,6 +527,7 @@ exports[`Storyshots Molecules / Input / Select Actions 1`] = `
   white-space: nowrap;
   overflow: hidden;
   text-align: left;
+  color: #6E6E69;
 }
 
 .c13 {
@@ -869,6 +871,7 @@ exports[`Storyshots Molecules / Input / Select Actions And Empty Option List 1`]
   white-space: nowrap;
   overflow: hidden;
   text-align: left;
+  color: #6E6E69;
 }
 
 .c13 {
@@ -1164,6 +1167,7 @@ exports[`Storyshots Molecules / Input / Select Auto Focus 1`] = `
   white-space: nowrap;
   overflow: hidden;
   text-align: left;
+  color: #6E6E69;
 }
 
 .c13 {
@@ -1511,6 +1515,7 @@ Array [
   white-space: nowrap;
   overflow: hidden;
   text-align: left;
+  color: #6E6E69;
 }
 
 .c13 {
@@ -2017,6 +2022,7 @@ Array [
   white-space: nowrap;
   overflow: hidden;
   text-align: left;
+  color: #6E6E69;
 }
 
 .c13 {
@@ -3039,6 +3045,7 @@ exports[`Storyshots Molecules / Input / Select Default Story 1`] = `
   white-space: nowrap;
   overflow: hidden;
   text-align: left;
+  color: #6E6E69;
 }
 
 .c13 {
@@ -3465,6 +3472,7 @@ exports[`Storyshots Molecules / Input / Select Default variations 1`] = `
   white-space: nowrap;
   overflow: hidden;
   text-align: left;
+  color: #6E6E69;
 }
 
 .c17 {
@@ -4380,6 +4388,7 @@ exports[`Storyshots Molecules / Input / Select Disabled Items 1`] = `
   white-space: nowrap;
   overflow: hidden;
   text-align: left;
+  color: #6E6E69;
 }
 
 .c13 {
@@ -4749,6 +4758,7 @@ Array [
   white-space: nowrap;
   overflow: hidden;
   text-align: left;
+  color: #6E6E69;
 }
 
 .c13 {
@@ -5121,6 +5131,7 @@ exports[`Storyshots Molecules / Input / Select Full Width 1`] = `
   white-space: nowrap;
   overflow: hidden;
   text-align: left;
+  color: #6E6E69;
 }
 
 .c14 {
@@ -5464,6 +5475,7 @@ exports[`Storyshots Molecules / Input / Select Fully Empty 1`] = `
   white-space: nowrap;
   overflow: hidden;
   text-align: left;
+  color: #6E6E69;
 }
 
 .c13 {
@@ -5759,6 +5771,7 @@ exports[`Storyshots Molecules / Input / Select Grouped Options 1`] = `
   white-space: nowrap;
   overflow: hidden;
   text-align: left;
+  color: #6E6E69;
 }
 
 .c13 {
@@ -6912,6 +6925,7 @@ exports[`Storyshots Molecules / Input / Select Hide Label 1`] = `
   white-space: nowrap;
   overflow: hidden;
   text-align: left;
+  color: #6E6E69;
 }
 
 .c13 {
@@ -7235,6 +7249,7 @@ exports[`Storyshots Molecules / Input / Select Inside Modal 1`] = `
   white-space: nowrap;
   overflow: hidden;
   text-align: left;
+  color: #6E6E69;
 }
 
 .c16 {
@@ -11948,6 +11963,7 @@ exports[`Storyshots Molecules / Input / Select On A Coloured Background 1`] = `
   white-space: nowrap;
   overflow: hidden;
   text-align: left;
+  color: #6E6E69;
 }
 
 .c14 {
@@ -12255,6 +12271,7 @@ exports[`Storyshots Molecules / Input / Select On Blur And On Focus 1`] = `
   white-space: nowrap;
   overflow: hidden;
   text-align: left;
+  color: #6E6E69;
 }
 
 .c13 {
@@ -12598,6 +12615,7 @@ exports[`Storyshots Molecules / Input / Select On Search Query Change 1`] = `
   white-space: nowrap;
   overflow: hidden;
   text-align: left;
+  color: #6E6E69;
 }
 
 .c13 {
@@ -12941,6 +12959,7 @@ exports[`Storyshots Molecules / Input / Select Overflow Story 1`] = `
   white-space: nowrap;
   overflow: hidden;
   text-align: left;
+  color: #6E6E69;
 }
 
 .c13 {
@@ -13977,6 +13996,7 @@ exports[`Storyshots Molecules / Input / Select Placement Top 1`] = `
   white-space: nowrap;
   overflow: hidden;
   text-align: left;
+  color: #6E6E69;
 }
 
 .c14 {
@@ -14669,6 +14689,7 @@ exports[`Storyshots Molecules / Input / Select Search Story 1`] = `
   white-space: nowrap;
   overflow: hidden;
   text-align: left;
+  color: #6E6E69;
 }
 
 .c13 {
@@ -15111,6 +15132,7 @@ exports[`Storyshots Molecules / Input / Select Size S 1`] = `
   white-space: nowrap;
   overflow: hidden;
   text-align: left;
+  color: #6E6E69;
 }
 
 .c17 {
@@ -16030,6 +16052,7 @@ exports[`Storyshots Molecules / Input / Select Tracking 1`] = `
   white-space: nowrap;
   overflow: hidden;
   text-align: left;
+  color: #6E6E69;
 }
 
 .c13 {
@@ -16338,6 +16361,7 @@ Array [
   white-space: nowrap;
   overflow: hidden;
   text-align: left;
+  color: #6E6E69;
 }
 
 .c13 {
@@ -16642,6 +16666,7 @@ Array [
   white-space: nowrap;
   overflow: hidden;
   text-align: left;
+  color: #6E6E69;
 }
 
 .c13 {
@@ -17008,6 +17033,7 @@ exports[`Storyshots Molecules / Input / Select With Custom Height 1`] = `
   white-space: nowrap;
   overflow: hidden;
   text-align: left;
+  color: #6E6E69;
 }
 
 .c22 {
@@ -17402,6 +17428,7 @@ exports[`Storyshots Molecules / Input / Select With Label Tooltip 1`] = `
   white-space: nowrap;
   overflow: hidden;
   text-align: left;
+  color: #6E6E69;
 }
 
 .c16 {
@@ -17762,6 +17789,7 @@ Array [
   white-space: nowrap;
   overflow: hidden;
   text-align: left;
+  color: #6E6E69;
 }
 
 .c16 {
@@ -18120,6 +18148,7 @@ exports[`Storyshots Molecules / Input / Select With Modal Title Full Screen On M
   white-space: nowrap;
   overflow: hidden;
   text-align: left;
+  color: #6E6E69;
 }
 
 .c16 {
@@ -18464,6 +18493,7 @@ exports[`Storyshots Molecules / Input / Select Without Search Component 1`] = `
   white-space: nowrap;
   overflow: hidden;
   text-align: left;
+  color: #6E6E69;
 }
 
 .c14 {

--- a/src/Molecules/Input/Select/lib/defaults/SelectedValue.tsx
+++ b/src/Molecules/Input/Select/lib/defaults/SelectedValue.tsx
@@ -19,7 +19,7 @@ const EllipsizingText = styled.span<{ $isPlaceholder: boolean }>`
   white-space: nowrap;
   overflow: hidden;
   text-align: left;
-  ${(p) => (p.$isPlaceholder ? `color: ${p.theme.color.placeholder};` : '')}
+  ${(p) => (p.$isPlaceholder ? `color: ${p.theme.color.placeholderText};` : '')}
 `;
 
 const CHEVRON_WIDTH = 20;

--- a/src/Molecules/Input/Select/lib/defaults/SelectedValue.tsx
+++ b/src/Molecules/Input/Select/lib/defaults/SelectedValue.tsx
@@ -13,12 +13,13 @@ const getLabelOrPlaceholder = (state: ContextType[0]) => {
   return R.pathOr('', [0, 'label'], value);
 };
 
-const EllipsizingText = styled.span`
+const EllipsizingText = styled.span<{ $isPlaceholder: boolean }>`
   width: 100%;
   text-overflow: ellipsis;
   white-space: nowrap;
   overflow: hidden;
   text-align: left;
+  ${(p) => (p.$isPlaceholder ? `color: ${p.theme.color.placeholder};` : '')}
 `;
 
 const CHEVRON_WIDTH = 20;
@@ -32,9 +33,13 @@ const StyledFlexedBox = styled(Box)`
 
 export const SelectedValue = () => {
   const [state] = useSelectMachineFromContext();
+  const isPlaceholder = state.context.selectedItems.length === 0;
+
   return (
     <StyledFlexedBox px={2}>
-      <EllipsizingText>{getLabelOrPlaceholder(state)}</EllipsizingText>
+      <EllipsizingText $isPlaceholder={isPlaceholder}>
+        {getLabelOrPlaceholder(state)}
+      </EllipsizingText>
     </StyledFlexedBox>
   );
 };

--- a/src/theme/__snapshots__/Theme.stories.storyshot
+++ b/src/theme/__snapshots__/Theme.stories.storyshot
@@ -5860,7 +5860,7 @@ exports[`Storyshots Others / Theme Colors (semantic) 1`] = `
       <td
         className="c5"
       >
-        placeholder
+        placeholderText
       </td>
       <td
         className="c5"

--- a/src/theme/__snapshots__/Theme.stories.storyshot
+++ b/src/theme/__snapshots__/Theme.stories.storyshot
@@ -5860,6 +5860,39 @@ exports[`Storyshots Others / Theme Colors (semantic) 1`] = `
       <td
         className="c5"
       >
+        placeholder
+      </td>
+      <td
+        className="c5"
+      >
+        <div
+          className="c6"
+        />
+        #6E6E69
+      </td>
+      <td
+        className="c5"
+      >
+        <div
+          className="c6"
+        />
+        #6E6E69
+      </td>
+      <td
+        className="c5"
+      >
+        <div
+          className="c25"
+        />
+        #A0A09B
+      </td>
+    </tr>
+    <tr
+      className="c2"
+    >
+      <td
+        className="c5"
+      >
         positive
       </td>
       <td

--- a/src/theme/createDarkColors.tsx
+++ b/src/theme/createDarkColors.tsx
@@ -151,7 +151,7 @@ export const createDarkColors = (rawColor: RawColors): ThemeColors => {
     palettePink: rawColor.palettes.pink,
     paletteTurquoise: rawColor.palettes.turquoise,
 
-    placeholder: rawColor.gray3,
+    placeholderText: rawColor.gray3,
 
     positive: rawColor.positive,
 

--- a/src/theme/createDarkColors.tsx
+++ b/src/theme/createDarkColors.tsx
@@ -33,10 +33,10 @@ export const createDarkColors = (rawColor: RawColors): ThemeColors => {
     backgroundDark: rawColor.gray2,
 
     barGraphHighlight: Color(rawColor.complementaryBlue1).alpha(0.3).rgb().string(),
-    
+
     barScaleActiveBar: rawColor.complementaryTurquoise1,
     barScaleInactiveBar: rawColor.gray6,
-    
+
     borderActive: rawColor.brandTurquoise,
 
     bubbleBackground: rawColor.gray1,
@@ -150,6 +150,8 @@ export const createDarkColors = (rawColor: RawColors): ThemeColors => {
     ],
     palettePink: rawColor.palettes.pink,
     paletteTurquoise: rawColor.palettes.turquoise,
+
+    placeholder: rawColor.gray3,
 
     positive: rawColor.positive,
 

--- a/src/theme/createLightColors.tsx
+++ b/src/theme/createLightColors.tsx
@@ -151,7 +151,7 @@ export const createLightColors = (rawColor: RawColors): ThemeColors => {
     palettePink: rawColor.palettes.pink,
     paletteTurquoise: rawColor.palettes.turquoise,
 
-    placeholder: rawColor.gray2,
+    placeholderText: rawColor.gray2,
 
     positive: rawColor.positive,
 

--- a/src/theme/createLightColors.tsx
+++ b/src/theme/createLightColors.tsx
@@ -35,10 +35,10 @@ export const createLightColors = (rawColor: RawColors): ThemeColors => {
     backgroundDark: rawColor.gray0,
 
     barGraphHighlight: Color(rawColor.complementaryBlue1).alpha(0.1).rgb().string(),
-    
+
     barScaleActiveBar: rawColor.complementaryBlue1,
     barScaleInactiveBar: rawColor.gray6,
-    
+
     borderActive: rawColor.cta,
 
     bubbleBackground: rawColor.white,
@@ -150,6 +150,8 @@ export const createLightColors = (rawColor: RawColors): ThemeColors => {
     ],
     palettePink: rawColor.palettes.pink,
     paletteTurquoise: rawColor.palettes.turquoise,
+
+    placeholder: rawColor.gray2,
 
     positive: rawColor.positive,
 

--- a/src/theme/theme.types.ts
+++ b/src/theme/theme.types.ts
@@ -230,6 +230,8 @@ export type ThemeColors = {
   paletteMap: string[];
   palettePink: string[];
   paletteTurquoise: string[];
+  /** gray2 */
+  placeholder: RawColor['gray2'];
   /** positive */
   positive: RawColor['positive'];
   /** gray6 */

--- a/src/theme/theme.types.ts
+++ b/src/theme/theme.types.ts
@@ -231,7 +231,7 @@ export type ThemeColors = {
   palettePink: string[];
   paletteTurquoise: string[];
   /** gray2 */
-  placeholder: RawColor['gray2'];
+  placeholderText: RawColor['gray2'];
   /** positive */
   positive: RawColor['positive'];
   /** gray6 */


### PR DESCRIPTION
Changes `Input` placeholder color to `gray2` (`gray3` in darkmode) according to design to distinguish between selected and placeholder text/options.