### PR TITLE
fix: 🐛 add classname to persistant tooltip and related comps

### DIFF
--- a/src/Molecules/PersistentTooltip/PersistentTooltip.stories.tsx
+++ b/src/Molecules/PersistentTooltip/PersistentTooltip.stories.tsx
@@ -108,39 +108,6 @@ export const CustomTitleAndDescription = () => {
   );
 };
 
-const StyledPersistentTooltip = styled(PersistentTooltip)`
-  ${PersistentTooltip.components.CloseButtonIcon} {
-    fill: ${(p) => p.theme.color.text};
-    width: ${(p) => p.theme.spacing.unit(2)}px;
-    height: ${(p) => p.theme.spacing.unit(2)}px;
-  }
-`;
-
-export const StyledSubcomponents = () => {
-  const [isOpen, setIsOpen] = useState(true);
-
-  return (
-    <StoryWrapper>
-      <StyledPersistentTooltip
-        isOpen={isOpen}
-        title={<Typography type="title2">I&apos;m in a box</Typography>}
-        description={
-          <Typography>
-            The max width is set with a prop for this tooltip. Also, it&apos;s subcomponents styled
-            – different color, smaller close button.
-          </Typography>
-        }
-        closeButtonTitle="Close by clicking X"
-        backgroundColor={(t) => t.color.warning}
-        borderColor={(t) => t.color.negative}
-        onClose={() => setIsOpen(false)}
-      >
-        <Input.Text label="Label" />
-      </StyledPersistentTooltip>
-    </StoryWrapper>
-  );
-};
-
 export const DifferentPositions = () => {
   const [openOne, setOpenOne] = useState(true);
   const [openTwo, setOpenTwo] = useState(true);
@@ -223,6 +190,72 @@ export const PersistentTooltipInDrawer = () => {
           <Input.Text label="Label" />
         </PersistentTooltip>
       </Drawer>
+    </StoryWrapper>
+  );
+};
+
+const StyledPersistentTooltipWithMargin = styled(PersistentTooltip)`
+  margin-right: 20px;
+`;
+
+export const StyledPersistentTooltipInDrawer = () => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <StoryWrapper>
+      <Drawer
+        onAnimationComplete={() => {
+          setIsOpen(true);
+        }}
+        preventOnClickOutsideDataAttributes={['data-specific-drawer-prevent-click-outside']}
+      >
+        <Box mt={50}>
+          <StyledPersistentTooltipWithMargin
+            isOpen={isOpen}
+            title="This is a styled persistent tooltip"
+            description="If you want to slightly re-position the tooltip, style it and add some margin!"
+            closeButtonTitle="Close by clicking X"
+            onClose={() => setIsOpen(false)}
+            data-specific-drawer-prevent-click-outside
+            position="left"
+          >
+            <Input.Text label="Label" />
+          </StyledPersistentTooltipWithMargin>
+        </Box>
+      </Drawer>
+    </StoryWrapper>
+  );
+};
+
+const StyledPersistentTooltipSubComponents = styled(PersistentTooltip)`
+  ${PersistentTooltip.components.CloseButtonIcon} {
+    fill: ${(p) => p.theme.color.text};
+    width: ${(p) => p.theme.spacing.unit(2)}px;
+    height: ${(p) => p.theme.spacing.unit(2)}px;
+  }
+`;
+
+export const StyledSubcomponents = () => {
+  const [isOpen, setIsOpen] = useState(true);
+
+  return (
+    <StoryWrapper>
+      <StyledPersistentTooltipSubComponents
+        isOpen={isOpen}
+        title={<Typography type="title2">I&apos;m in a box</Typography>}
+        description={
+          <Typography>
+            The max width is set with a prop for this tooltip. Also, it&apos;s subcomponents styled
+            – different color, smaller close button.
+          </Typography>
+        }
+        closeButtonTitle="Close by clicking X"
+        backgroundColor={(t) => t.color.warning}
+        borderColor={(t) => t.color.negative}
+        onClose={() => setIsOpen(false)}
+      >
+        <Input.Text label="Label" />
+      </StyledPersistentTooltipSubComponents>
     </StoryWrapper>
   );
 };

--- a/src/Molecules/PersistentTooltip/PersistentTooltip.tsx
+++ b/src/Molecules/PersistentTooltip/PersistentTooltip.tsx
@@ -26,6 +26,7 @@ const components = {
 export const PersistentTooltip = forwardRef<HTMLDivElement, PersistentTooltipProps>(
   (
     {
+      className,
       children,
       id: idProp,
       position = 'bottom',
@@ -96,6 +97,7 @@ export const PersistentTooltip = forwardRef<HTMLDivElement, PersistentTooltipPro
         })}
         {isOpen && (
           <StyledPopOver
+            className={className}
             id={id}
             ref={ref as any}
             label={label}

--- a/src/Molecules/PersistentTooltip/PersistentTooltip.types.ts
+++ b/src/Molecules/PersistentTooltip/PersistentTooltip.types.ts
@@ -1,6 +1,7 @@
 import { Props as PopOverProps } from '../../common/PopOver/PopOver.types';
 
 export type Props = {
+  className?: string;
   children: React.ReactChild;
   isOpen: boolean;
   onClose: () => void;

--- a/src/Molecules/PersistentTooltip/__snapshots__/PersistentTooltip.stories.storyshot
+++ b/src/Molecules/PersistentTooltip/__snapshots__/PersistentTooltip.stories.storyshot
@@ -1640,7 +1640,7 @@ Array [
               className="c6"
             >
               <input
-                aria-describedby="nn-persistent-tooltip-25"
+                aria-describedby="nn-persistent-tooltip-24"
                 className="NormalizedInput__Input-sc-1m4kmh9-0 c7"
                 type="text"
                 variant="normal"
@@ -1653,7 +1653,7 @@ Array [
     <portal-dummy>
       <span
         className="c8 c9"
-        id="nn-persistent-tooltip-25"
+        id="nn-persistent-tooltip-24"
         style={
           Object {
             "left": "0",
@@ -2058,7 +2058,7 @@ Array [
               className="c6"
             >
               <input
-                aria-describedby="nn-persistent-tooltip-26"
+                aria-describedby="nn-persistent-tooltip-25"
                 className="NormalizedInput__Input-sc-1m4kmh9-0 c7"
                 type="text"
                 variant="normal"
@@ -2071,7 +2071,7 @@ Array [
     <portal-dummy>
       <span
         className="c8 c9"
-        id="nn-persistent-tooltip-26"
+        id="nn-persistent-tooltip-25"
         style={
           Object {
             "left": "0",
@@ -2476,7 +2476,7 @@ Array [
               className="c6"
             >
               <input
-                aria-describedby="nn-persistent-tooltip-27"
+                aria-describedby="nn-persistent-tooltip-26"
                 className="NormalizedInput__Input-sc-1m4kmh9-0 c7"
                 type="text"
                 variant="normal"
@@ -2489,7 +2489,7 @@ Array [
     <portal-dummy>
       <span
         className="c8 c9"
-        id="nn-persistent-tooltip-27"
+        id="nn-persistent-tooltip-26"
         style={
           Object {
             "left": "0",
@@ -2894,7 +2894,7 @@ Array [
               className="c6"
             >
               <input
-                aria-describedby="nn-persistent-tooltip-28"
+                aria-describedby="nn-persistent-tooltip-27"
                 className="NormalizedInput__Input-sc-1m4kmh9-0 c7"
                 type="text"
                 variant="normal"
@@ -2907,7 +2907,7 @@ Array [
     <portal-dummy>
       <span
         className="c8 c9"
-        id="nn-persistent-tooltip-28"
+        id="nn-persistent-tooltip-27"
         style={
           Object {
             "left": "0",
@@ -3399,6 +3399,428 @@ Array [
 ]
 `;
 
+exports[`Storyshots Molecules / Persistent Tooltip Styled Persistent Tooltip In Drawer 1`] = `
+Array [
+  .c0 {
+  margin-bottom: 16px;
+  background-color: transparent;
+}
+
+.c1 {
+  font-family: 'Nordnet Sans Mono',-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
+  color: #282823;
+  margin: 0;
+  font-weight: 800;
+  font-size: 20px;
+  line-height: 1.2;
+}
+
+@media (min-width:760px) {
+  .c1 {
+    font-size: 24px;
+    line-height: 1.1666666666666667;
+  }
+}
+
+@media (min-width:760px) {
+
+}
+
+@media (min-width:1600px) {
+
+}
+
+@media (max-width:759px) {
+
+}
+
+@media (max-width:759px) {
+
+}
+
+<div
+    className="c0"
+  >
+    <span
+      className="c1"
+    >
+      This component is used to let the user discover new features
+    </span>
+  </div>,
+  .c6 {
+  margin-top: 200px;
+  background-color: transparent;
+}
+
+.c10 {
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c8 {
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.c4 {
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  width: 16px;
+  height: 16px;
+  fill: #282823;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  display: block;
+}
+
+.c3 {
+  font-family: 'Nordnet Sans Mono',-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
+  color: inherit;
+  margin: 0;
+  font-weight: 700;
+  font-size: 14px;
+  line-height: 1.4285714285714286;
+}
+
+.c9 {
+  font-family: 'Nordnet Sans Mono',-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
+  color: #6E6E69;
+  margin: 0;
+  font-weight: 400;
+  font-size: 14px;
+  line-height: 1.4285714285714286;
+}
+
+.c11 {
+  font-family: 'Nordnet Sans Mono',-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
+  color: #282823;
+  margin: 0;
+  font-weight: 400;
+  font-size: 14px;
+  line-height: 1.4285714285714286;
+}
+
+.c1 {
+  font-family: inherit;
+  font-size: 100%;
+  line-height: 1.15;
+  margin: 0;
+  overflow: visible;
+  text-transform: none;
+  position: relative;
+  box-sizing: border-box;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  padding: 0;
+  background-color: transparent;
+  color: #282823;
+  border: none;
+  border-radius: 0;
+  cursor: pointer;
+}
+
+.c1,
+.c1[type='button'],
+.c1[type='reset'],
+.c1[type='submit'] {
+  -webkit-appearance: button;
+}
+
+.c1::-moz-focus-inner,
+.c1[type='button']::-moz-focus-inner,
+.c1[type='reset']::-moz-focus-inner,
+.c1[type='submit']::-moz-focus-inner {
+  border-style: none;
+  padding: 0;
+}
+
+.c1:-moz-focusring,
+.c1[type='button']:-moz-focusring,
+.c1[type='reset']:-moz-focusring,
+.c1[type='submit']:-moz-focusring {
+  outline: 1px dotted ButtonText;
+}
+
+.c13 {
+  font-family: inherit;
+  font-size: 100%;
+  line-height: 1.15;
+  margin: 0;
+  overflow: visible;
+  border: 0;
+  width: 100%;
+  padding: 8px;
+  margin: 0;
+  line-height: inherit;
+  box-sizing: border-box;
+  height: 40px;
+  border: solid;
+  border-color: #BCBCB6;
+  border-width: 1px;
+  position: relative;
+  background-color: #FFFFFF;
+}
+
+.c13:focus {
+  border-width: 1px;
+}
+
+.c13:hover {
+  border-color: #4B4B46;
+}
+
+.c13:focus {
+  border-color: #0046FF;
+}
+
+.c13::-webkit-input-placeholder {
+  color: #6E6E69;
+  line-height: inherit;
+  opacity: 1;
+}
+
+.c13::-moz-placeholder {
+  color: #6E6E69;
+  line-height: inherit;
+  opacity: 1;
+}
+
+.c13:-ms-input-placeholder {
+  color: #6E6E69;
+  line-height: inherit;
+  opacity: 1;
+}
+
+.c13::placeholder {
+  color: #6E6E69;
+  line-height: inherit;
+  opacity: 1;
+}
+
+.c13:disabled::-webkit-input-placeholder {
+  color: #A0A09B;
+}
+
+.c13:disabled::-moz-placeholder {
+  color: #A0A09B;
+}
+
+.c13:disabled:-ms-input-placeholder {
+  color: #A0A09B;
+}
+
+.c13:disabled::placeholder {
+  color: #A0A09B;
+}
+
+.c12 {
+  position: relative;
+  padding: 0px 0;
+}
+
+.c2 {
+  position: absolute;
+  top: 20px;
+  right: 20px;
+}
+
+.c5 {
+  overflow-y: auto;
+  overflow-x: hidden;
+  margin-bottom: 20px;
+  padding: 0 20px;
+}
+
+.c0 {
+  padding: 20px 20px 0 20px;
+  margin-bottom: 8px;
+  min-height: 20px;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+}
+
+.c7 {
+  width: 200px;
+  display: inline-block;
+}
+
+@media (min-width:760px) {
+
+}
+
+@media (min-width:760px) {
+
+}
+
+@media (min-width:1600px) {
+
+}
+
+@media (max-width:759px) {
+  .c5 {
+    padding: 0 12px;
+  }
+}
+
+@media (max-width:759px) {
+  .c0 {
+    padding: 20px 12px 0 12px;
+  }
+}
+
+<portal-dummy>
+    <div
+      data-focus-guard={true}
+      style={
+        Object {
+          "height": "0px",
+          "left": "1px",
+          "overflow": "hidden",
+          "padding": 0,
+          "position": "fixed",
+          "top": "1px",
+          "width": "1px",
+        }
+      }
+      tabIndex={0}
+    />
+    <div
+      data-focus-guard={true}
+      style={
+        Object {
+          "height": "0px",
+          "left": "1px",
+          "overflow": "hidden",
+          "padding": 0,
+          "position": "fixed",
+          "top": "1px",
+          "width": "1px",
+        }
+      }
+      tabIndex={1}
+    />
+    <div
+      data-focus-lock-disabled={false}
+      onBlur={[Function]}
+      onFocus={[Function]}
+    >
+      <div
+        onScrollCapture={[Function]}
+        onTouchMoveCapture={[Function]}
+        onWheelCapture={[Function]}
+      >
+        <div>
+          <div
+            className="c0"
+            onTouchStart={[Function]}
+          >
+            <button
+              className="NormalizedButton__Button-sc-ey7f5x-0 c1 c2"
+              onClick={[Function]}
+              type="button"
+            >
+              <span
+                className="c3"
+              >
+                <svg
+                  aria-hidden="true"
+                  className="c4"
+                  focusable="false"
+                  preserveAspectRatio="xMidYMid meet"
+                  role="presentation"
+                  viewBox="0 0 16 16"
+                >
+                  <path
+                    d="M6.857 8L0 1.143 1.143 0 8 6.857 14.857 0 16 1.143 9.143 8 16 14.857 14.857 16 8 9.143 1.143 16 0 14.857z"
+                    fillRule="evenodd"
+                  />
+                </svg>
+              </span>
+            </button>
+          </div>
+          <div
+            className="c5"
+          >
+            <div
+              className="c6"
+            >
+              <div
+                className="c7"
+              >
+                <label
+                  className="c8"
+                  hidden={false}
+                >
+                  <span
+                    className="c9"
+                  >
+                    <div
+                      className="c10"
+                    >
+                      Label 
+                    </div>
+                    <span
+                      className="c11"
+                    >
+                      <div
+                        className="c12"
+                      >
+                        <input
+                          className="NormalizedInput__Input-sc-1m4kmh9-0 c13"
+                          type="text"
+                          variant="normal"
+                        />
+                      </div>
+                    </span>
+                  </span>
+                </label>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      data-focus-guard={true}
+      style={
+        Object {
+          "height": "0px",
+          "left": "1px",
+          "overflow": "hidden",
+          "padding": 0,
+          "position": "fixed",
+          "top": "1px",
+          "width": "1px",
+        }
+      }
+      tabIndex={0}
+    />
+  </portal-dummy>,
+]
+`;
+
 exports[`Storyshots Molecules / Persistent Tooltip Styled Subcomponents 1`] = `
 Array [
   .c0 {
@@ -3575,7 +3997,7 @@ Array [
             className="c5"
           >
             <input
-              aria-describedby="nn-persistent-tooltip-24"
+              aria-describedby="nn-persistent-tooltip-30"
               className="NormalizedInput__Input-sc-1m4kmh9-0 c6"
               type="text"
               variant="normal"
@@ -3773,7 +4195,7 @@ Array [
 <portal-dummy>
     <span
       className="c0 c1 c2"
-      id="nn-persistent-tooltip-24"
+      id="nn-persistent-tooltip-30"
       style={
         Object {
           "left": "0",
@@ -4989,7 +5411,7 @@ Array [
       className="c1"
     >
       <span
-        aria-describedby="nn-persistent-tooltip-30"
+        aria-describedby="nn-persistent-tooltip-31"
       >
         <svg
           aria-hidden="true"
@@ -5008,7 +5430,7 @@ Array [
       <portal-dummy>
         <span
           className="c3 c4"
-          id="nn-persistent-tooltip-30"
+          id="nn-persistent-tooltip-31"
           style={
             Object {
               "left": "0",
@@ -5300,7 +5722,7 @@ Array [
       className="c1"
     >
       <div
-        aria-describedby="nn-persistent-tooltip-31"
+        aria-describedby="nn-persistent-tooltip-32"
       >
         <svg
           aria-hidden="true"
@@ -5319,7 +5741,7 @@ Array [
       <portal-dummy>
         <span
           className="c3 c4"
-          id="nn-persistent-tooltip-31"
+          id="nn-persistent-tooltip-32"
           style={
             Object {
               "left": "0",

--- a/src/Molecules/ShowMoreButton/__snapshots__/ShowMoreButton.stories.storyshot
+++ b/src/Molecules/ShowMoreButton/__snapshots__/ShowMoreButton.stories.storyshot
@@ -493,7 +493,7 @@ exports[`Storyshots Molecules / ShowMoreButton Loading 1`] = `
       >
         <defs>
           <linearGradient
-            id="spinner-72val-Spinner-1"
+            id="spinner-74val-Spinner-1"
             x1="50%"
             x2="50%"
             y1="0%"
@@ -511,7 +511,7 @@ exports[`Storyshots Molecules / ShowMoreButton Loading 1`] = `
             />
           </linearGradient>
           <linearGradient
-            id="spinner-72val-Spinner-2"
+            id="spinner-74val-Spinner-2"
             x1="50%"
             x2="50%"
             y1="0%"
@@ -534,11 +534,11 @@ exports[`Storyshots Molecules / ShowMoreButton Loading 1`] = `
         >
           <path
             d="M12,0 C18.627417,0 24,5.372583 24,12 C24,18.627417 18.627417,24 12,24 M12,21 C16.9705627,21 21,16.9705627 21,12 C21,7.02943725 16.9705627,3 12,3"
-            fill="url(#spinner-72val-Spinner-1)"
+            fill="url(#spinner-74val-Spinner-1)"
           />
           <path
             d="M0,0 C6.627417,0 12,5.372583 12,12 C12,18.627417 6.627417,24 0,24 M0,21 C4.97056275,21 9,16.9705627 9,12 C9,7.02943725 4.97056275,3 0,3"
-            fill="url(#spinner-72val-Spinner-2)"
+            fill="url(#spinner-74val-Spinner-2)"
             transform="rotate(-180 6 12)"
           />
         </g>

--- a/src/Molecules/Tooltip/Tooltip.tsx
+++ b/src/Molecules/Tooltip/Tooltip.tsx
@@ -19,6 +19,7 @@ import { useTooltip } from './hooks';
 export const Tooltip: TooltipComponent = forwardRef(
   (
     {
+      className,
       children,
       label,
       ariaLabel,
@@ -65,6 +66,7 @@ export const Tooltip: TooltipComponent = forwardRef(
 
         {isOpen && (
           <PopOver
+            className={className}
             id={id}
             ref={ref as any}
             triggerElement={triggerElement}

--- a/src/Molecules/Tooltip/__snapshots__/Tooltip.stories.storyshot
+++ b/src/Molecules/Tooltip/__snapshots__/Tooltip.stories.storyshot
@@ -242,7 +242,7 @@ Array [
       className="c1"
     >
       <div
-        aria-describedby="nn-tooltip-53"
+        aria-describedby="nn-tooltip-54"
         onBlur={[Function]}
         onFocus={[Function]}
         onKeyDown={[Function]}
@@ -268,7 +268,7 @@ Array [
       <portal-dummy>
         <span
           className="c3"
-          id="nn-tooltip-53"
+          id="nn-tooltip-54"
           style={
             Object {
               "left": "0",
@@ -1359,7 +1359,7 @@ Array [
       className="c1"
     >
       <span
-        aria-describedby="nn-tooltip-54"
+        aria-describedby="nn-tooltip-55"
         onBlur={[Function]}
         onFocus={[Function]}
         onKeyDown={[Function]}
@@ -1385,7 +1385,7 @@ Array [
       <portal-dummy>
         <span
           className="c3"
-          id="nn-tooltip-54"
+          id="nn-tooltip-55"
           style={
             Object {
               "left": "0",
@@ -1502,7 +1502,7 @@ Array [
       className="c1"
     >
       <div
-        aria-describedby="nn-tooltip-55"
+        aria-describedby="nn-tooltip-56"
         onBlur={[Function]}
         onFocus={[Function]}
         onKeyDown={[Function]}
@@ -1528,7 +1528,7 @@ Array [
       <portal-dummy>
         <span
           className="c3"
-          id="nn-tooltip-55"
+          id="nn-tooltip-56"
           style={
             Object {
               "left": "0",

--- a/src/common/PopOver/PopOver.tsx
+++ b/src/common/PopOver/PopOver.tsx
@@ -43,9 +43,10 @@ const components = {
   TooltipContent: StyledTooltipContent,
 };
 
-const PopOver = (forwardRef<HTMLSpanElement, Props>(
+const PopOver = forwardRef<HTMLSpanElement, Props>(
   (
     {
+      className,
       id,
       label,
       ariaLabel,
@@ -88,6 +89,7 @@ const PopOver = (forwardRef<HTMLSpanElement, Props>(
     return (
       <Portal>
         <StyledSpan
+          className={className}
           id={id}
           ref={mergeRefs([setPopperElement, ref])}
           $inModal={inModal}
@@ -114,7 +116,7 @@ const PopOver = (forwardRef<HTMLSpanElement, Props>(
       </Portal>
     );
   },
-) as any) as React.ForwardRefExoticComponent<Props & React.RefAttributes<HTMLSpanElement>> & {
+) as any as React.ForwardRefExoticComponent<Props & React.RefAttributes<HTMLSpanElement>> & {
   components: typeof components;
 };
 

--- a/src/common/PopOver/PopOver.types.ts
+++ b/src/common/PopOver/PopOver.types.ts
@@ -17,6 +17,7 @@ export type Position =
   | 'left-end';
 
 export type Props = {
+  className?: string;
   id?: string;
   label: React.ReactNode;
   position?: Position;


### PR DESCRIPTION
ClassName wasn't properly passed through for tooltip components, causing
TS error when trying to style specialized components with
styled-components.