### PR TITLE
fix: 🐛  resolve bug for unwanted scroll to top

### DIFF
--- a/src/Molecules/TabsNav/TabsNav.tsx
+++ b/src/Molecules/TabsNav/TabsNav.tsx
@@ -89,7 +89,7 @@ export const TabsNav: Component = ({
     (ref) => {
       if (ref && scrollRef && scrollRef.current && scrollOptions.active) {
         const offsetleft = ref.offsetLeft;
-        const tabWidth = ref.getBoundingClientRect().width;
+        const { width: tabWidth } = ref.getBoundingClientRect();
         const containerWidth = scrollRef.current.getBoundingClientRect().width;
 
         const scrollToLeft = offsetleft + tabWidth / 2 - containerWidth / 2;

--- a/src/Molecules/TabsNav/TabsNav.tsx
+++ b/src/Molecules/TabsNav/TabsNav.tsx
@@ -1,11 +1,10 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useRef } from 'react';
 import styled from 'styled-components';
-import scrollIntoView, { StandardBehaviorOptions } from 'scroll-into-view-if-needed';
 import { Component, ItemProps, ScrollStyleProps, TitleProps } from './TabsNav.types';
 import { scrollStyles } from './TabsNav.styles';
 import { useIntersect } from '../../common/Hooks';
 import { Flexbox, TabTitle, Typography } from '../..';
-import { assert } from '../../common/utils';
+import { assert, mergeRefs } from '../../common/utils';
 import { useKeyboardNavigation } from '../Tabs/useKeyboardNavigation';
 import { useLink } from '../../common/Links';
 import { LinkProps } from '../../common/Links/types';
@@ -13,14 +12,7 @@ import { LinkProps } from '../../common/Links/types';
 const DEFAULT_SCROLL_OPTIONS = {
   active: false,
   scrollBarHidden: false,
-  scrollIntoViewOptions: null,
   scrollFade: false,
-};
-
-const DEFAULT_SCROLL_INTO_VIEW_OPTIONS: StandardBehaviorOptions = {
-  behavior: 'smooth',
-  inline: 'center',
-  block: 'end',
 };
 
 export const Item: React.FC<ItemProps> = ({ children }) => {
@@ -91,19 +83,26 @@ export const TabsNav: Component = ({
 
   const [setIntersectionLeftRef, intersectionLeftRatio] = useIntersect<HTMLDivElement>();
   const [setIntersectionRightRef, intersectionRightRatio] = useIntersect<HTMLDivElement>();
+  const scrollRef = useRef<HTMLDivElement>(null);
 
   const scrollToRefCallback = useCallback(
     (ref) => {
-      if (ref && scrollOptions.active) {
+      if (ref && scrollRef && scrollRef.current && scrollOptions.active) {
+        const offsetleft = ref.offsetLeft;
+        const tabWidth = ref.getBoundingClientRect().width;
+        const containerWidth = scrollRef.current.getBoundingClientRect().width;
+
+        const scrollToLeft = offsetleft + tabWidth / 2 - containerWidth / 2;
+
         setTimeout(() => {
-          scrollIntoView(
-            ref,
-            scrollOptions?.scrollIntoViewOptions ?? DEFAULT_SCROLL_INTO_VIEW_OPTIONS,
-          );
+          scrollRef.current?.scrollTo({
+            left: scrollToLeft,
+            behavior: 'smooth',
+          });
         }, 0);
       }
     },
-    [scrollOptions.active, scrollOptions?.scrollIntoViewOptions],
+    [scrollOptions.active],
   );
 
   const setIntersectionRef = (index: number) => {
@@ -124,7 +123,15 @@ export const TabsNav: Component = ({
       assert(false, 'There should be only <TabsNav.Tab> children inside of <TabsNav> component');
     } else if (c) {
       titles.push(
-        <Flexbox ref={setIntersectionRef(i)} item as="li" key={c.props.to}>
+        <Flexbox
+          ref={mergeRefs([
+            scrollOptions.scrollFade ? setIntersectionRef(i) : null,
+            c.props.active ? scrollToRefCallback : null,
+          ])}
+          item
+          as="li"
+          key={c.props.to}
+        >
           <Title
             active={!!c.props.active}
             onClick={c.props.onTitleClick}
@@ -134,7 +141,6 @@ export const TabsNav: Component = ({
             onKeyDown={onKeyDown}
             height={height}
             className={c.props.className}
-            ref={c.props.active ? scrollToRefCallback : null}
           >
             {c.props.title}
           </Title>
@@ -151,6 +157,7 @@ export const TabsNav: Component = ({
       $intersectionRightRatio={intersectionRightRatio || 0}
       className={className}
       container
+      ref={scrollRef}
     >
       <Flexbox container direction="row" gutter={4} sm={{ gutter: 8 }}>
         {titles}

--- a/src/Molecules/TabsNav/TabsNav.types.ts
+++ b/src/Molecules/TabsNav/TabsNav.types.ts
@@ -1,5 +1,3 @@
-import { StandardBehaviorOptions } from 'scroll-into-view-if-needed';
-
 export type HtmlProps = Omit<React.HTMLProps<HTMLSpanElement>, 'children'>;
 
 export type ItemProps = {
@@ -20,11 +18,6 @@ export type ContainerProps = {
   scrollOptions?: {
     active: boolean;
     scrollBarHidden: boolean;
-    scrollIntoViewOptions?: {
-      behavior?: StandardBehaviorOptions['behavior'];
-      inline?: StandardBehaviorOptions['inline'];
-      block?: StandardBehaviorOptions['block'];
-    };
     scrollFade?: boolean;
   };
 };


### PR DESCRIPTION
Uses scrollTo instead of package to calculate scroll destination.
Prevents unwanted scroll to top when interacting with the page where TabsNav is used.
Co-Authors: William Bruce, Robin Andersson