### PR TITLE
fix: 🐛 added option to show close button for status modal

### DIFF
--- a/src/Organisms/StatusModal/StatusModal.stories.tsx
+++ b/src/Organisms/StatusModal/StatusModal.stories.tsx
@@ -67,6 +67,7 @@ storiesOf('Organisms / StatusModal', module)
           {...defaultProps}
           loading={false}
           options={twoButtonsOptions}
+          showClose
           onClose={(confirmed: boolean) => {
             setButtonClicked(confirmed ? 'CONFIRM' : 'CANCEL');
           }}

--- a/src/Organisms/StatusModal/StatusModal.tsx
+++ b/src/Organisms/StatusModal/StatusModal.tsx
@@ -3,7 +3,13 @@ import { Box, Button, Flexbox, Modal, Spinner, Typography, OldIcon } from '../..
 import { Props } from './StatusModal.types';
 import { isFunction } from '../../common/utils';
 
-const StatusModal: React.FC<Props> = ({ id = '', loading = false, onClose, options = {} }) => {
+const StatusModal: React.FC<Props> = ({
+  id = '',
+  loading = false,
+  onClose,
+  options = {},
+  showClose = false,
+}) => {
   const [showModal, setShowModal] = useState(false);
 
   const { status, title, text, textConfirm, textCancel } = options || {};
@@ -30,8 +36,8 @@ const StatusModal: React.FC<Props> = ({ id = '', loading = false, onClose, optio
   return (
     <Modal
       open={showModal}
-      onClose={onClose}
-      hideClose
+      onClose={closeModal}
+      hideClose={!showClose}
       closeOnBackdropClick
       isStatusModal
       fullScreenMobile={false}

--- a/src/Organisms/StatusModal/StatusModal.tsx
+++ b/src/Organisms/StatusModal/StatusModal.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { Box, Button, Flexbox, Modal, Spinner, Typography, OldIcon } from '../..';
+import { Box, Button, Flexbox, Modal, Spinner, Typography, Badge } from '../..';
 import { Props } from './StatusModal.types';
 import { isFunction } from '../../common/utils';
 
@@ -38,7 +38,7 @@ const StatusModal: React.FC<Props> = ({
   return (
     <Modal
       open={showModal}
-      onClose={closeModal}
+      onClose={onClose}
       hideClose={!showClose}
       closeOnBackdropClick
       isStatusModal
@@ -55,15 +55,9 @@ const StatusModal: React.FC<Props> = ({
           justifyContent="center"
         >
           {loading && <Spinner id={`${id}-spinner`} size={23} />}
-          {status === 'SUCCESS' && (
-            <OldIcon.CheckMarkCircle fill={(t) => t.color.functionGreen} size={23} />
-          )}
-          {status === 'ERROR' && (
-            <OldIcon.CrossCircle fill={(t) => t.color.functionRed} size={23} />
-          )}
-          {status === 'WARNING' && (
-            <OldIcon.WarningTriangle color={(t) => t.color.warning} size={23} />
-          )}
+          {status === 'SUCCESS' && <Badge.Status variant="complete" badgeSize="xl" />}
+          {status === 'ERROR' && <Badge.Status variant="error" badgeSize="xl" />}
+          {status === 'WARNING' && <Badge.Status variant="warning" badgeSize="xl" />}
           <Flexbox container direction="column" alignItems="center" gutter={2}>
             {title && (
               <Typography type="title2" textAlign="center">

--- a/src/Organisms/StatusModal/StatusModal.types.ts
+++ b/src/Organisms/StatusModal/StatusModal.types.ts
@@ -13,4 +13,5 @@ export type Props = {
   onClose: Function;
   options: Option;
   id: string;
+  showClose?: boolean;
 };

--- a/src/Organisms/StatusModal/StatusModal.types.ts
+++ b/src/Organisms/StatusModal/StatusModal.types.ts
@@ -11,6 +11,8 @@ type Option = {
   text: string;
   textConfirm: string;
   textCancel?: string;
+  onConfirm?: Function;
+  onCancel?: Function;
 } | null;
 
 export type Props = {


### PR DESCRIPTION
the change is backward compatible, fret not