### PR TITLE
fix: 🐛 transient props for removing console warnings in test

### DIFF
--- a/src/Molecules/Modal/Modal.types.ts
+++ b/src/Molecules/Modal/Modal.types.ts
@@ -26,7 +26,7 @@ export type BackdropProps = {
 };
 
 export type DialogProps = {
-  show: boolean;
+  $show: boolean;
   onClick: (e: React.MouseEvent<HTMLElement>) => void;
   $fullScreenMobile?: boolean;
   $fixedBottomMobile?: boolean;

--- a/src/Molecules/Modal/ModalInner.tsx
+++ b/src/Molecules/Modal/ModalInner.tsx
@@ -245,11 +245,11 @@ export const ModalInner: React.FC<Props> = ({
               onAnimationComplete={onAnimationComplete || noop}
               aria-labelledby={titleId}
               className={className}
-              show={show}
               role="dialog"
               {...animationProps}
               ref={dialogRef}
               onClick={handleDialogClick}
+              $show={show}
               $fullScreenMobile={fullScreenMobile}
               $fixedBottomMobile={fixedBottomMobile}
               isStatusModal={isStatusModal}


### PR DESCRIPTION
Just removes a console.error when performing a tests involving a Modal