### PR TITLE
fix: need to declare ref on tooltip

### DIFF
--- a/src/Molecules/Tooltip/Tooltip.types.ts
+++ b/src/Molecules/Tooltip/Tooltip.types.ts
@@ -29,6 +29,7 @@ export type Props = {
   openDelay?: number;
   closeDelay?: number;
   isOpen?: boolean;
+  ref?: React.MutableRefObject<any>;
   /**
    * @wrapChild
    * Wraps children with a span DOM element.


### PR DESCRIPTION
Motivation is this: 

`TS2322:` Type '{ children: Element; ref: MutableRefObject<undefined>; isOpen: boolean; label: Element; pointerEvents: true; }' is not assignable to type 'IntrinsicAttributes & Props'.
  Property 'ref' does not exist on type 'IntrinsicAttributes & Props'.`