### PR TITLE
fix: 🐛 don't render hidden search input on mobile screen

### DIFF
--- a/src/Molecules/Input/Select/Select.tsx
+++ b/src/Molecules/Input/Select/Select.tsx
@@ -84,7 +84,7 @@ const Select = (props: Props) => {
   const isFullscreenOnMobile = smallScreen && props.fullscreenOnMobile && !props.withPortal;
 
   const isDisableSearchComponent =
-    isFullscreenOnMobile && !props.showSearch ? true : props.disableSearchComponent;
+    smallScreen && !props.showSearch ? true : props.disableSearchComponent;
 
   /******      Machine instantiation      ******/
   const machineHandlers = useMachine(SelectMachine, {

--- a/src/Molecules/Input/Select/__snapshots__/Select.stories.storyshot
+++ b/src/Molecules/Input/Select/__snapshots__/Select.stories.storyshot
@@ -7929,6 +7929,7 @@ exports[`Storyshots Molecules / Input / Select Link With Dropdown And Search Box
       className="c2"
       onBlur={[Function]}
       onFocus={[Function]}
+      tabIndex={0}
       width="300px"
     >
       <div
@@ -8393,6 +8394,7 @@ exports[`Storyshots Molecules / Input / Select Link With Dropdown And Search Box
       className="c2"
       onBlur={[Function]}
       onFocus={[Function]}
+      tabIndex={0}
       width="300px"
     >
       <div
@@ -8846,6 +8848,7 @@ exports[`Storyshots Molecules / Input / Select Link With Dropdown And Search Box
       className="c2"
       onBlur={[Function]}
       onFocus={[Function]}
+      tabIndex={0}
       width="150px"
     >
       <div
@@ -9308,6 +9311,7 @@ exports[`Storyshots Molecules / Input / Select Link With Dropdown And Search Box
       className="c2"
       onBlur={[Function]}
       onFocus={[Function]}
+      tabIndex={0}
       width="250px"
     >
       <div
@@ -9772,6 +9776,7 @@ exports[`Storyshots Molecules / Input / Select List Positioned To The Left 1`] =
       className="c2"
       onBlur={[Function]}
       onFocus={[Function]}
+      tabIndex={0}
       width="300px"
     >
       <div

--- a/src/Molecules/Input/Select/lib/wrappers/FormFieldOrFragment.tsx
+++ b/src/Molecules/Input/Select/lib/wrappers/FormFieldOrFragment.tsx
@@ -95,6 +95,7 @@ export const FormFieldOrFragment = React.forwardRef<HTMLDivElement, any>(
     if (noFormField) {
       return (
         <StyledRelativeDiv
+          tabIndex={0}
           ref={ref}
           fullWidth={fullWidth}
           width={props.width}


### PR DESCRIPTION
Input.Select no longer renders a hidden text input on small screens. On
mobile devices the virtual keyboard would appear and auto focus on the
input element. Also adds TabIndex when noFormField prop is set due to
inconsistent focus and blur behaviors between safari and other browsers.