### PR TITLE
feat: 🎸 add util function to get units

### DIFF
--- a/src/common/unitUtils.ts
+++ b/src/common/unitUtils.ts
@@ -1,0 +1,7 @@
+import { Theme } from '../theme/theme.types';
+
+export const units =
+  (unit: number) =>
+  ({ theme }: { theme: Theme }) => {
+    return theme.spacing.unit(unit);
+  };

--- a/src/index.ts
+++ b/src/index.ts
@@ -106,6 +106,7 @@ import {
 /** Utils */
 import { numberWithLimit } from './common/utils';
 import { above, below, between } from './common/mediaUtils';
+import { units } from './common/unitUtils';
 
 /** Exports for types */
 export type {
@@ -217,6 +218,7 @@ export {
   above,
   below,
   between,
+  units,
   theme,
   useKeyPress,
   useLink,


### PR DESCRIPTION
when consuming the ui librabry, this util abstracts away the need to
call the theme when you need units. Instead of writing ${(theme) =>
theme.spacing.unit(x)}px, you can use the util and write ${units(x)}px;
instead