### PR TITLE
feat: 🎸 bugfix for progress indicator unique keys

### DIFF
--- a/src/Molecules/ProgressIndicator/ProgressIndicator.tsx
+++ b/src/Molecules/ProgressIndicator/ProgressIndicator.tsx
@@ -63,7 +63,7 @@ const ProgressIndicator: FC<Props> = ({
             [...numberOfSteps].map((steps, index) => {
               return (
                 <CompletionBar
-                  key={`${numberOfSteps}${steps}`}
+                  key={`completion_bar_${index + 1}`}
                   completion={currentStep[index] / Number(steps)}
                   noButtons={noButtons}
                 />


### PR DESCRIPTION
Keys should be unique so that components maintain their identity across updates.