### PR TITLE
refactor: 💡 add children to types

### DIFF
--- a/src/Atoms/Box/Box.types.ts
+++ b/src/Atoms/Box/Box.types.ts
@@ -58,6 +58,7 @@ export type Props = {
   as?: keyof JSX.IntrinsicElements | React.ComponentType<any>;
   backgroundColor?: 'inherit' | ColorFn;
   className?: string;
+  children?: React.ReactNode;
 } & Paddings &
   Margins &
   MediaRelatedProps &

--- a/src/Atoms/CssGrid/CssGrid.types.ts
+++ b/src/Atoms/CssGrid/CssGrid.types.ts
@@ -53,7 +53,7 @@ type BaseItemProps = {
   justify?: 'start' | 'end' | 'center' | 'stretch';
   align?: 'start' | 'end' | 'center' | 'stretch';
   place?: string;
-  children: React.ReactNode;
+  children?: React.ReactNode;
 };
 
 export type ItemProps = SizeAwareProps<BaseItemProps>;

--- a/src/Atoms/CssGrid/CssGrid.types.ts
+++ b/src/Atoms/CssGrid/CssGrid.types.ts
@@ -53,6 +53,7 @@ type BaseItemProps = {
   justify?: 'start' | 'end' | 'center' | 'stretch';
   align?: 'start' | 'end' | 'center' | 'stretch';
   place?: string;
+  children: React.ReactNode;
 };
 
 export type ItemProps = SizeAwareProps<BaseItemProps>;

--- a/src/Atoms/DropdownBubble/DropdownBubble.types.ts
+++ b/src/Atoms/DropdownBubble/DropdownBubble.types.ts
@@ -12,4 +12,5 @@ export type Props = {
    * styled-components for all css-related props
    */
   maxHeight?: string;
+  children?: React.ReactNode;
 };

--- a/src/Atoms/FadedScroll/FadedScroll.types.ts
+++ b/src/Atoms/FadedScroll/FadedScroll.types.ts
@@ -18,6 +18,7 @@ export type Props = {
   enableMobileFade?: boolean;
   disableTopFade?: boolean;
   ref?: React.Ref<HTMLDivElement>;
+  children?: React.ReactNode;
 };
 
 export type Component = React.FC<Props>;

--- a/src/Atoms/FormLabel/FormLabel.types.ts
+++ b/src/Atoms/FormLabel/FormLabel.types.ts
@@ -4,4 +4,5 @@ export type Props = {
   forId?: string;
   hideLabel?: boolean;
   disabled?: boolean;
+  children?: React.ReactNode;
 };

--- a/src/Atoms/Legend/Legend.types.ts
+++ b/src/Atoms/Legend/Legend.types.ts
@@ -1,4 +1,5 @@
 export type Props = {
   className?: string;
   styleType?: 'caption' | 'label';
+  children?: React.ReactNode;
 };

--- a/src/Atoms/Media/Media.types.ts
+++ b/src/Atoms/Media/Media.types.ts
@@ -3,4 +3,5 @@ import { Theme } from '../../theme/theme.types';
 export type Props = {
   as?: keyof JSX.IntrinsicElements | React.ComponentType<{ className?: string }>;
   query: string | ((theme: Theme) => string);
+  children?: React.ReactNode;
 };

--- a/src/Atoms/Portal/Portal.types.ts
+++ b/src/Atoms/Portal/Portal.types.ts
@@ -1,3 +1,4 @@
 export type Props = {
   attachTo?: HTMLElement | null;
+  children?: React.ReactNode;
 };

--- a/src/Atoms/TabTitle/TabTitle.types.ts
+++ b/src/Atoms/TabTitle/TabTitle.types.ts
@@ -2,4 +2,5 @@ export type Props = {
   active?: boolean;
   height?: number;
   variant?: 'normal' | 'large';
+  children?: React.ReactNode;
 };

--- a/src/Atoms/Table/Table.types.ts
+++ b/src/Atoms/Table/Table.types.ts
@@ -2,6 +2,7 @@ export type Props = {
   tableLayout?: string;
   width?: string;
   maxHeight?: number;
+  children: React.ReactNode;
 };
 
 export type TableComponent = React.FunctionComponent<Props>;

--- a/src/Atoms/Table/Table.types.ts
+++ b/src/Atoms/Table/Table.types.ts
@@ -2,7 +2,7 @@ export type Props = {
   tableLayout?: string;
   width?: string;
   maxHeight?: number;
-  children: React.ReactNode;
+  children?: React.ReactNode;
 };
 
 export type TableComponent = React.FunctionComponent<Props>;

--- a/src/Atoms/Table/Tbody/Tbody.types.ts
+++ b/src/Atoms/Table/Tbody/Tbody.types.ts
@@ -1,5 +1,6 @@
 type Props = {
   className?: string;
+  children: React.ReactNode;
 };
 
 export type TbodyComponent = React.FunctionComponent<Props>;

--- a/src/Atoms/Table/Tbody/Tbody.types.ts
+++ b/src/Atoms/Table/Tbody/Tbody.types.ts
@@ -1,6 +1,6 @@
 type Props = {
   className?: string;
-  children: React.ReactNode;
+  children?: React.ReactNode;
 };
 
 export type TbodyComponent = React.FunctionComponent<Props>;

--- a/src/Atoms/Table/Td/Td.types.ts
+++ b/src/Atoms/Table/Td/Td.types.ts
@@ -2,6 +2,7 @@ export type Props = {
   textAlign?: string;
   ellipsis?: boolean;
   className?: string;
+  children: React.ReactNode;
 };
 
 export type TdComponent = React.FunctionComponent<Props>;

--- a/src/Atoms/Table/Td/Td.types.ts
+++ b/src/Atoms/Table/Td/Td.types.ts
@@ -2,7 +2,7 @@ export type Props = {
   textAlign?: string;
   ellipsis?: boolean;
   className?: string;
-  children: React.ReactNode;
+  children?: React.ReactNode;
 };
 
 export type TdComponent = React.FunctionComponent<Props>;

--- a/src/Atoms/Table/Tfoot/Tfoot.types.ts
+++ b/src/Atoms/Table/Tfoot/Tfoot.types.ts
@@ -1,1 +1,5 @@
-export type TfootComponent = React.FunctionComponent;
+export type Props = {
+  children: React.ReactNode;
+};
+
+export type TfootComponent = React.FunctionComponent<Props>;

--- a/src/Atoms/Table/Tfoot/Tfoot.types.ts
+++ b/src/Atoms/Table/Tfoot/Tfoot.types.ts
@@ -1,5 +1,5 @@
 export type Props = {
-  children: React.ReactNode;
+  children?: React.ReactNode;
 };
 
 export type TfootComponent = React.FunctionComponent<Props>;

--- a/src/Atoms/Table/Th/Th.types.ts
+++ b/src/Atoms/Table/Th/Th.types.ts
@@ -4,6 +4,7 @@ export type Props = {
   className?: string;
   ellipsis?: boolean;
   scope?: 'col' | 'row' | 'colgroup' | 'rowgroup';
+  children: React.ReactNode;
 };
 
 export type ThComponent = React.FunctionComponent<Props>;

--- a/src/Atoms/Table/Th/Th.types.ts
+++ b/src/Atoms/Table/Th/Th.types.ts
@@ -4,7 +4,7 @@ export type Props = {
   className?: string;
   ellipsis?: boolean;
   scope?: 'col' | 'row' | 'colgroup' | 'rowgroup';
-  children: React.ReactNode;
+  children?: React.ReactNode;
 };
 
 export type ThComponent = React.FunctionComponent<Props>;

--- a/src/Atoms/Table/Thead/Thead.types.ts
+++ b/src/Atoms/Table/Thead/Thead.types.ts
@@ -1,6 +1,6 @@
 export type Props = {
   stickyHeader?: boolean;
-  children: React.ReactNode;
+  children?: React.ReactNode;
 };
 
 export type TheadComponent = React.FunctionComponent<Props>;

--- a/src/Atoms/Table/Thead/Thead.types.ts
+++ b/src/Atoms/Table/Thead/Thead.types.ts
@@ -1,5 +1,6 @@
 export type Props = {
   stickyHeader?: boolean;
+  children: React.ReactNode;
 };
 
 export type TheadComponent = React.FunctionComponent<Props>;

--- a/src/Atoms/Table/Tr/Tr.types.ts
+++ b/src/Atoms/Table/Tr/Tr.types.ts
@@ -2,6 +2,7 @@ export type Props = {
   textAlign?: string;
   className?: string;
   onClick?: (e: React.MouseEvent) => void;
+  children: React.ReactNode;
 };
 
 export type TrComponent = React.FunctionComponent<Props>;

--- a/src/Atoms/Table/Tr/Tr.types.ts
+++ b/src/Atoms/Table/Tr/Tr.types.ts
@@ -2,7 +2,7 @@ export type Props = {
   textAlign?: string;
   className?: string;
   onClick?: (e: React.MouseEvent) => void;
-  children: React.ReactNode;
+  children?: React.ReactNode;
 };
 
 export type TrComponent = React.FunctionComponent<Props>;

--- a/src/Atoms/VisuallyHidden/VisuallyHidden.types.ts
+++ b/src/Atoms/VisuallyHidden/VisuallyHidden.types.ts
@@ -2,6 +2,7 @@ import React from 'react';
 
 type Props = {
   as?: keyof JSX.IntrinsicElements | React.ComponentType<any>;
+  children?: React.ReactNode;
 };
 
 export type VisuallyHiddenComponent = React.FunctionComponent<Props>;

--- a/src/Molecules/Badge/components/AccountBadge/AccountBadge.tsx
+++ b/src/Molecules/Badge/components/AccountBadge/AccountBadge.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 import {
   AccountBadgeComponent,
   AccountBadgeCompoundComponent,
+  AccountBadgeContentProps,
   AccountBadgeProps,
 } from './AccountBadge.types';
 import { BaseBadge } from '..';
@@ -15,9 +16,7 @@ const StyledTypography = styled(Typography)`
   font-weight: 800;
 `;
 
-const AccountBadgeContent: React.FC<{
-  typographyType: React.ComponentProps<typeof Typography>['type'];
-}> = ({ children, typographyType }) => {
+const AccountBadgeContent: React.FC<AccountBadgeContentProps> = ({ children, typographyType }) => {
   if (typeof children === 'undefined') return null;
   if (isFunction(children)) return children();
   if (isElement(children)) return children;

--- a/src/Molecules/Badge/components/AccountBadge/AccountBadge.types.ts
+++ b/src/Molecules/Badge/components/AccountBadge/AccountBadge.types.ts
@@ -1,5 +1,6 @@
 import { AccountBadgeStackComponent } from '../AccountBadgeStack/AccountBadgeStack.types';
 import { ColorFn, HtmlProps } from '../BaseBadge/BaseBadge.types';
+import { Typography } from '../../../..';
 
 export type AccountBadgeProps = HtmlProps & {
   children: React.ReactNode;
@@ -13,3 +14,8 @@ export type AccountBadgeComponent = React.ForwardRefExoticComponent<
 export interface AccountBadgeCompoundComponent extends AccountBadgeComponent {
   Stack: AccountBadgeStackComponent;
 }
+
+export type AccountBadgeContentProps = {
+  typographyType: React.ComponentProps<typeof Typography>['type'];
+  children?: React.ReactNode;
+};

--- a/src/Molecules/Badge/components/NumberBadge/NumberBadge.tsx
+++ b/src/Molecules/Badge/components/NumberBadge/NumberBadge.tsx
@@ -3,7 +3,12 @@ import styled, { css } from 'styled-components';
 import { Typography } from '../../../..';
 import { ColorFn } from '../../../../common/Types';
 import { isElement, isFunction } from '../../../../common/utils';
-import { StyledBaseBadgeProps, Props, NumberBadgeComponent } from './NumberBadge.types';
+import {
+  StyledBaseBadgeProps,
+  Props,
+  NumberBadgeComponent,
+  NumberBadgeContentProps,
+} from './NumberBadge.types';
 import { BaseBadge } from '../BaseBadge';
 import {
   MAP_FONT_SIZE,
@@ -33,10 +38,11 @@ const StyledBaseBadge: React.FC<StyledBaseBadgeProps> = styled(BaseBadge)<Styled
   ${(p) => (p.$padding ? `padding: 0 ${p.theme.spacing.unit(p.$padding)}px;` : '')}
 `;
 
-const NumberBadgeContent: React.FC<{
-  color?: ColorFn;
-  typographyType: React.ComponentProps<typeof Typography>['type'];
-}> = ({ children, color, typographyType }) => {
+const NumberBadgeContent: React.FC<NumberBadgeContentProps> = ({
+  children,
+  color,
+  typographyType,
+}) => {
   if (typeof children === 'undefined') return null;
   if (isFunction(children)) return children();
   if (isElement(children)) return children;

--- a/src/Molecules/Badge/components/NumberBadge/NumberBadge.types.ts
+++ b/src/Molecules/Badge/components/NumberBadge/NumberBadge.types.ts
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Typography } from '../../../..';
 import { ColorFn } from '../../../../common/Types';
 import { BaseBadgeProps, HtmlProps } from '../BaseBadge/BaseBadge.types';
 
@@ -17,6 +18,12 @@ type BaseProps = HtmlProps & {
 
 export type Props = BaseProps & {
   badgeSize?: 'xs' | 's' | 'm' | 'l' | number;
+  children?: React.ReactNode;
+};
+
+export type NumberBadgeContentProps = {
+  color?: ColorFn;
+  typographyType: React.ComponentProps<typeof Typography>['type'];
   children?: React.ReactNode;
 };
 

--- a/src/Molecules/Button/components/ButtonContent/ButtonContent.types.tsx
+++ b/src/Molecules/Button/components/ButtonContent/ButtonContent.types.tsx
@@ -14,6 +14,7 @@ export type ButtonContentProps = {
   size: 's' | 'm' | 'l';
   /** @default primary */
   variant: 'primary' | 'secondary' | 'neutral';
+  children?: React.ReactNode;
 };
 
 export type ButtonContentComponent = React.FC<ButtonContentProps>;

--- a/src/Molecules/CollapsibleCard/Collapsible.types.ts
+++ b/src/Molecules/CollapsibleCard/Collapsible.types.ts
@@ -14,6 +14,7 @@ export type CollapsibleProps = {
   titleRowPaddingX?: number;
   action?: React.ReactNode;
   fullWidthTitle?: boolean;
+  children?: React.ReactNode;
 };
 
 export type IndicatorsProps = {

--- a/src/Molecules/Drawer/Drawer.types.ts
+++ b/src/Molecules/Drawer/Drawer.types.ts
@@ -17,6 +17,7 @@ export type Props = {
   onAnimationComplete?: () => void;
   disableInitialAnimation?: boolean;
   preventOnClickOutsideDataAttributes?: string[];
+  children?: React.ReactNode;
 } & Omit<HtmlDivProps, 'title'>;
 
 export type TitleProps = {

--- a/src/Molecules/FeedbackBanner/FeedbackBanner.types.ts
+++ b/src/Molecules/FeedbackBanner/FeedbackBanner.types.ts
@@ -8,6 +8,7 @@ export type FeedbackBannerProps = {
   title?: string | React.ReactChild | React.ReactChild[];
   withIcon?: boolean;
   className?: string;
+  children: React.ReactNode;
 };
 
 export type FeedbackBannerComponent = React.FC<FeedbackBannerProps>;

--- a/src/Molecules/FeedbackBanner/FeedbackBanner.types.ts
+++ b/src/Molecules/FeedbackBanner/FeedbackBanner.types.ts
@@ -8,7 +8,7 @@ export type FeedbackBannerProps = {
   title?: string | React.ReactChild | React.ReactChild[];
   withIcon?: boolean;
   className?: string;
-  children: React.ReactNode;
+  children?: React.ReactNode;
 };
 
 export type FeedbackBannerComponent = React.FC<FeedbackBannerProps>;

--- a/src/Molecules/Fieldset/Fieldset.types.ts
+++ b/src/Molecules/Fieldset/Fieldset.types.ts
@@ -1,3 +1,4 @@
 export type Props = {
   className?: string;
+  children?: React.ReactNode;
 };

--- a/src/Molecules/FlexTable/Cell/Cell.types.ts
+++ b/src/Molecules/FlexTable/Cell/Cell.types.ts
@@ -43,6 +43,7 @@ type TextWrapperProps = {
   truncate?: boolean;
   className?: string;
   weight?: string;
+  children?: React.ReactNode;
 };
 
 export type TextWrapperComponent = React.FC<TextWrapperProps>;

--- a/src/Molecules/FlexTable/Header/HeaderContent/HeaderContent.types.ts
+++ b/src/Molecules/FlexTable/Header/HeaderContent/HeaderContent.types.ts
@@ -37,4 +37,9 @@ type onSortClick = () => void;
 
 export type UIProps = { onSortClick: onSortClick };
 
-export type Props = { sortable: boolean; sortOrder: SortOrder; sorted: boolean };
+export type Props = {
+  sortable: boolean;
+  sortOrder: SortOrder;
+  sorted: boolean;
+  children?: React.ReactNode;
+};

--- a/src/Molecules/FlexTable/Row/components/ExpandItems/ExpandItems.types.ts
+++ b/src/Molecules/FlexTable/Row/components/ExpandItems/ExpandItems.types.ts
@@ -15,6 +15,7 @@ type TextWrapperProps = {
    * @default false
    */
   isLabel?: boolean;
+  children?: React.ReactNode;
 };
 
 export type TextWrapperComponent = React.FC<TextWrapperProps>;

--- a/src/Molecules/FlexTable/shared/ColumnProvider/ColumnProvider.tsx
+++ b/src/Molecules/FlexTable/shared/ColumnProvider/ColumnProvider.tsx
@@ -5,6 +5,7 @@ import {
   ColumnsDataState,
   ColumnsDispatch,
   ColumnsState,
+  ColumnProviderProps,
 } from './ColumnProvider.types';
 import { SORT_ORDER_NONE } from '../constants';
 
@@ -61,7 +62,7 @@ const columnReducer = (state: ColumnsState, action: ColumnActions): ColumnsState
   }
 };
 
-export const ColumnProvider: React.FC = ({ children }) => {
+export const ColumnProvider: React.FC<ColumnProviderProps> = ({ children }) => {
   const [state, dispatch] = useReducer(columnReducer, { data: {} });
   return (
     <ColumnDataContext.Provider value={state.data}>

--- a/src/Molecules/FlexTable/shared/ColumnProvider/ColumnProvider.types.ts
+++ b/src/Molecules/FlexTable/shared/ColumnProvider/ColumnProvider.types.ts
@@ -28,4 +28,8 @@ type SetInitialSortingAction = {
   controlledSort: boolean;
 };
 
+export type ColumnProviderProps = {
+  children?: React.ReactNode;
+};
+
 export type ColumnActions = SetSortingAction | SetInitialSortingAction;

--- a/src/Molecules/FlexTable/shared/Text/Text.types.ts
+++ b/src/Molecules/FlexTable/shared/Text/Text.types.ts
@@ -4,6 +4,7 @@ export type TextProps = {
   className?: string;
   color?: ColorFn;
   weight?: string;
+  children?: React.ReactNode;
 };
 
 export type TextComponent = React.FC<TextProps>;

--- a/src/Molecules/FlexTable/stories/WithCustomCells.stories.tsx
+++ b/src/Molecules/FlexTable/stories/WithCustomCells.stories.tsx
@@ -22,6 +22,7 @@ const StyledFlexboxContainer = styled(Flexbox)`
 export const CustomCells = () => {
   const Story = () => {
     const TruncateStartHeader: React.FC<{
+      children?: React.ReactNode;
       currency: string;
       columnId: string;
       flex: string;

--- a/src/Molecules/FlexTable/stories/WithDifferentColumns.stories.tsx
+++ b/src/Molecules/FlexTable/stories/WithDifferentColumns.stories.tsx
@@ -71,7 +71,7 @@ export const DifferentAlignmentsTable = () => (
   </StyledBackground>
 );
 
-const FlagCell: React.FC<{ columnId: string } & FlexProps> = React.memo(
+const FlagCell: React.FC<{ children?: React.ReactNode; columnId: string } & FlexProps> = React.memo(
   ({ children, columnId, ...cellProps }) => (
     <FlexTable.Cell columnId={columnId} {...cellProps}>
       <FlexTable.CellInlineContainer>

--- a/src/Molecules/FlexTable/stories/WithDifferentHeaders.stories.tsx
+++ b/src/Molecules/FlexTable/stories/WithDifferentHeaders.stories.tsx
@@ -18,7 +18,7 @@ export default {
 
 export const DefaultTableHeaders = () => {
   const DefaultTableHeadersExample = () => {
-    const CustomisedTableHeader: React.FC = ({ children }) => (
+    const CustomisedTableHeader: React.FC<{ children?: React.ReactNode }> = ({ children }) => (
       <FlexTable.Header columnId="column3" sortable>
         {({ sortable, sorted, onSortClick, sortOrder }) => (
           <FlexTable.Header.SortButton onClick={onSortClick}>

--- a/src/Molecules/FormField/FormField.types.ts
+++ b/src/Molecules/FormField/FormField.types.ts
@@ -2,6 +2,7 @@ export type LabelAddonProp = {
   labelTooltip?: string;
   labelTooltipPosition?: 'top' | 'left' | 'bottom' | 'right';
   hideLabel?: boolean;
+  children?: React.ReactNode;
 };
 
 export type Props = {

--- a/src/Molecules/InfoBar/InfoBar.types.ts
+++ b/src/Molecules/InfoBar/InfoBar.types.ts
@@ -8,6 +8,7 @@ export type InfoBarProps = {
   /** @default general */
   variant?: Variant;
   onClose?: () => void;
+  children?: React.ReactNode;
 };
 
 export type InfoBarIconProps = {

--- a/src/Molecules/Input/Select/lib/SingleSelectList/SingleSelectList.tsx
+++ b/src/Molecules/Input/Select/lib/SingleSelectList/SingleSelectList.tsx
@@ -12,6 +12,7 @@ import {
 } from '../../../../..';
 
 type ListProps = {
+  children?: React.ReactNode;
   searchComponent?: React.ReactNode;
   actionsComponent?: React.ReactNode;
   maxHeight?: string;

--- a/src/Molecules/Input/Select/lib/defaults/List.tsx
+++ b/src/Molecules/Input/Select/lib/defaults/List.tsx
@@ -12,6 +12,7 @@ type ListProps = {
   itemsPerColumn?: number;
   columnWidth?: string;
   listWidth?: string;
+  children?: React.ReactNode;
 };
 
 const StyledColumnsList = styled(UIList)<any>`

--- a/src/Molecules/Input/Select/lib/defaults/ListFullScreen.tsx
+++ b/src/Molecules/Input/Select/lib/defaults/ListFullScreen.tsx
@@ -11,6 +11,7 @@ type ListFullScreenProps = {
   maxHeight?: string;
   noFormField?: boolean;
   placement?: 'bottom' | 'top';
+  children?: React.ReactNode;
 };
 
 const StyledList = styled(UIList)<{ role: string }>`

--- a/src/Molecules/ListWithTitles/ListWithTitles.stories.tsx
+++ b/src/Molecules/ListWithTitles/ListWithTitles.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Flexbox, ListItem, ListWithTitles } from '../..';
 
-const ItemContainer: React.FunctionComponent = ({ children }) => (
+const ItemContainer: React.FunctionComponent<{ children?: React.ReactNode }> = ({ children }) => (
   <Flexbox container justifyContent="space-between">
     {children}
   </Flexbox>

--- a/src/Molecules/Modal/Modal.types.ts
+++ b/src/Molecules/Modal/Modal.types.ts
@@ -18,6 +18,7 @@ export type InnerProps = {
   isStatusModal?: boolean;
   onAnimationComplete?: () => void;
   showBackdrop?: boolean;
+  children: React.ReactNode;
 };
 
 export type BackdropProps = {

--- a/src/Molecules/Modal/Modal.types.ts
+++ b/src/Molecules/Modal/Modal.types.ts
@@ -18,7 +18,7 @@ export type InnerProps = {
   isStatusModal?: boolean;
   onAnimationComplete?: () => void;
   showBackdrop?: boolean;
-  children: React.ReactNode;
+  children?: React.ReactNode;
 };
 
 export type BackdropProps = {

--- a/src/Molecules/Pagination/PaginationRouteHelper.tsx
+++ b/src/Molecules/Pagination/PaginationRouteHelper.tsx
@@ -10,6 +10,7 @@ interface MatchParams {
 interface PaginationRouteHelperProps {
   currentPage: number;
   setCurrentPage: (pageNumber: number) => void;
+  children?: React.ReactNode;
 }
 
 interface ViewProps extends PaginationRouteHelperProps {

--- a/src/Molecules/Slider/SliderTrack/SliderTrack.types.ts
+++ b/src/Molecules/Slider/SliderTrack/SliderTrack.types.ts
@@ -8,6 +8,7 @@ export type InternalProps = {
 export type Props = {
   disabled?: boolean;
   variant?: Variant;
+  children?: React.ReactNode;
 };
 
 export type Component = React.FC<Props>;

--- a/src/Organisms/ShowMore/ShowMore.types.ts
+++ b/src/Organisms/ShowMore/ShowMore.types.ts
@@ -8,4 +8,5 @@ export type Props = {
   showMoreText: string;
   onShowMore?: React.MouseEventHandler;
   linesToClamp?: number;
+  children?: React.ReactNode;
 };

--- a/src/common/Links/ReactRouterLinkHelper.tsx
+++ b/src/common/Links/ReactRouterLinkHelper.tsx
@@ -1,7 +1,7 @@
 import React, { FC } from 'react';
 import { Link as RRLink, MemoryRouter } from 'react-router-dom';
 import { LinkProvider } from '.';
-import { LinkProps } from './types';
+import { LinkProps, ProviderProps } from './types';
 
 export const RawLink: FC<LinkProps> = (props) => {
   const {
@@ -30,7 +30,7 @@ export const RawLink: FC<LinkProps> = (props) => {
   );
 };
 
-export const Provider: FC = ({ children }) => {
+export const Provider: FC<ProviderProps> = ({ children }) => {
   return (
     <MemoryRouter>
       <LinkProvider link={RawLink}>

--- a/src/common/Links/types.ts
+++ b/src/common/Links/types.ts
@@ -7,9 +7,14 @@ export type LinkProps = Partial<HTMLProps<HTMLAnchorElement>> & {
   cms?: boolean;
   fullServerRedirect?: boolean;
   innerRef?: Ref<any>;
+  children?: ReactNode;
 };
 
 export type LinkProviderProps = {
   link: FC<LinkProps>;
   children: ReactNode;
+};
+
+export type ProviderProps = {
+  children?: ReactNode;
 };


### PR DESCRIPTION
add children to types to prevent errors after removing implicit children in react 18