### PR TITLE
feat: 🎸 change Badge sub-component naming convention

### DIFF
--- a/src/Molecules/Badge/Badge.md
+++ b/src/Molecules/Badge/Badge.md
@@ -10,14 +10,14 @@ The BaseBadge is flexible and exposed externally as Badge, and all the other bad
 
 ❗❗ `<Badge>` should only be used directly as a last resort if none of the other badge components covers your intended use case. Consider implementing a new sub badge component if design requires.
 
-### Account Badge (Badge.AccountBadge)
+### Account Badge (Badge.Account)
 
-This replaces the deprecated `Avatar` component, and is used to display a representation of an entity (e.g. a bank, an account type, etc.).
+Account Badge is used to display a representation of an entity (e.g. a bank, an account type, etc.).
 
 - `badgeColor` - a theme color function used to set the color for the background/badge.
 - `badgeSize` - sets the width/height (symmetric ratio) of the badge. Available sizes are: `'l'`: 48px, `'m'`: 32px, `'s'`: 24px.
 
-### Icon Badge (Badge.IconBadge)
+### Icon Badge (Badge.Icon)
 
 Badge with an `Icon` or `Illustration`. Used to bring flair or bring attention to something.
 
@@ -25,7 +25,7 @@ Badge with an `Icon` or `Illustration`. Used to bring flair or bring attention t
 - `badgeSize` - sets the width/height (symmetric ratio) of the badge. Available sizes are: `'xl'`: 80px, `'l'`: 48px, `'m'`: 40px, `'s'`: 32px.
 - `children` - the `Icon`- or `Illustration`- component.
 
-### Label Badge (Badge.LabelBadge)
+### Label Badge (Badge.Label)
 
 Brings attention to a property on a page entity.
 
@@ -35,7 +35,7 @@ Brings attention to a property on a page entity.
 - `weight` - sets the font weight.
 - `children` - the badge's text content.
 
-### Notification Badge (Badge.NotificationBadge)
+### Notification Badge (Badge.Notification)
 
 Used to display user notifications. Displays the notification as a badge with numbers or as a dot.
 If the `badgeSize` is `xs` the badge cannot have children.
@@ -47,7 +47,7 @@ If the `badgeSize` is `xs` the badge cannot have children.
 - `symmetricShape` - forces the component to be symmetrical. i.e round.
 - `children` - the number of notifications.
 
-### Status Badge (Badge.StatusBadge)
+### Status Badge (Badge.Status)
 
 The Status Badge is used for displaying the statuses like `'create'`, `'complete'`, `'pending',` `'error'`, `'warning'` or `'information'`.
 The status can be passed in as a `string` to `variant` which will render the corresponding `icon` and `badgeColor`.
@@ -55,10 +55,10 @@ The status can be passed in as a `string` to `variant` which will render the cor
 - `badgeSize` - sets the width/height on the badge. Available sizes: `'xl'`: 72px `'l'`: 48px `'m'`: 32px `'s'`: 24px.
 - `variant` - status as a string. Statuses are: `'create'`, `'complete'`, `'pending',` `'error'`, `'warning'` or `'information'`.
 
-### Tooltip Badge (Badge.TooltipBadge)
+### Tooltip Badge (Badge.Tooltip)
 
-TooltipBadge is used to display a clickable/hoverable badge for displaying additonal information in a `Tooltip` or a `Drawer`.
-Consumer have to wrap TooltipBadge in a Tooltip or define their own onClick function.
+Tooltip is used to display a clickable/hoverable badge for displaying additonal information in a `Tooltip` or a `Drawer`.
+Consumer have to wrap Tooltip in a Tooltip or define their own onClick function.
 If the `onClick` prop is passed in to the component, it will add styling to cursor and highlight the badge.
 
 - `badgeSize` - sets the width/height on the badge. Available sizes: `'l'`: 24px `'s'`: 16px.

--- a/src/Molecules/Badge/Badge.ts
+++ b/src/Molecules/Badge/Badge.ts
@@ -12,9 +12,9 @@ import {
 // Typecasts to attach sub badge components below
 export const Badge = BaseBadge as BadgeComponent;
 
-Badge.IconBadge = IconBadge;
-Badge.StatusBadge = StatusBadge;
-Badge.LabelBadge = LabelBadge;
-Badge.NotificationBadge = NotificationBadge;
-Badge.AccountBadge = AccountBadge;
-Badge.TooltipBadge = TooltipBadge;
+Badge.Icon = IconBadge;
+Badge.Status = StatusBadge;
+Badge.Label = LabelBadge;
+Badge.Notification = NotificationBadge;
+Badge.Account = AccountBadge;
+Badge.Tooltip = TooltipBadge;

--- a/src/Molecules/Badge/Badge.types.ts
+++ b/src/Molecules/Badge/Badge.types.ts
@@ -7,12 +7,12 @@ import { AccountBadgeComponent } from './components/AccountBadge/AccountBadge.ty
 import { TooltipBadgeComponent } from './components/TooltipBadge/TooltipBadge.types';
 
 type BadgeVariants = {
-  LabelBadge: LabelBadgeComponent;
-  IconBadge: IconBadgeComponent;
-  StatusBadge: StatusBadgeComponent;
-  NotificationBadge: NotificationBadgeComponent;
-  AccountBadge: AccountBadgeComponent;
-  TooltipBadge: TooltipBadgeComponent;
+  Label: LabelBadgeComponent;
+  Icon: IconBadgeComponent;
+  Status: StatusBadgeComponent;
+  Notification: NotificationBadgeComponent;
+  Account: AccountBadgeComponent;
+  Tooltip: TooltipBadgeComponent;
 };
 
 export type BadgeComponent = BaseBadgeComponent & BadgeVariants;

--- a/src/Molecules/Badge/components/AccountBadge/AccountBadge.stories.tsx
+++ b/src/Molecules/Badge/components/AccountBadge/AccountBadge.stories.tsx
@@ -5,42 +5,42 @@ import { Flexbox, Typography } from '../../../..';
 import Badge from '../..';
 
 export default {
-  title: 'Molecules / Badge / AccountBadge',
+  title: 'Molecules / Badge / Account',
   parameters: {
-    component: Badge.AccountBadge,
+    component: Badge.Account,
   },
 };
 
 export const Showcase = () => (
   <Flexbox container>
     <Flexbox container direction="column">
-      <Badge.AccountBadge badgeSize="l">ISK</Badge.AccountBadge>
-      <Badge.AccountBadge badgeSize="m">ISK</Badge.AccountBadge>
-      <Badge.AccountBadge badgeSize="s">ISK</Badge.AccountBadge>
+      <Badge.Account badgeSize="l">ISK</Badge.Account>
+      <Badge.Account badgeSize="m">ISK</Badge.Account>
+      <Badge.Account badgeSize="s">ISK</Badge.Account>
     </Flexbox>
 
     <Flexbox container direction="column">
-      <Badge.AccountBadge badgeColor={(t) => t.color.badgeBackgroundPositive} badgeSize="l">
+      <Badge.Account badgeColor={(t) => t.color.badgeBackgroundPositive} badgeSize="l">
         SEB
-      </Badge.AccountBadge>
-      <Badge.AccountBadge badgeColor={(t) => t.color.badgeBackgroundPositive} badgeSize="m">
+      </Badge.Account>
+      <Badge.Account badgeColor={(t) => t.color.badgeBackgroundPositive} badgeSize="m">
         SEB
-      </Badge.AccountBadge>
-      <Badge.AccountBadge badgeColor={(t) => t.color.badgeBackgroundPositive} badgeSize="s">
+      </Badge.Account>
+      <Badge.Account badgeColor={(t) => t.color.badgeBackgroundPositive} badgeSize="s">
         SEB
-      </Badge.AccountBadge>
+      </Badge.Account>
     </Flexbox>
 
     <Flexbox container direction="column">
-      <Badge.AccountBadge badgeColor={(t) => t.color.badgeBackground} badgeSize="l">
+      <Badge.Account badgeColor={(t) => t.color.badgeBackground} badgeSize="l">
         Handels
-      </Badge.AccountBadge>
-      <Badge.AccountBadge badgeColor={(t) => t.color.badgeBackground} badgeSize="m">
+      </Badge.Account>
+      <Badge.Account badgeColor={(t) => t.color.badgeBackground} badgeSize="m">
         HB
-      </Badge.AccountBadge>
-      <Badge.AccountBadge badgeColor={(t) => t.color.badgeBackground} badgeSize="s">
+      </Badge.Account>
+      <Badge.Account badgeColor={(t) => t.color.badgeBackground} badgeSize="s">
         HB
-      </Badge.AccountBadge>
+      </Badge.Account>
     </Flexbox>
   </Flexbox>
 );
@@ -59,19 +59,19 @@ export const CustomChildren = () => (
       {
         title: 'Typography as child',
         component: (
-          <Badge.AccountBadge>
+          <Badge.Account>
             <Typography color={(t) => t.color.badgeTextColor} type="caption">
               KF
             </Typography>
-          </Badge.AccountBadge>
+          </Badge.Account>
         ),
       },
       {
         title: 'Styled typography as child',
         component: (
-          <Badge.AccountBadge>
+          <Badge.Account>
             <StyledTypography>ASK</StyledTypography>
-          </Badge.AccountBadge>
+          </Badge.Account>
         ),
       },
     ]}

--- a/src/Molecules/Badge/components/AccountBadge/__snapshots__/AccountBadge.stories.storyshot
+++ b/src/Molecules/Badge/components/AccountBadge/__snapshots__/AccountBadge.stories.storyshot
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Storyshots Molecules / Badge / AccountBadge Custom children 1`] = `
+exports[`Storyshots Molecules / Badge / Account Custom children 1`] = `
 .c3 {
   font-family: 'Nordnet Sans Mono',-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
   color: #282823;
@@ -159,7 +159,7 @@ exports[`Storyshots Molecules / Badge / AccountBadge Custom children 1`] = `
 </div>
 `;
 
-exports[`Storyshots Molecules / Badge / AccountBadge Showcase 1`] = `
+exports[`Storyshots Molecules / Badge / Account Showcase 1`] = `
 .c0 {
   box-sizing: border-box;
   display: -webkit-box;

--- a/src/Molecules/Badge/components/IconBadge/IconBadge.stories.tsx
+++ b/src/Molecules/Badge/components/IconBadge/IconBadge.stories.tsx
@@ -4,9 +4,9 @@ import Badge from '../..';
 import { Display } from '../../../../common/Display';
 
 export default {
-  title: 'Molecules / Badge / IconBadge',
+  title: 'Molecules / Badge / Icon',
   parameters: {
-    component: Badge.IconBadge,
+    component: Badge.Icon,
   },
 };
 
@@ -17,46 +17,46 @@ export const DefaultAndCommonUseCases = () => {
         {
           title: 'Default use',
           component: (
-            <Badge.IconBadge>
+            <Badge.Icon>
               <Icon.Add8 />
-            </Badge.IconBadge>
+            </Badge.Icon>
           ),
         },
         {
           title: 'Custom icon badge with custom props',
           component: (
-            <Badge.IconBadge badgeColor={(t) => t.color.bulbBackground} badgeSize="l">
+            <Badge.Icon badgeColor={(t) => t.color.bulbBackground} badgeSize="l">
               <Icon.Lightbulb24 color={(t) => t.color.bulbForeground} />
-            </Badge.IconBadge>
+            </Badge.Icon>
           ),
         },
         {
           title: 'Custom icon badge size',
           component: (
-            <Badge.IconBadge badgeColor={(t) => t.color.bulbBackground} badgeSize={30}>
+            <Badge.Icon badgeColor={(t) => t.color.bulbBackground} badgeSize={30}>
               <Icon.Lightbulb24 color={(t) => t.color.bulbForeground} />
-            </Badge.IconBadge>
+            </Badge.Icon>
           ),
         },
         {
           title: 'Badge with illustration default use',
           component: (
-            <Badge.IconBadge badgeSize="xl">
+            <Badge.Icon badgeSize="xl">
               <Illustration.UrgentMailFill64 />
-            </Badge.IconBadge>
+            </Badge.Icon>
           ),
         },
         {
           title: 'Badge with illustration with custom props',
           component: (
-            <Badge.IconBadge badgeSize="xl">
+            <Badge.Icon badgeSize="xl">
               <span>
                 <Illustration.UrgentMailFill64
                   color={(t) => t.color.badgeIconColor}
                   secondaryColor={(t) => t.color.warning}
                 />
               </span>
-            </Badge.IconBadge>
+            </Badge.Icon>
           ),
         },
       ]}

--- a/src/Molecules/Badge/components/IconBadge/__snapshots__/IconBadge.stories.storyshot
+++ b/src/Molecules/Badge/components/IconBadge/__snapshots__/IconBadge.stories.storyshot
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Storyshots Molecules / Badge / IconBadge Default and common use cases 1`] = `
+exports[`Storyshots Molecules / Badge / Icon Default and common use cases 1`] = `
 .c5 {
   color: #212121;
   -webkit-user-select: none;

--- a/src/Molecules/Badge/components/LabelBadge/LabelBadge.stories.tsx
+++ b/src/Molecules/Badge/components/LabelBadge/LabelBadge.stories.tsx
@@ -3,9 +3,9 @@ import Badge from '../..';
 import { Display } from '../../../../common/Display';
 
 export default {
-  title: 'Molecules / Badge / LabelBadge',
+  title: 'Molecules / Badge / Label',
   parameters: {
-    component: Badge.LabelBadge,
+    component: Badge.Label,
   },
 };
 
@@ -15,37 +15,35 @@ export const Showcase = () => {
       items={[
         {
           title: 'Primary',
-          component: <Badge.LabelBadge>Primary</Badge.LabelBadge>,
+          component: <Badge.Label>Primary</Badge.Label>,
         },
         {
           title: 'Primary Bold',
-          component: <Badge.LabelBadge weight="bold">Primary Bold</Badge.LabelBadge>,
+          component: <Badge.Label weight="bold">Primary Bold</Badge.Label>,
         },
         {
           title: 'Secondary',
-          component: <Badge.LabelBadge type="secondary">Secondary</Badge.LabelBadge>,
+          component: <Badge.Label type="secondary">Secondary</Badge.Label>,
         },
         {
           title: 'Secondary Bold',
           component: (
-            <Badge.LabelBadge type="secondary" weight="bold">
+            <Badge.Label type="secondary" weight="bold">
               Secondary Bold
-            </Badge.LabelBadge>
+            </Badge.Label>
           ),
         },
         {
           title: 'Custom badge color',
           component: (
-            <Badge.LabelBadge badgeColor={(t) => t.color.badgeBackgroundNegative}>
+            <Badge.Label badgeColor={(t) => t.color.badgeBackgroundNegative}>
               Custom badge color
-            </Badge.LabelBadge>
+            </Badge.Label>
           ),
         },
         {
           title: 'Custom text color',
-          component: (
-            <Badge.LabelBadge color={(t) => t.color.warning}>Custom text color</Badge.LabelBadge>
-          ),
+          component: <Badge.Label color={(t) => t.color.warning}>Custom text color</Badge.Label>,
         },
       ]}
     />

--- a/src/Molecules/Badge/components/LabelBadge/__snapshots__/LabelBadge.stories.storyshot
+++ b/src/Molecules/Badge/components/LabelBadge/__snapshots__/LabelBadge.stories.storyshot
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Storyshots Molecules / Badge / LabelBadge Showcase 1`] = `
+exports[`Storyshots Molecules / Badge / Label Showcase 1`] = `
 .c3 {
   font-family: 'Nordnet Sans Mono',-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
   color: #282823;

--- a/src/Molecules/Badge/components/NotificationBadge/NotificationBadge.stories.tsx
+++ b/src/Molecules/Badge/components/NotificationBadge/NotificationBadge.stories.tsx
@@ -6,9 +6,9 @@ import Badge from '../..';
 import { numberWithLimit } from '../../../../common/utils';
 
 export default {
-  title: 'Molecules / Badge / NotificationBadge',
+  title: 'Molecules / Badge / Notification',
   parameters: {
-    component: Badge.NotificationBadge,
+    component: Badge.Notification,
   },
 };
 
@@ -17,20 +17,20 @@ export const Showcase = () => (
     items={[
       {
         title: 'Default Notification Badge',
-        component: <Badge.NotificationBadge>1</Badge.NotificationBadge>,
+        component: <Badge.Notification>1</Badge.Notification>,
       },
       {
         title: 'Badge with different sizes',
         component: (
           <>
             <Box mb={1}>
-              <Badge.NotificationBadge badgeSize="s">1</Badge.NotificationBadge>
+              <Badge.Notification badgeSize="s">1</Badge.Notification>
             </Box>
             <Box mb={1}>
-              <Badge.NotificationBadge badgeSize="m">2</Badge.NotificationBadge>
+              <Badge.Notification badgeSize="m">2</Badge.Notification>
             </Box>
             <Box mb={1}>
-              <Badge.NotificationBadge badgeSize="l">3</Badge.NotificationBadge>
+              <Badge.Notification badgeSize="l">3</Badge.Notification>
             </Box>
           </>
         ),
@@ -40,19 +40,19 @@ export const Showcase = () => (
         component: (
           <>
             <Box mb={1}>
-              <Badge.NotificationBadge badgeColor={(t) => t.color.badgeBackgroundPositive}>
+              <Badge.Notification badgeColor={(t) => t.color.badgeBackgroundPositive}>
                 2
-              </Badge.NotificationBadge>
+              </Badge.Notification>
             </Box>
             <Box mb={1}>
-              <Badge.NotificationBadge badgeColor={(t) => t.color.badgeBackgroundNegative}>
+              <Badge.Notification badgeColor={(t) => t.color.badgeBackgroundNegative}>
                 3
-              </Badge.NotificationBadge>
+              </Badge.Notification>
             </Box>
             <Box mb={1}>
-              <Badge.NotificationBadge badgeColor={(t) => t.color.badgeBackgroundWarning}>
+              <Badge.Notification badgeColor={(t) => t.color.badgeBackgroundWarning}>
                 4
-              </Badge.NotificationBadge>
+              </Badge.Notification>
             </Box>
           </>
         ),
@@ -62,22 +62,22 @@ export const Showcase = () => (
         component: (
           <>
             <Box mb={1}>
-              <Badge.NotificationBadge badgeSize="xs" />
+              <Badge.Notification badgeSize="xs" />
             </Box>
             <Box mb={1}>
-              <Badge.NotificationBadge
+              <Badge.Notification
                 badgeColor={(t) => t.color.badgeBackgroundPositive}
                 badgeSize="xs"
               />
             </Box>
             <Box mb={1}>
-              <Badge.NotificationBadge
+              <Badge.Notification
                 badgeColor={(t) => t.color.badgeBackgroundNegative}
                 badgeSize="xs"
               />
             </Box>
             <Box mb={1}>
-              <Badge.NotificationBadge
+              <Badge.Notification
                 badgeColor={(t) => t.color.badgeBackgroundWarning}
                 badgeSize="xs"
               />
@@ -87,22 +87,20 @@ export const Showcase = () => (
       },
       {
         title: 'Custom text color',
-        component: (
-          <Badge.NotificationBadge color={(t) => t.color.warning}>5</Badge.NotificationBadge>
-        ),
+        component: <Badge.Notification color={(t) => t.color.warning}>5</Badge.Notification>,
       },
       {
         title: 'Badge with large number',
         component: (
           <>
             <Box mb={1}>
-              <Badge.NotificationBadge badgeSize="s">99</Badge.NotificationBadge>
+              <Badge.Notification badgeSize="s">99</Badge.Notification>
             </Box>
             <Box mb={1}>
-              <Badge.NotificationBadge>99</Badge.NotificationBadge>
+              <Badge.Notification>99</Badge.Notification>
             </Box>
             <Box mb={1}>
-              <Badge.NotificationBadge>123</Badge.NotificationBadge>
+              <Badge.Notification>123</Badge.Notification>
             </Box>
           </>
         ),
@@ -120,16 +118,14 @@ export const CommonUseCases = () => {
       items={[
         {
           title: 'Number with limit',
-          component: (
-            <Badge.NotificationBadge>{numberWithLimit(1234567, 99)}</Badge.NotificationBadge>
-          ),
+          component: <Badge.Notification>{numberWithLimit(1234567, 99)}</Badge.Notification>,
         },
         {
           title: 'Text with Badge',
           component: (
             <Box my={2}>
               <Typography>
-                Orders <Badge.NotificationBadge>7</Badge.NotificationBadge>
+                Orders <Badge.Notification>7</Badge.Notification>
               </Typography>
             </Box>
           ),
@@ -139,18 +135,18 @@ export const CommonUseCases = () => {
           component: (
             <Box my={2}>
               <Box my={2}>
-                <Badge.NotificationBadge badgeSize="xs" />
+                <Badge.Notification badgeSize="xs" />
                 <Typography type="tertiary"> Buy order</Typography>
               </Box>
               <Box my={2}>
-                <Badge.NotificationBadge
+                <Badge.Notification
                   badgeSize="xs"
                   badgeColor={(t) => t.color.badgeBackgroundNegative}
                 />
                 <Typography type="tertiary"> Sell order</Typography>
               </Box>
               <Box my={2}>
-                <Badge.NotificationBadge
+                <Badge.Notification
                   badgeSize="xs"
                   badgeColor={(t) => t.color.badgeBackgroundWarning}
                 />
@@ -164,8 +160,7 @@ export const CommonUseCases = () => {
           component: (
             <Box my={2}>
               <Typography>
-                Orders{' '}
-                <Badge.NotificationBadge aria-label="7 new orders">7</Badge.NotificationBadge>
+                Orders <Badge.Notification aria-label="7 new orders">7</Badge.Notification>
               </Typography>
             </Box>
           ),
@@ -175,7 +170,7 @@ export const CommonUseCases = () => {
           component: (
             <Box my={2}>
               <Typography>
-                Orders <Badge.NotificationBadge>7</Badge.NotificationBadge>
+                Orders <Badge.Notification>7</Badge.Notification>
               </Typography>
             </Box>
           ),
@@ -196,7 +191,7 @@ export const SpecializedChildren = () => {
           title: 'Component as child',
           component: (
             <Box my={2}>
-              <Badge.NotificationBadge color={(t) => t.color.badgeTextColor}>
+              <Badge.Notification color={(t) => t.color.badgeTextColor}>
                 <>
                   <Typography type="title3" color={(t) => t.color.badgeTextColor}>
                     8
@@ -205,7 +200,7 @@ export const SpecializedChildren = () => {
                     %
                   </Typography>
                 </>
-              </Badge.NotificationBadge>
+              </Badge.Notification>
               <Typography as="p" type="caption">
                 * It&apos;s up to developer to set child component font (family, size, etc.)
               </Typography>
@@ -216,13 +211,13 @@ export const SpecializedChildren = () => {
           title: 'Function as child',
           component: (
             <Box my={2}>
-              <Badge.NotificationBadge color={(t) => t.color.badgeTextColor}>
+              <Badge.Notification color={(t) => t.color.badgeTextColor}>
                 {() => (
                   <Typography type="tertiary" color={(t) => t.color.badgeTextColor}>
                     9%
                   </Typography>
                 )}
-              </Badge.NotificationBadge>
+              </Badge.Notification>
               <Typography as="p" type="caption">
                 * It&apos;s up to developer to set child function font (family, size, etc.)
               </Typography>
@@ -260,9 +255,9 @@ export const BadgeWithAnimation = () => {
                 >
                   -
                 </Button>
-                <Badge.NotificationBadge key={notificationsExampleOne} animateOnChange>
+                <Badge.Notification key={notificationsExampleOne} animateOnChange>
                   {notificationsExampleOne}
-                </Badge.NotificationBadge>
+                </Badge.Notification>
                 <Button
                   variant="secondary"
                   onClick={() => setNotificationsExampleOne(notificationsExampleOne + 1)}
@@ -287,12 +282,12 @@ export const BadgeWithAnimation = () => {
                 >
                   -
                 </Button>
-                <Badge.NotificationBadge
+                <Badge.Notification
                   key={notificationsExampleTwo}
                   animateOnChange={isNewNotifications}
                 >
                   {notificationsExampleTwo}
-                </Badge.NotificationBadge>
+                </Badge.Notification>
                 <Button
                   variant="secondary"
                   onClick={() => {

--- a/src/Molecules/Badge/components/NotificationBadge/__snapshots__/NotificationBadge.stories.storyshot
+++ b/src/Molecules/Badge/components/NotificationBadge/__snapshots__/NotificationBadge.stories.storyshot
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Storyshots Molecules / Badge / NotificationBadge Badge with animation 1`] = `
+exports[`Storyshots Molecules / Badge / Notification Badge with animation 1`] = `
 .c4 {
   padding-top: 12px;
   padding-bottom: 12px;
@@ -342,7 +342,7 @@ exports[`Storyshots Molecules / Badge / NotificationBadge Badge with animation 1
 </div>
 `;
 
-exports[`Storyshots Molecules / Badge / NotificationBadge Common use cases 1`] = `
+exports[`Storyshots Molecules / Badge / Notification Common use cases 1`] = `
 .c7 {
   margin-top: 8px;
   margin-bottom: 8px;
@@ -660,8 +660,7 @@ exports[`Storyshots Molecules / Badge / NotificationBadge Common use cases 1`] =
         <span
           className="c3"
         >
-          Orders
-           
+          Orders 
           <span
             aria-label="7 new orders"
             className="c4 c5"
@@ -713,7 +712,7 @@ exports[`Storyshots Molecules / Badge / NotificationBadge Common use cases 1`] =
 </div>
 `;
 
-exports[`Storyshots Molecules / Badge / NotificationBadge Showcase 1`] = `
+exports[`Storyshots Molecules / Badge / Notification Showcase 1`] = `
 .c7 {
   margin-bottom: 4px;
   background-color: transparent;
@@ -1305,7 +1304,7 @@ exports[`Storyshots Molecules / Badge / NotificationBadge Showcase 1`] = `
 </div>
 `;
 
-exports[`Storyshots Molecules / Badge / NotificationBadge Specialized children 1`] = `
+exports[`Storyshots Molecules / Badge / Notification Specialized children 1`] = `
 .c4 {
   margin-top: 8px;
   margin-bottom: 8px;

--- a/src/Molecules/Badge/components/StatusBadge/StatusBadge.stories.tsx
+++ b/src/Molecules/Badge/components/StatusBadge/StatusBadge.stories.tsx
@@ -4,9 +4,9 @@ import FeedbackBanner from '../../../FeedbackBanner';
 import { Box, Flexbox, Typography } from '../../../..';
 
 export default {
-  title: 'Molecules / Badge / StatusBadge',
+  title: 'Molecules / Badge / Status',
   parameters: {
-    component: Badge.StatusBadge,
+    component: Badge.Status,
   },
 };
 
@@ -15,7 +15,7 @@ export const InformationStatusBadge = () => (
     <Box mb={4}>
       <Typography type="title2">Default Status Badge</Typography>
       <Box>
-        <Badge.StatusBadge />
+        <Badge.Status />
       </Box>
     </Box>
     <Box mb={4}>
@@ -26,45 +26,45 @@ export const InformationStatusBadge = () => (
     </Box>
     <Flexbox container>
       <Flexbox container direction="column">
-        <Badge.StatusBadge variant="create" badgeSize="xl" />
-        <Badge.StatusBadge variant="create" badgeSize="l" />
-        <Badge.StatusBadge variant="create" badgeSize="m" />
-        <Badge.StatusBadge variant="create" badgeSize="s" />
+        <Badge.Status variant="create" badgeSize="xl" />
+        <Badge.Status variant="create" badgeSize="l" />
+        <Badge.Status variant="create" badgeSize="m" />
+        <Badge.Status variant="create" badgeSize="s" />
       </Flexbox>
 
       <Flexbox container direction="column">
-        <Badge.StatusBadge variant="complete" badgeSize="xl" />
-        <Badge.StatusBadge variant="complete" badgeSize="l" />
-        <Badge.StatusBadge variant="complete" badgeSize="m" />
-        <Badge.StatusBadge variant="complete" badgeSize="s" />
+        <Badge.Status variant="complete" badgeSize="xl" />
+        <Badge.Status variant="complete" badgeSize="l" />
+        <Badge.Status variant="complete" badgeSize="m" />
+        <Badge.Status variant="complete" badgeSize="s" />
       </Flexbox>
 
       <Flexbox container direction="column">
-        <Badge.StatusBadge variant="pending" badgeSize="xl" />
-        <Badge.StatusBadge variant="pending" badgeSize="l" />
-        <Badge.StatusBadge variant="pending" badgeSize="m" />
-        <Badge.StatusBadge variant="pending" badgeSize="s" />
+        <Badge.Status variant="pending" badgeSize="xl" />
+        <Badge.Status variant="pending" badgeSize="l" />
+        <Badge.Status variant="pending" badgeSize="m" />
+        <Badge.Status variant="pending" badgeSize="s" />
       </Flexbox>
 
       <Flexbox container direction="column">
-        <Badge.StatusBadge variant="error" badgeSize="xl" />
-        <Badge.StatusBadge variant="error" badgeSize="l" />
-        <Badge.StatusBadge variant="error" badgeSize="m" />
-        <Badge.StatusBadge variant="error" badgeSize="s" />
+        <Badge.Status variant="error" badgeSize="xl" />
+        <Badge.Status variant="error" badgeSize="l" />
+        <Badge.Status variant="error" badgeSize="m" />
+        <Badge.Status variant="error" badgeSize="s" />
       </Flexbox>
 
       <Flexbox container direction="column">
-        <Badge.StatusBadge variant="warning" badgeSize="xl" />
-        <Badge.StatusBadge variant="warning" badgeSize="l" />
-        <Badge.StatusBadge variant="warning" badgeSize="m" />
-        <Badge.StatusBadge variant="warning" badgeSize="s" />
+        <Badge.Status variant="warning" badgeSize="xl" />
+        <Badge.Status variant="warning" badgeSize="l" />
+        <Badge.Status variant="warning" badgeSize="m" />
+        <Badge.Status variant="warning" badgeSize="s" />
       </Flexbox>
 
       <Flexbox container direction="column">
-        <Badge.StatusBadge variant="information" badgeSize="xl" />
-        <Badge.StatusBadge variant="information" badgeSize="l" />
-        <Badge.StatusBadge variant="information" badgeSize="m" />
-        <Badge.StatusBadge variant="information" badgeSize="s" />
+        <Badge.Status variant="information" badgeSize="xl" />
+        <Badge.Status variant="information" badgeSize="l" />
+        <Badge.Status variant="information" badgeSize="m" />
+        <Badge.Status variant="information" badgeSize="s" />
       </Flexbox>
     </Flexbox>
   </>

--- a/src/Molecules/Badge/components/StatusBadge/__snapshots__/StatusBadge.stories.storyshot
+++ b/src/Molecules/Badge/components/StatusBadge/__snapshots__/StatusBadge.stories.storyshot
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Storyshots Molecules / Badge / StatusBadge Default and all combinations 1`] = `
+exports[`Storyshots Molecules / Badge / Status Default and all combinations 1`] = `
 Array [
   .c0 {
   margin-bottom: 16px;

--- a/src/Molecules/Badge/components/TooltipBadge/TooltipBadge.stories.tsx
+++ b/src/Molecules/Badge/components/TooltipBadge/TooltipBadge.stories.tsx
@@ -6,9 +6,9 @@ import Badge from '../..';
 import { Display } from '../../../../common/Display';
 
 export default {
-  title: 'Molecules / Badge / TooltipBadge',
+  title: 'Molecules / Badge / Tooltip',
   parameters: {
-    component: Badge.TooltipBadge,
+    component: Badge.Tooltip,
   },
 };
 
@@ -29,46 +29,46 @@ export const DefaultUse = () => {
       items={[
         {
           title: 'Small Tooltip Badge',
-          component: <Badge.TooltipBadge badgeSize="s" />,
+          component: <Badge.Tooltip badgeSize="s" />,
         },
         {
           title: 'Small Tooltip Badge – Tooltip on hover',
           component: (
             <Tooltip label={label} position="top">
-              <Badge.TooltipBadge badgeSize="s" />
+              <Badge.Tooltip badgeSize="s" />
             </Tooltip>
           ),
         },
         {
           title: 'Large Tooltip Badge',
-          component: <Badge.TooltipBadge badgeSize="l" />,
+          component: <Badge.Tooltip badgeSize="l" />,
         },
         {
           title: 'Large Tooltip Badge – Tooltip on hover',
           component: (
             <>
               <Tooltip label={label} position="top">
-                <Badge.TooltipBadge />
+                <Badge.Tooltip />
               </Tooltip>
             </>
           ),
         },
         {
           title: 'Large Tooltip Badge – onClick action',
-          component: <Badge.TooltipBadge badgeSize="l" onClick={action('TooltipBadge clicked')} />,
+          component: <Badge.Tooltip badgeSize="l" onClick={action('TooltipBadge clicked')} />,
         },
         {
           title: 'Large Tooltip Badge – onClick opens drawer',
           component: (
             <>
-              <Badge.TooltipBadge
+              <Badge.Tooltip
                 badgeSize="l"
                 onClick={() => toggleDrawer()}
                 data-drawer-prevent-click-outside
               />
               <Drawer onClose={closeDrawer} title="TooltipBadge with hover in Drawer" open={open}>
                 <Tooltip label="Extra information goes here" position="top">
-                  <Badge.TooltipBadge />
+                  <Badge.Tooltip />
                 </Tooltip>
               </Drawer>
             </>

--- a/src/Molecules/Badge/components/TooltipBadge/__snapshots__/TooltipBadge.stories.storyshot
+++ b/src/Molecules/Badge/components/TooltipBadge/__snapshots__/TooltipBadge.stories.storyshot
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Storyshots Molecules / Badge / TooltipBadge Default and common use cases 1`] = `
+exports[`Storyshots Molecules / Badge / Tooltip Default and common use cases 1`] = `
 .c3 {
   font-family: 'Nordnet Sans Mono',-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
   color: #282823;

--- a/src/Molecules/Input/Select/Select.stories.tsx
+++ b/src/Molecules/Input/Select/Select.stories.tsx
@@ -128,7 +128,7 @@ const AccountValue = () => {
       ) : (
         <Flexbox container item justifyContent="space-between" gutter={2} grow={1}>
           <Flexbox item container alignItems="center" basis="32px" grow={0}>
-            <Badge.AccountBadge badgeSize="s">{selectedOption.symbol}</Badge.AccountBadge>
+            <Badge.Account badgeSize="s">{selectedOption.symbol}</Badge.Account>
           </Flexbox>
           <Flexbox item container alignItems="center" grow={1}>
             <Typography type="tertiary" weight="bold" color={(t) => t.color.text}>
@@ -168,7 +168,7 @@ const AccountListItem = ({ index }) => {
     <StyledBox px={2} py={1} focused={focused} isKeyboardNavigation={isKeyboardNavigation}>
       <Flexbox container justifyContent="space-between" gutter={4}>
         <Flexbox item container alignItems="center" basis="32px" grow={0}>
-          <Badge.AccountBadge badgeSize="s">{option.symbol}</Badge.AccountBadge>
+          <Badge.Account badgeSize="s">{option.symbol}</Badge.Account>
         </Flexbox>
         <Flexbox item container direction="column" grow={1}>
           <Flexbox item>


### PR DESCRIPTION
Changed from <Badge.LabelBadge> to <Badge.Label>

co-authors: Anton Bergwall

BREAKING CHANGE: 🧨 Modify Badge sub-component naming convention to use e.g. <Badge.Label>
instead of <Badge.LabelBadge>