### PR TITLE
fix: input field tooltip when in modal

### DIFF
--- a/src/Molecules/FormField/FormField.stories.tsx
+++ b/src/Molecules/FormField/FormField.stories.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { Flexbox, FormField } from '../..';
+import React, { useState } from 'react';
+import { Box, Flexbox, FormField, Modal } from '../..';
 
 export default {
   title: 'Molecules / FormField',
@@ -80,4 +80,43 @@ export const withLabelTooltip = () => (
 
 withLabelTooltip.story = {
   name: 'With label tooltip',
+};
+
+export const withLabelTooltipInsideModal = () => {
+  const Example = () => {
+    const [open, setOpen] = useState(true);
+
+    const onOpen = () => {
+      setOpen(true);
+    };
+
+    const onClose = () => {
+      setOpen(false);
+    };
+
+    return (
+      <>
+        <button type="button" onClick={onOpen}>
+          Open modal
+        </button>
+        <Modal onClose={onClose} title="Dialog information" open={open}>
+          <Box mb={2}>
+            <FormField
+              label="Label"
+              labelTooltip="Tooltip content"
+              fieldId="unique-id-1"
+              labelTooltipInModal
+            >
+              <div style={{ background: 'aqua' }}>Pass in any children you want</div>
+            </FormField>
+          </Box>
+        </Modal>
+      </>
+    );
+  };
+  return <Example />;
+};
+
+withLabelTooltipInsideModal.story = {
+  name: 'With label tooltip inside modal',
 };

--- a/src/Molecules/FormField/FormField.tsx
+++ b/src/Molecules/FormField/FormField.tsx
@@ -32,6 +32,7 @@ const WithOptionalAddon: React.FC<LabelAddonProp> = ({
   labelTooltip,
   labelTooltipPosition,
   hideLabel,
+  labelTooltipInModal,
 }) =>
   hideLabel ? (
     <>{children}</>
@@ -39,7 +40,12 @@ const WithOptionalAddon: React.FC<LabelAddonProp> = ({
     <Flexbox container alignItems="center">
       {children}
       {labelTooltip && (
-        <Tooltip position={labelTooltipPosition} label={labelTooltip}>
+        <Tooltip
+          position={labelTooltipPosition}
+          label={labelTooltip}
+          inModal={labelTooltipInModal}
+          wrapChild={labelTooltipInModal}
+        >
           <TooltipIcon size={4} />
         </Tooltip>
       )}
@@ -60,6 +66,7 @@ export const FormField = React.forwardRef<HTMLDivElement, Props>(
       label,
       labelTooltip,
       labelTooltipPosition,
+      labelTooltipInModal,
       required = false,
       showRequired = false,
       width,
@@ -74,9 +81,10 @@ export const FormField = React.forwardRef<HTMLDivElement, Props>(
       field = (
         <FormLabel disabled={disabled}>
           <WithOptionalAddon
-            labelTooltip={labelTooltip}
-            labelTooltipPosition={labelTooltipPosition}
             hideLabel={hideLabel}
+            labelTooltip={labelTooltip}
+            labelTooltipInModal={labelTooltipInModal}
+            labelTooltipPosition={labelTooltipPosition}
           >
             {hideLabel ? <VisuallyHidden>{labelText}</VisuallyHidden> : labelText}
           </WithOptionalAddon>
@@ -88,9 +96,10 @@ export const FormField = React.forwardRef<HTMLDivElement, Props>(
         field = (
           <Fieldset>
             <WithOptionalAddon
-              labelTooltip={labelTooltip}
-              labelTooltipPosition={labelTooltipPosition}
               hideLabel={hideLabel}
+              labelTooltip={labelTooltip}
+              labelTooltipInModal={labelTooltipInModal}
+              labelTooltipPosition={labelTooltipPosition}
             >
               <Legend styleType="label">{labelText}</Legend>
             </WithOptionalAddon>
@@ -102,9 +111,10 @@ export const FormField = React.forwardRef<HTMLDivElement, Props>(
           <>
             <FormLabel hideLabel={hideLabel} forId={fieldId || forId}>
               <WithOptionalAddon
-                labelTooltip={labelTooltip}
-                labelTooltipPosition={labelTooltipPosition}
                 hideLabel={hideLabel}
+                labelTooltip={labelTooltip}
+                labelTooltipInModal={labelTooltipInModal}
+                labelTooltipPosition={labelTooltipPosition}
               >
                 {labelText}
               </WithOptionalAddon>

--- a/src/Molecules/FormField/FormField.types.ts
+++ b/src/Molecules/FormField/FormField.types.ts
@@ -3,6 +3,7 @@ export type LabelAddonProp = {
   labelTooltipPosition?: 'top' | 'left' | 'bottom' | 'right';
   hideLabel?: boolean;
   children?: React.ReactNode;
+  labelTooltipInModal?: boolean
 };
 
 export type Props = {

--- a/src/Molecules/Input/Checkbox/Checkbox.tsx
+++ b/src/Molecules/Input/Checkbox/Checkbox.tsx
@@ -131,6 +131,7 @@ const Checkbox: CheckboxComponent & { components: typeof components; Shape: type
     label,
     labelTooltip,
     labelTooltipPosition,
+    labelTooltipInModal,
     name,
     onBlur,
     onChange,
@@ -191,6 +192,8 @@ const Checkbox: CheckboxComponent & { components: typeof components; Shape: type
               <Tooltip
                 label={labelTooltip}
                 {...(labelTooltipPosition && { position: labelTooltipPosition })}
+                inModal={labelTooltipInModal}
+                wrapChild={labelTooltipInModal}
               >
                 <TooltipIcon size={4} />
               </Tooltip>

--- a/src/Molecules/Input/Checkbox/Checkbox.types.ts
+++ b/src/Molecules/Input/Checkbox/Checkbox.types.ts
@@ -13,6 +13,7 @@ export type Props = {
   label: string | JSX.Element;
   labelTooltip?: string;
   labelTooltipPosition?: 'top' | 'left' | 'bottom' | 'right';
+  labelTooltipInModal?: boolean;
   name?: string;
   required?: boolean;
   value?: string;

--- a/src/Molecules/Input/Number/Number.tsx
+++ b/src/Molecules/Input/Number/Number.tsx
@@ -326,6 +326,7 @@ const NumberInput: NumberComponent & {
           'label',
           'labelTooltip',
           'labelTooltipPosition',
+          'labelTooltipInModal',
           'width',
           'className',
         ],

--- a/src/Molecules/Input/Number/Number.types.ts
+++ b/src/Molecules/Input/Number/Number.types.ts
@@ -34,6 +34,7 @@ export type Props = {
   label: string;
   labelTooltip?: string;
   labelTooltipPosition?: 'top' | 'left' | 'bottom' | 'right';
+  labelTooltipInModal?: boolean;
   leftAddon?: React.ReactNode;
   max?: string | number;
   min?: string | number;

--- a/src/Molecules/Input/Phone/Phone.tsx
+++ b/src/Molecules/Input/Phone/Phone.tsx
@@ -208,6 +208,7 @@ const PhoneComponent = React.forwardRef<HTMLInputElement, Props>((props, ref) =>
           'label',
           'labelTooltip',
           'labelTooltipPosition',
+          'labelTooltipInModal',
           'className',
           'width',
           'disabled',

--- a/src/Molecules/Input/Phone/Phone.types.ts
+++ b/src/Molecules/Input/Phone/Phone.types.ts
@@ -15,6 +15,7 @@ export type Props = {
   hideLabel?: boolean;
   labelTooltip?: string;
   labelTooltipPosition?: 'top' | 'left' | 'bottom' | 'right';
+  labelTooltipInModal?: boolean;
   autoComplete?: string;
   autoFocus?: boolean;
   name?: string;

--- a/src/Molecules/Input/Select/Select.tsx
+++ b/src/Molecules/Input/Select/Select.tsx
@@ -292,6 +292,7 @@ const Select = (props: Props) => {
           hideLabel={props.hideLabel}
           labelToolTip={props.labelTooltip}
           labelTooltipPosition={props.labelTooltipPosition}
+          labelTooltipInModal={props.labelTooltipInModal}
           noFormField={props.noFormField}
           ref={formFieldRef}
           innerRef={selectWrapperRef}

--- a/src/Molecules/Input/Select/Select.types.ts
+++ b/src/Molecules/Input/Select/Select.types.ts
@@ -22,6 +22,7 @@ export type Props = {
   hideLabel?: boolean;
   labelTooltip?: string;
   labelTooltipPosition?: 'top' | 'left' | 'bottom' | 'right';
+  labelTooltipInModal?: boolean;
   placeholder?: string;
   label: string;
   name?: string;

--- a/src/Molecules/Input/Select/lib/wrappers/FormFieldOrFragment.tsx
+++ b/src/Molecules/Input/Select/lib/wrappers/FormFieldOrFragment.tsx
@@ -87,6 +87,7 @@ export const FormFieldOrFragment = React.forwardRef<HTMLDivElement, any>(
       size,
       labelToolTip,
       labelTooltipPosition,
+      labelTooltipInModal,
       innerRef,
       ...props
     },
@@ -120,6 +121,7 @@ export const FormFieldOrFragment = React.forwardRef<HTMLDivElement, any>(
             fieldId={id}
             labelTooltip={labelToolTip}
             labelTooltipPosition={labelTooltipPosition}
+            labelTooltipInModal={labelTooltipInModal}
             {...props}
             {...(fullWidth ? { width: '100%' } : {})}
             ref={ref}

--- a/src/Molecules/Input/Text/Text.tsx
+++ b/src/Molecules/Input/Text/Text.tsx
@@ -221,6 +221,7 @@ const TextComponent = React.forwardRef<HTMLInputElement, Props>((props, ref) => 
           'label',
           'labelTooltip',
           'labelTooltipPosition',
+          'labelTooltipInModal',
           'className',
           'width',
           'disabled',

--- a/src/Molecules/Input/Textarea/Textarea.tsx
+++ b/src/Molecules/Input/Textarea/Textarea.tsx
@@ -107,6 +107,7 @@ export const Textarea: React.FC<Props> & {
           'label',
           'labelTooltip',
           'labelTooltipPosition',
+          'labelTooltipInModal',
           'width',
         ],
         props,

--- a/src/Molecules/Input/Textarea/Textarea.types.ts
+++ b/src/Molecules/Input/Textarea/Textarea.types.ts
@@ -6,6 +6,7 @@ export type Props = {
   hideLabel?: boolean;
   labelTooltip?: string;
   labelTooltipPosition?: 'top' | 'left' | 'bottom' | 'right';
+  labelTooltipInModal?: boolean;
   autoFocus?: boolean;
   name?: string;
   error?: string;


### PR DESCRIPTION
The Tooltip component has a property to indicate if it is being displayed in a modal or not. But when using the tooltip inside the label of an input field this property is not accessible. This makes the tooltip not work when the field is placed in a modal.