### PR TITLE
fix: 🐛 use scroll-into-view-if-needed to solve bug on ios

### DIFF
--- a/src/Molecules/TabsNav/TabsNav.tsx
+++ b/src/Molecules/TabsNav/TabsNav.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback } from 'react';
 import styled from 'styled-components';
+import scrollIntoView, { StandardBehaviorOptions } from 'scroll-into-view-if-needed';
 import { Component, ItemProps, ScrollStyleProps, TitleProps } from './TabsNav.types';
 import { scrollStyles } from './TabsNav.styles';
 import { useIntersect } from '../../common/Hooks';
@@ -16,7 +17,7 @@ const DEFAULT_SCROLL_OPTIONS = {
   scrollFade: false,
 };
 
-const DEFAULT_SCROLL_INTO_VIEW_OPTIONS = {
+const DEFAULT_SCROLL_INTO_VIEW_OPTIONS: StandardBehaviorOptions = {
   behavior: 'smooth',
   inline: 'center',
   block: 'end',
@@ -95,13 +96,14 @@ export const TabsNav: Component = ({
     (ref) => {
       if (ref && scrollOptions.active) {
         setTimeout(() => {
-          ref.scrollIntoView(
-            scrollOptions.scrollIntoViewOptions ?? DEFAULT_SCROLL_INTO_VIEW_OPTIONS,
+          scrollIntoView(
+            ref,
+            scrollOptions?.scrollIntoViewOptions ?? DEFAULT_SCROLL_INTO_VIEW_OPTIONS,
           );
         }, 0);
       }
     },
-    [scrollOptions.active, scrollOptions.scrollIntoViewOptions],
+    [scrollOptions.active, scrollOptions?.scrollIntoViewOptions],
   );
 
   const setIntersectionRef = (index: number) => {

--- a/src/Molecules/TabsNav/TabsNav.types.ts
+++ b/src/Molecules/TabsNav/TabsNav.types.ts
@@ -1,3 +1,5 @@
+import { StandardBehaviorOptions } from 'scroll-into-view-if-needed';
+
 export type HtmlProps = Omit<React.HTMLProps<HTMLSpanElement>, 'children'>;
 
 export type ItemProps = {
@@ -18,7 +20,11 @@ export type ContainerProps = {
   scrollOptions?: {
     active: boolean;
     scrollBarHidden: boolean;
-    scrollIntoViewOptions?: { behavior?: string; inline?: string; block?: string };
+    scrollIntoViewOptions?: {
+      behavior?: StandardBehaviorOptions['behavior'];
+      inline?: StandardBehaviorOptions['inline'];
+      block?: StandardBehaviorOptions['block'];
+    };
     scrollFade?: boolean;
   };
 };


### PR DESCRIPTION
Uses scroll-into-view-if-needed to solve unwanted horizontal scroll on ios browsers