### PR TITLE
UC-26: add rounded corners to Dropdowns (Input.Select and DropdownBubble)

### DIFF
--- a/src/Atoms/DropdownBubble/DropdownBubble.tsx
+++ b/src/Atoms/DropdownBubble/DropdownBubble.tsx
@@ -133,7 +133,7 @@ export const DropdownBubble = styled.div<Props>`
       p.invertedColors ? p.theme.color.textLight : p.theme.color.text,
       p.textColor,
     )};
-  border-radius: ${({ theme }) => theme.borderRadius(4)};
+  border-radius: ${(p) => p.theme.borderRadius(p.borderRadius ? p.borderRadius : 4)};
   ${bottomAndTopPlacementCss}
   ${triangleCss}
 `;

--- a/src/Atoms/DropdownBubble/DropdownBubble.tsx
+++ b/src/Atoms/DropdownBubble/DropdownBubble.tsx
@@ -133,6 +133,7 @@ export const DropdownBubble = styled.div<Props>`
       p.invertedColors ? p.theme.color.textLight : p.theme.color.text,
       p.textColor,
     )};
+  border-radius: ${({ theme }) => theme.borderRadius(4)};
   ${bottomAndTopPlacementCss}
   ${triangleCss}
 `;

--- a/src/Atoms/DropdownBubble/DropdownBubble.types.ts
+++ b/src/Atoms/DropdownBubble/DropdownBubble.types.ts
@@ -1,4 +1,5 @@
 import { ColorFn } from 'common/Types';
+import { BORDER_RADIUS } from 'theme/theme.types';
 
 export type Props = {
   /**
@@ -22,4 +23,5 @@ export type Props = {
    * for use when you want light mode tooltip colors in dark mode and opposite
    */
   invertedColors?: boolean;
+  borderRadius?: BORDER_RADIUS;
 };

--- a/src/Molecules/Input/Select/lib/wrappers/FormFieldOrFragment.tsx
+++ b/src/Molecules/Input/Select/lib/wrappers/FormFieldOrFragment.tsx
@@ -72,6 +72,7 @@ const SelectWrapper = styled.div`
   background: ${(p) => p.theme.color.inputBackground};
   box-sizing: border-box;
   position: relative;
+  border-radius: ${({ theme }) => theme.borderRadius(4)};
 `;
 
 export const FormFieldOrFragment = React.forwardRef<HTMLDivElement, any>(

--- a/src/Molecules/Slider/Slider.tsx
+++ b/src/Molecules/Slider/Slider.tsx
@@ -255,7 +255,7 @@ const Slider: Component = ({
                 }}
               >
                 <StyledDropdownBubble
-                  borderRadius={2gst}
+                  borderRadius={2}
                   $variant={variant}
                   position="center"
                   placement="top"

--- a/src/Molecules/Slider/Slider.tsx
+++ b/src/Molecules/Slider/Slider.tsx
@@ -255,6 +255,7 @@ const Slider: Component = ({
                 }}
               >
                 <StyledDropdownBubble
+                  borderRadius={2gst}
                   $variant={variant}
                   position="center"
                   placement="top"

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -2,7 +2,7 @@ import { filter, mapObjIndexed, pipe, prop as Rprop, values } from 'ramda';
 import { lightTheme, darkTheme, a11yTheme } from '@nordnet/design-tokens';
 
 import { assert, deprecate, isNumber } from '../common/utils';
-import { Theme, ThemeColorsVersion, ThemeConfig } from './theme.types';
+import { BORDER_RADIUS, Theme, ThemeColorsVersion, ThemeConfig } from './theme.types';
 import { createLightColors, getColorLightScheme } from './createLightColors';
 import { createDarkColors, getColorDarkScheme } from './createDarkColors';
 
@@ -81,6 +81,8 @@ export const createTheme = (config: ThemeConfig = {}): Theme => {
     gutter: GUTTER,
   };
 
+  const borderRadius = (radius: BORDER_RADIUS) => `${radius}px`;
+
   return {
     animation: {
       easing: {},
@@ -119,5 +121,6 @@ export const createTheme = (config: ThemeConfig = {}): Theme => {
     size: deprecate('theme.size, please use theme.breakpoint instead.')(size),
     spacing,
     zIndex,
+    borderRadius,
   };
 };

--- a/src/theme/theme.types.ts
+++ b/src/theme/theme.types.ts
@@ -13,6 +13,11 @@ type Unit = {
   valueOf: () => number;
 };
 
+export type BORDER_RADIUS = 2 | 4 | 6;
+type BorderRadius = {
+  (radius: BORDER_RADIUS): string;
+};
+
 export type RawColor = {
   // BRAND
   brandBlue: string;
@@ -1007,4 +1012,5 @@ export type Theme = {
   };
   isHighContrastMode: boolean;
   isDarkMode: boolean;
+  borderRadius: BorderRadius;
 };


### PR DESCRIPTION
Add 4px border radius to Input.Select and DropdownBubble. Give DropdownBubble a prop for borderRadius since it's used by multiple components with different radius size. Slider tooltip got 2px border radius