### PR TITLE
feat: deprecate gutter and use gap

### DIFF
--- a/docs/1.Intro.stories.mdx
+++ b/docs/1.Intro.stories.mdx
@@ -25,7 +25,7 @@ import { Flexbox, Typography, Link, Box, Separator } from '../src';
 >
   <Flexbox
     container
-    gutter={0}
+    gap={0}
     alignItems="center"
     direction="column"
     justifyContent="center"

--- a/src/Atoms/CssGrid/CssGrid.tsx
+++ b/src/Atoms/CssGrid/CssGrid.tsx
@@ -38,8 +38,8 @@ const getGutterStyles = (props: { gutter: Gutter; theme: Theme }) => {
   }
 
   return `
-    column-gap: ${theme.spacing.unit(col)}px;;
-    row-gap: ${theme.spacing.unit(row)}px;;
+    column-gap: ${theme.spacing.unit(col)}px;
+    row-gap: ${theme.spacing.unit(row)}px;
   `;
 };
 

--- a/src/Atoms/Flexbox/Flexbox.stories.tsx
+++ b/src/Atoms/Flexbox/Flexbox.stories.tsx
@@ -47,17 +47,6 @@ export const columnSizedFlexboxes = () => (
   </Flexbox>
 );
 
-export const withCustomGutter = () => (
-  <Flexbox container gutter={5}>
-    <Flexbox item size={6}>
-      <Content>Col 1</Content>
-    </Flexbox>
-    <Flexbox item size={6}>
-      <Content>Col 2</Content>
-    </Flexbox>
-  </Flexbox>
-);
-
 const tenTimes = [...Array(10)].map((_, i) => {
   return i + 1;
 });
@@ -142,8 +131,8 @@ export const withConditionallyVisibleFlexItem = () => {
 
 export const withContainerAndItemProps = () => {
   return (
-    <Flexbox container gutter={5}>
-      <Flexbox container item direction="column" gutter={5}>
+    <Flexbox container gap={5}>
+      <Flexbox container item direction="column" gap={5}>
         <Flexbox item>
           <Content>First element here</Content>
         </Flexbox>
@@ -170,12 +159,12 @@ export const withBreakpointProps = () => {
   return (
     <Flexbox
       container
-      gutter={4}
+      gap={4}
       direction="column"
-      sm={{ gutter: 6 }}
-      md={{ gutter: 6, direction: 'row' }}
-      lg={{ gutter: 10, direction: 'row' }}
-      xl={{ gutter: 10, direction: 'row' }}
+      sm={{ gap: 6 }}
+      md={{ gap: 6, direction: 'row' }}
+      lg={{ gap: 10, direction: 'row' }}
+      xl={{ gap: 10, direction: 'row' }}
     >
       <Flexbox item>
         <Content>First element here</Content>
@@ -221,7 +210,7 @@ const HeightAndWidthTemplate: Story<{
       height={height}
       alignItems="center"
       justifyContent="space-between"
-      gutter={5}
+      gap={5}
     >
       <Flexbox item height="100%">
         <GrowingDiv>One</GrowingDiv>
@@ -255,7 +244,7 @@ export const differentSizedItems = () => (
     height={100}
     alignItems="center"
     justifyContent="space-between"
-    gutter={5}
+    gap={5}
   >
     <Flexbox item width="100%" height="100%">
       <GrowingDiv>One</GrowingDiv>

--- a/src/Atoms/Flexbox/Flexbox.tsx
+++ b/src/Atoms/Flexbox/Flexbox.tsx
@@ -72,7 +72,7 @@ const getGapStyles = (theme: Theme, gap: Props['gap']) => {
   }
 
   if (typeof gap === 'number') {
-    gapStyle = `${theme.spacing.unit(gap)}px`;
+    gapStyle = `${theme.spacing.unit(gap)}px;`;
   } else if (typeof gap === 'string') {
     gapStyle = gap;
   } else {

--- a/src/Atoms/Flexbox/Flexbox.types.ts
+++ b/src/Atoms/Flexbox/Flexbox.types.ts
@@ -13,6 +13,7 @@ export type ContainerProps = {
   /** flexbox direction */
   direction?: 'row' | 'row-reverse' | 'column' | 'column-reverse';
   wrap?: 'nowrap' | 'wrap' | 'wrap-reverse';
+  /** @deprecated use gap instead */
   gutter?: number;
   hidden?: boolean;
   justifyContent?:

--- a/src/Atoms/Icon/action/Action.stories.tsx
+++ b/src/Atoms/Icon/action/Action.stories.tsx
@@ -14,7 +14,7 @@ export default {
 };
 
 const SizeIcons = (size: string) => (
-  <Flexbox container gutter={8} wrap="wrap">
+  <Flexbox container gap={8} wrap="wrap">
     {Object?.entries(Icon)
       ?.filter((name) => name[0].includes(size))
       .map(([iconName, IconComponent]: [string, React.ComponentType<any>], index) => (

--- a/src/Atoms/Icon/communication/Communication.stories.tsx
+++ b/src/Atoms/Icon/communication/Communication.stories.tsx
@@ -14,7 +14,7 @@ export default {
 };
 
 const SizeIcons = (size: string) => (
-  <Flexbox container gutter={8} wrap="wrap">
+  <Flexbox container gap={8} wrap="wrap">
     {Object?.entries(Icon)
       ?.filter((name) => name[0].includes(size))
       .map(([iconName, IconComponent]: [string, React.ComponentType<any>], index) => (

--- a/src/Atoms/Icon/device/Device.stories.tsx
+++ b/src/Atoms/Icon/device/Device.stories.tsx
@@ -14,7 +14,7 @@ export default {
 };
 
 const SizeIcons = (size: string) => (
-  <Flexbox container gutter={8} wrap="wrap">
+  <Flexbox container gap={8} wrap="wrap">
     {Object?.entries(Icon)
       ?.filter((name) => name[0].includes(size))
       .map(([iconName, IconComponent]: [string, React.ComponentType<any>], index) => (

--- a/src/Atoms/Icon/file/File.stories.tsx
+++ b/src/Atoms/Icon/file/File.stories.tsx
@@ -14,7 +14,7 @@ export default {
 };
 
 const SizeIcons = (size: string) => (
-  <Flexbox container gutter={8} wrap="wrap">
+  <Flexbox container gap={8} wrap="wrap">
     {Object?.entries(Icon)
       ?.filter((name) => name[0].includes(size))
       .map(([iconName, IconComponent]: [string, React.ComponentType<any>], index) => (

--- a/src/Atoms/Icon/finance/Finance.stories.tsx
+++ b/src/Atoms/Icon/finance/Finance.stories.tsx
@@ -14,7 +14,7 @@ export default {
 };
 
 const SizeIcons = (size: string) => (
-  <Flexbox container gutter={8} wrap="wrap">
+  <Flexbox container gap={8} wrap="wrap">
     {Object?.entries(Icon)
       ?.filter((name) => name[0].includes(size))
       .map(([iconName, IconComponent]: [string, React.ComponentType<any>], index) => (

--- a/src/Atoms/Icon/general/General.stories.tsx
+++ b/src/Atoms/Icon/general/General.stories.tsx
@@ -14,7 +14,7 @@ export default {
 };
 
 const SizeIcons = (size: string) => (
-  <Flexbox container gutter={8} wrap="wrap">
+  <Flexbox container gap={8} wrap="wrap">
     {Object?.entries(Icon)
       ?.filter((name) => name[0].includes(size))
       .map(([iconName, IconComponent]: [string, React.ComponentType<any>], index) => (

--- a/src/Atoms/Icon/graph/Graph.stories.tsx
+++ b/src/Atoms/Icon/graph/Graph.stories.tsx
@@ -14,7 +14,7 @@ export default {
 };
 
 const SizeIcons = (size: string) => (
-  <Flexbox container gutter={8} wrap="wrap">
+  <Flexbox container gap={8} wrap="wrap">
     {Object?.entries(Icon)
       ?.filter((name) => name[0].includes(size))
       .map(([iconName, IconComponent]: [string, React.ComponentType<any>], index) => (

--- a/src/Atoms/Icon/industry/Industry.stories.tsx
+++ b/src/Atoms/Icon/industry/Industry.stories.tsx
@@ -14,7 +14,7 @@ export default {
 };
 
 const SizeIcons = (size: string) => (
-  <Flexbox container gutter={8} wrap="wrap">
+  <Flexbox container gap={8} wrap="wrap">
     {Object?.entries(Icon)
       ?.filter((name) => name[0].includes(size))
       .map(([iconName, IconComponent]: [string, React.ComponentType<any>], index) => (

--- a/src/Atoms/Icon/transfer/Transfer.stories.tsx
+++ b/src/Atoms/Icon/transfer/Transfer.stories.tsx
@@ -14,7 +14,7 @@ export default {
 };
 
 const SizeIcons = (size: string) => (
-  <Flexbox container gutter={8} wrap="wrap">
+  <Flexbox container gap={8} wrap="wrap">
     {Object?.entries(Icon)
       ?.filter((name) => name[0].includes(size))
       .map(([iconName, IconComponent]: [string, React.ComponentType<any>], index) => (

--- a/src/Atoms/Illustration/Illustration.stories.tsx
+++ b/src/Atoms/Illustration/Illustration.stories.tsx
@@ -105,7 +105,7 @@ const StyledLabeledValue = styled(LabeledValue)`
 `;
 
 const SizeIllustrations = (size: string) => (
-  <StyledFlexbox container gutter={8} wrap="wrap">
+  <StyledFlexbox container gap={8} wrap="wrap">
     {Object?.entries(Illustration)
       ?.filter((name) => name[0].includes(size))
       .map(

--- a/src/Atoms/Pill/Pill.stories.tsx
+++ b/src/Atoms/Pill/Pill.stories.tsx
@@ -38,7 +38,7 @@ roundedPill.story = {
 
 export const pillWithBar = () => (
   <Pill barColor={(t) => t.color.cta}>
-    <Flexbox container gutter={1} alignItems="center">
+    <Flexbox container gap={1} alignItems="center">
       <Flexbox item>
         <Button type="button" variant="neutral">
           <Typography type="tertiary" weight="bold">

--- a/src/Atoms/Pill/components/RoundedPill/RoundedPill.tsx
+++ b/src/Atoms/Pill/components/RoundedPill/RoundedPill.tsx
@@ -45,7 +45,7 @@ const Circle = styled.div<CircleProps>`
 export const RoundedPill: React.FC<Props> = ({ className, label, color, development, onClose }) => (
   <StyledDivRounded className={className} $hasOnClose={isFunction(onClose)}>
     <Button variant="neutral" onClick={onClose}>
-      <Flexbox container alignItems="center" gutter={1}>
+      <Flexbox container alignItems="center" gap={1}>
         {color ? (
           <Flexbox item>
             <Circle $color={color} />

--- a/src/Molecules/AccordionItem/AccordionItem.stories.tsx
+++ b/src/Molecules/AccordionItem/AccordionItem.stories.tsx
@@ -57,7 +57,7 @@ export const controlled = () => {
     return (
       <>
         <Box mb={4}>
-          <Flexbox container gutter={4}>
+          <Flexbox container gap={4}>
             <Flexbox item>
               <Button variant="primary" onClick={() => clickHandler('first')}>
                 Toggle first

--- a/src/Molecules/BarScale/BarScale.tsx
+++ b/src/Molecules/BarScale/BarScale.tsx
@@ -27,7 +27,7 @@ export const BarScale: React.FC<Props> = ({
 
   return (
     <>
-      <Flexbox container gutter={gutter}>
+      <Flexbox container gap={gutter}>
         {R.range(1, verifiedMaxRating + 1)?.map((bar) => (
           <Flexbox key={bar} item flex="1 1 auto">
             <Indicator $isActive={isActive(bar)} $barHeight={barHeight} />

--- a/src/Molecules/BottomWizardBar/BottomWizardBar.tsx
+++ b/src/Molecules/BottomWizardBar/BottomWizardBar.tsx
@@ -56,8 +56,8 @@ const BottomWizardBar: React.FC<Props> = ({
         <nav aria-label={titleText}>
           <Flexbox
             container
-            gutter={4}
-            sm={{ gutter: 8 }}
+            gap={4}
+            sm={{ gap: 8 }}
             justifyContent="space-between"
             alignItems="center"
           >
@@ -78,8 +78,8 @@ const BottomWizardBar: React.FC<Props> = ({
               </Flexbox>
             )}
             <Flexbox
-              gutter={4}
-              sm={{ gutter: 8 }}
+              gap={4}
+              sm={{ gap: 8 }}
               container
               item
               {...(isEmbedded && { flex: '1' })}
@@ -98,7 +98,7 @@ const BottomWizardBar: React.FC<Props> = ({
                     color={(t) => t.color.cta}
                     {...(previousButtonLink && { to: previousButtonLink })}
                   >
-                    <Flexbox container justifyContent="center" alignItems="center" gutter={2}>
+                    <Flexbox container justifyContent="center" alignItems="center" gap={2}>
                       <OldIcon.ThinChevron direction="left" inline color="currentColor" size={4} />
                       {previousText}
                     </Flexbox>

--- a/src/Molecules/Button/Button.Gallery.stories.tsx
+++ b/src/Molecules/Button/Button.Gallery.stories.tsx
@@ -74,7 +74,7 @@ const ButtonDisplays: React.FC<{
                 title: toTitle(buttonSize),
                 component: iconPicker(buttonSize).map((icon) => (
                   <Box key={`${variant}${buttonSize}${icon.iconName}`} pb={5}>
-                    <Flexbox container gutter={5}>
+                    <Flexbox container gap={5}>
                       {iconPlacements.map((iconPlacement) => (
                         <Flexbox
                           item
@@ -133,7 +133,7 @@ const ButtonsWithIconsTemplate: Story<{
     <>
       <Card>
         <Box p={5}>
-          <Flexbox container gutter={4} alignItems="center">
+          <Flexbox container gap={4} alignItems="center">
             <Flexbox item>
               <Typography>Icon pages:</Typography>
             </Flexbox>

--- a/src/Molecules/Button/components/BaseButton/Button.Default.stories.tsx
+++ b/src/Molecules/Button/components/BaseButton/Button.Default.stories.tsx
@@ -270,7 +270,7 @@ export const buttonWithFocusOn = () => {
       }
     };
     return (
-      <Flexbox container gutter={5}>
+      <Flexbox container gap={5}>
         <Flexbox item>
           <Button onClick={handleFocus}>Click to focus</Button>
         </Flexbox>
@@ -455,7 +455,7 @@ buttonThatIsFullWidth.story = {
 };
 
 export const buttonsComposedInAGroup = () => (
-  <Flexbox container gutter={2}>
+  <Flexbox container gap={2}>
     <Flexbox item flex="1 1 50%">
       <Button type="submit" onClick={action('submit')} fullWidth>
         Submit

--- a/src/Molecules/Button/components/BaseButton/Button.Link.stories.tsx
+++ b/src/Molecules/Button/components/BaseButton/Button.Link.stories.tsx
@@ -51,7 +51,7 @@ linkLookingLikeAButtonThatIsFullWidth.story = {
 
 export const linksLookingLikeButtonsComposedInAGroup = () => (
   <Provider>
-    <Flexbox container gutter={2}>
+    <Flexbox container gap={2}>
       <Flexbox item flex="1">
         <Button to="/route1" onClick={action('submit')} fullWidth>
           Submit

--- a/src/Molecules/Button/components/ButtonContent/ButtonContent.tsx
+++ b/src/Molecules/Button/components/ButtonContent/ButtonContent.tsx
@@ -63,7 +63,7 @@ export const ButtonContent: ButtonContentComponent = (props) => {
       {icon ? (
         <Flexbox
           container
-          gutter={variant === 'neutral' && size === 's' ? 1 : 2}
+          gap={variant === 'neutral' && size === 's' ? 1 : 2}
           justifyContent="space-between"
           alignItems="baseline"
         >

--- a/src/Molecules/Button/components/PillButton/PillButton.stories.tsx
+++ b/src/Molecules/Button/components/PillButton/PillButton.stories.tsx
@@ -353,7 +353,7 @@ pillButtonThatIsFullWidth.story = {
 };
 
 export const pillButtonsComposedInAGroup = () => (
-  <Flexbox container gutter={2}>
+  <Flexbox container gap={2}>
     <Flexbox item flex="1 1 50%">
       <SecondaryBackground>
         <PillButton onClick={action('submit')} fullWidth>

--- a/src/Molecules/CheckList/DrawerTitle.tsx
+++ b/src/Molecules/CheckList/DrawerTitle.tsx
@@ -15,7 +15,7 @@ const DrawerTitle: FC<DrawerTitleProps> = ({
   onHelpClick = () => {},
 }): ReactElement => {
   return (
-    <Flexbox container gutter={2} alignItems="center">
+    <Flexbox container gap={2} alignItems="center">
       {showHelpTitle && (
         <Flexbox item>
           <Button variant="neutral" onClick={onHelpClick}>

--- a/src/Molecules/CoachMarks/CoachMarks.styled.ts
+++ b/src/Molecules/CoachMarks/CoachMarks.styled.ts
@@ -31,7 +31,7 @@ export const IconFlex = styled(Flexbox)`
 export const NavigationButtonsContainer = styled(Flexbox)<{ $hasSingleButton?: boolean }>`
   margin-left: auto;
   min-width: ${(p) =>
-    p.$hasSingleButton ? `${p.theme.spacing.unit(25)}px` : `${p.theme.spacing.unit(50)}px`};
+    p.$hasSingleButton ? `${p.theme.spacing.unit(19)}px` : `${p.theme.spacing.unit(44)}px`};
 `;
 
 export const Content = styled.div`

--- a/src/Molecules/CoachMarks/CoachMarks.tsx
+++ b/src/Molecules/CoachMarks/CoachMarks.tsx
@@ -148,9 +148,9 @@ export const CoachMarks: Component = ({
               noBorder={!!barColor}
             />
           )}
-          <Flexbox container item direction="column" flex="1" gutter={5} ref={internalCoachMarkRef}>
+          <Flexbox container item direction="column" flex="1" gap={5} ref={internalCoachMarkRef}>
             {body || (
-              <Flexbox container direction="column" gutter={1}>
+              <Flexbox container direction="column" gap={1}>
                 {icon && <IconFlex item>{icon}</IconFlex>}
                 {title && (
                   <Flexbox item>
@@ -176,7 +176,7 @@ export const CoachMarks: Component = ({
                 )}
               </Flexbox>
             )}
-            <FooterFlex container item alignItems="baseline" gutter={5}>
+            <FooterFlex container item alignItems="baseline" gap={5}>
               {closeButton ? (
                 <Flexbox item>
                   <Button variant="neutral" color={(t) => t.color.link} onClick={onClose}>
@@ -192,15 +192,15 @@ export const CoachMarks: Component = ({
                   </Flexbox>
                 )
               )}
-              <NavigationButtonsContainer container gutter={1} $hasSingleButton={!hasPrevStep}>
+              <NavigationButtonsContainer container gap={1} $hasSingleButton={!hasPrevStep}>
                 {hasPrevStep && (
-                  <Flexbox item flex="1 0 50%">
+                  <Flexbox item flex="1 1 50%">
                     <Button variant="secondary" onClick={handleStepBackwards} fullWidth>
                       {prevText}
                     </Button>
                   </Flexbox>
                 )}
-                <Flexbox item flex="1 0 50%">
+                <Flexbox item flex="1 1 50%">
                   {hasNextStep ? (
                     <Button
                       variant="primary"

--- a/src/Molecules/ControlsListItem/ControlsListItemSelectButton.tsx
+++ b/src/Molecules/ControlsListItem/ControlsListItemSelectButton.tsx
@@ -23,7 +23,7 @@ const ControlsListItemSelectButton = (buttonText: string | React.ReactElement) =
 
   return (
     <SelectWrapper>
-      <Flexbox container alignItems="center" gutter={2}>
+      <Flexbox container alignItems="center" gap={2}>
         <StyledTypography type="secondary" weight="bold">
           {buttonText}
         </StyledTypography>

--- a/src/Molecules/DatePicker/Double/DoubleDatePicker.stories.tsx
+++ b/src/Molecules/DatePicker/Double/DoubleDatePicker.stories.tsx
@@ -50,7 +50,7 @@ export const Controlled = () => {
 
   return (
     <>
-      <Flexbox container gutter={2}>
+      <Flexbox container gap={2}>
         <Flexbox item>
           <Button onClick={() => setStartDate(add(startDate, { days: 1 }))}>Next date</Button>
         </Flexbox>

--- a/src/Molecules/DatePicker/Double/DoubleDatePicker.tsx
+++ b/src/Molecules/DatePicker/Double/DoubleDatePicker.tsx
@@ -171,7 +171,7 @@ const DoubleDatePicker = React.forwardRef<HTMLDivElement, DoubleDatePickerProps>
 
   return (
     <div ref={(ref || selfRef) as React.Ref<HTMLDivElement>}>
-      <Flexbox container wrap="wrap" gutter={1} alignItems="flex-end">
+      <Flexbox container wrap="wrap" gap={1} alignItems="flex-end">
         <StyledInputText
           size={inputSize}
           label={labelFrom}

--- a/src/Molecules/DatePicker/Range/DateRangePicker.stories.tsx
+++ b/src/Molecules/DatePicker/Range/DateRangePicker.stories.tsx
@@ -45,7 +45,7 @@ export const Controlled = () => {
 
   return (
     <>
-      <Flexbox container gutter={2}>
+      <Flexbox container gap={2}>
         <Flexbox item>
           <Button onClick={() => setStartDate(add(startDate || new Date(), { days: 1 }))}>
             Next date

--- a/src/Molecules/DatePicker/Range/DateRangePicker.tsx
+++ b/src/Molecules/DatePicker/Range/DateRangePicker.tsx
@@ -237,7 +237,7 @@ const DateRangePicker = React.forwardRef<HTMLDivElement, Props>((props, ref) => 
         >
           <>
             <Box pb={4}>
-              <Flexbox container gutter={2} justifyContent="center">
+              <Flexbox container gap={2} justifyContent="center">
                 <Flexbox item flex="1">
                   <Input.Text
                     id="fromDate"

--- a/src/Molecules/DatePicker/Single/DatePicker.tsx
+++ b/src/Molecules/DatePicker/Single/DatePicker.tsx
@@ -228,7 +228,7 @@ const DatePicker = React.forwardRef<HTMLDivElement, SingleDatePickerProps>((prop
         >
           <>
             <Box pb={4}>
-              <Flexbox container gutter={2} justifyContent="center">
+              <Flexbox container gap={2} justifyContent="center">
                 <Flexbox item flex="1">
                   <Input.Text
                     id="fromDate"

--- a/src/Molecules/DatePicker/SingleClearable/DatePickerClearable.tsx
+++ b/src/Molecules/DatePicker/SingleClearable/DatePickerClearable.tsx
@@ -229,7 +229,7 @@ const DatePickerClearable = React.forwardRef<HTMLDivElement, SingleDatePickerCle
           >
             <>
               <Box pb={4}>
-                <Flexbox container gutter={2} justifyContent="center">
+                <Flexbox container gap={2} justifyContent="center">
                   <Flexbox item flex="1">
                     <Input.Text
                       id="fromDate"

--- a/src/Molecules/Drawer/Drawer.stories.tsx
+++ b/src/Molecules/Drawer/Drawer.stories.tsx
@@ -142,7 +142,7 @@ export const withCustomTitle = () => {
         <Drawer
           onClose={onClose}
           title={
-            <Flexbox container gutter={2} alignItems="center">
+            <Flexbox container gap={2} alignItems="center">
               <OldIcon.Bank />
               <Typography type="title2" as="h2">
                 Custom title

--- a/src/Molecules/FeedbackBanner/FeedbackBanner.tsx
+++ b/src/Molecules/FeedbackBanner/FeedbackBanner.tsx
@@ -62,7 +62,7 @@ export const FeedbackBanner: FeedbackBannerComponent = ({
 }) => {
   return (
     <StyledContainer className={className} variant={variant} scope={scope}>
-      <Flexbox container direction="row" alignItems="center" gutter={3}>
+      <Flexbox container direction="row" alignItems="center" gap={3}>
         {withIcon && <>{getIcon(variant)}</>}
         <TextFlexbox container item direction="column">
           {title && (

--- a/src/Molecules/FlexTable/Row/Row.tsx
+++ b/src/Molecules/FlexTable/Row/Row.tsx
@@ -51,7 +51,7 @@ type StyledRowProps = {
   $lg: Partial<ScreenSizeConfigurableProps>;
   $xl: Partial<ScreenSizeConfigurableProps>;
 };
-/* the cells are padded by row gutter 1 unit (4px) */
+/* the cells are padded by row gap 1 unit (4px) */
 const StyledRow = styled(Flexbox)<StyledRowProps>`
   background: ${(p) => p.theme.color.tableRowBackground};
 
@@ -163,11 +163,11 @@ const Row: RowComponent = ({
         $md={mdRow}
         $lg={lgRow}
         $xl={xlRow}
-        gutter={xsFlexbox?.columnDistance}
-        sm={{ gutter: smFlexbox?.columnDistance }}
-        md={{ gutter: mdFlexbox?.columnDistance }}
-        lg={{ gutter: lgFlexbox?.columnDistance }}
-        xl={{ gutter: xlFlexbox?.columnDistance }}
+        gap={xsFlexbox?.columnDistance}
+        sm={{ gap: smFlexbox?.columnDistance }}
+        md={{ gap: mdFlexbox?.columnDistance }}
+        lg={{ gap: lgFlexbox?.columnDistance }}
+        xl={{ gap: xlFlexbox?.columnDistance }}
         onClick={clickRowToExpand ? onExpandToggleClick : undefined}
         {...htmlProps}
       >

--- a/src/Molecules/FlexTable/Row/components/ExpandItems/ExpandItems.tsx
+++ b/src/Molecules/FlexTable/Row/components/ExpandItems/ExpandItems.tsx
@@ -14,7 +14,7 @@ export const ExpandItems: ExpandItemsComponent = ({ items }) => {
         </List>
       </Media>
       <Media query={(t) => t.media.greaterThan(t.breakpoints.md)}>
-        <Flexbox container wrap="wrap" gutter={10} as={List}>
+        <Flexbox container wrap="wrap" gap={10} as={List}>
           {items?.map((item, index) => (
             <ExpandItem key={`expandItem_desktop_${index + 1}`} item={item} />
           ))}

--- a/src/Molecules/FlexTable/shared/shared.types.ts
+++ b/src/Molecules/FlexTable/shared/shared.types.ts
@@ -18,6 +18,7 @@ export type FlexPropsType = Pick<
   | 'direction'
   | 'flex'
   | 'grow'
+  | 'gap'
   | 'gutter'
   | 'height'
   | 'item'

--- a/src/Molecules/FlexTable/stories/WithDifferentTableProps.stories.tsx
+++ b/src/Molecules/FlexTable/stories/WithDifferentTableProps.stories.tsx
@@ -61,7 +61,7 @@ const CustomTitle: React.FC<{ country: string; name: string; shortName: string }
   name,
   shortName,
 }) => (
-  <Flexbox container alignItems="baseline" gutter={1}>
+  <Flexbox container alignItems="baseline" gap={1}>
     <Flexbox item>
       <Flag country={country} size="s" />
     </Flexbox>

--- a/src/Molecules/FlexTable/stories/WithExpandableRows.stories.tsx
+++ b/src/Molecules/FlexTable/stories/WithExpandableRows.stories.tsx
@@ -42,7 +42,7 @@ const expandedItemsGenerator = (renderComponent = false) =>
   }, []);
 
 const expandChildrenComponents = (
-  <Flexbox container justifyContent="center" gutter={2}>
+  <Flexbox container justifyContent="center" gap={2}>
     <Flexbox item>
       <Button size="l" variant="primary">
         Buy

--- a/src/Molecules/FormField/FormField.stories.tsx
+++ b/src/Molecules/FormField/FormField.stories.tsx
@@ -27,7 +27,7 @@ defaultStory.story = {
 
 export const withGroupOfItems = () => (
   <FormField label="Caption to a group of items" fieldId="unique-id-1" group>
-    <Flexbox container gutter={5}>
+    <Flexbox container gap={5}>
       <Flexbox item>
         <div style={{ background: 'aqua' }}>Pass in any children you want</div>
       </Flexbox>

--- a/src/Molecules/Input/Checkbox/Checkbox.stories.tsx
+++ b/src/Molecules/Input/Checkbox/Checkbox.stories.tsx
@@ -175,7 +175,7 @@ withAnErrorIfNotChecked.story = {
 
 export const inAGroup = () => (
   <FormField label="Colors" group>
-    <Flexbox container gutter={5}>
+    <Flexbox container gap={5}>
       <Input.Checkbox name="example" value="green" label="Green" />
       <Input.Checkbox name="example" value="blue" label="Blue" />
       <Input.Checkbox name="example" value="yellow" label="Yellow" />
@@ -189,7 +189,7 @@ inAGroup.story = {
 
 export const inAGroupWithTooltip = () => (
   <FormField label="Colors" labelTooltip="Checkboxgroup tooltip" group>
-    <Flexbox container gutter={5}>
+    <Flexbox container gap={5}>
       <Input.Checkbox name="example" value="green" label="Green" />
       <Input.Checkbox name="example" value="blue" label="Blue" />
       <Input.Checkbox name="example" value="yellow" label="Yellow" />
@@ -206,7 +206,7 @@ export const inAGroupWithTooltipPositionTop = () => (
     <br />
     <br />
     <FormField label="Colors" labelTooltip="Checkboxgroup tooltip" labelTooltipPosition="top" group>
-      <Flexbox container gutter={5}>
+      <Flexbox container gap={5}>
         <Input.Checkbox name="example" value="green" label="Green" />
         <Input.Checkbox name="example" value="blue" label="Blue" />
         <Input.Checkbox name="example" value="yellow" label="Yellow" />
@@ -232,7 +232,7 @@ export const inAGroupWithError = () => {
         group
         {...(hasGroupError ? { error: 'This field is required' } : {})}
       >
-        <Flexbox container gutter={5}>
+        <Flexbox container gap={5}>
           <Input.Checkbox
             name="example"
             value="green"
@@ -330,7 +330,7 @@ elementLabelStory.story = {
 
 export const withDifferentSizes = () => {
   return (
-    <Flexbox container direction="column" gutter={1}>
+    <Flexbox container direction="column" gap={1}>
       <Input.Checkbox name="small" value="1" size="s" label="small" />
       <Input.Checkbox name="medium" value="2" label="medium" />
       <Input.Checkbox name="default" value="3" label="default" />

--- a/src/Molecules/Input/Phone/CountryCodeLabel/CountryCodeLabel.tsx
+++ b/src/Molecules/Input/Phone/CountryCodeLabel/CountryCodeLabel.tsx
@@ -8,7 +8,7 @@ const CountryCodeLabel: React.FC<Props> = ({
   prefixCode = '+46',
   noPrefix = false,
 }) => (
-  <Flexbox container alignItems="center" gutter={2}>
+  <Flexbox container alignItems="center" gap={2}>
     <Flexbox item>
       <Flag country={countryCode.toLowerCase()} size="s" />
     </Flexbox>

--- a/src/Molecules/Input/Phone/Phone.stories.tsx
+++ b/src/Molecules/Input/Phone/Phone.stories.tsx
@@ -91,7 +91,7 @@ export const isDisabled = () => (
 );
 
 export const sortByCountry = () => (
-  <Flexbox container direction="column" gutter={3}>
+  <Flexbox container direction="column" gap={3}>
     <Input.Phone name="country-code-example" label="Sweden" sortByCountry="se" />
     <Input.Phone name="country-code-example" label="Denmark" sortByCountry="dk" />
     <Input.Phone name="country-code-example" label="Finland" sortByCountry="fi" />

--- a/src/Molecules/Input/Phone/Phone.tsx
+++ b/src/Molecules/Input/Phone/Phone.tsx
@@ -81,7 +81,7 @@ const PhoneComponent = React.forwardRef<HTMLInputElement, Props>((props, ref) =>
       },
       {
         label: (
-          <Flexbox container alignItems="center" gutter={3}>
+          <Flexbox container alignItems="center" gap={3}>
             <Flexbox item>
               <OldIcon.Globe size={3} />
             </Flexbox>

--- a/src/Molecules/Input/Radio/Radio.stories.tsx
+++ b/src/Molecules/Input/Radio/Radio.stories.tsx
@@ -130,7 +130,7 @@ withAnErrorIfNotChecked.story = {
 
 export const inAGroup = () => (
   <FormField label="Colors" group>
-    <Flexbox container gutter={5}>
+    <Flexbox container gap={5}>
       <Input.Radio name="example" value="green" label="Green" />
       <Input.Radio name="example" value="blue" label="Blue" />
       <Input.Radio name="example" value="yellow" label="Yellow" />
@@ -144,7 +144,7 @@ inAGroup.story = {
 
 export const inAGroupWithTooltip = () => (
   <FormField label="Colors" labelTooltip="Checkbox tooltip" group>
-    <Flexbox container gutter={5}>
+    <Flexbox container gap={5}>
       <Input.Radio name="example" value="green" label="Green" />
       <Input.Radio name="example" value="blue" label="Blue" />
       <Input.Radio name="example" value="yellow" label="Yellow" />
@@ -161,7 +161,7 @@ export const inAGroupWithTooltipPositionTop = () => (
     <br />
     <br />
     <FormField label="Colors" labelTooltip="Checkbox tooltip" labelTooltipPosition="top" group>
-      <Flexbox container gutter={5}>
+      <Flexbox container gap={5}>
         <Input.Radio name="example" value="green" label="Green" />
         <Input.Radio name="example" value="blue" label="Blue" />
         <Input.Radio name="example" value="yellow" label="Yellow" />
@@ -187,7 +187,7 @@ export const inAGroupWithError = () => {
         group
         {...(hasGroupError ? { error: 'This field is required' } : {})}
       >
-        <Flexbox container gutter={5}>
+        <Flexbox container gap={5}>
           <Input.Radio
             name="example"
             value="green"
@@ -273,7 +273,7 @@ onAColouredBackground.story = {
 
 export const inAGroupWithCustomLabel = () => (
   <FormField label="Colors" labelTooltip="Checkbox tooltip" group>
-    <Flexbox container gutter={5}>
+    <Flexbox container gap={5}>
       <Input.Radio id="Green" name="example" value="green" label="Green" noRadioCircle>
         <StyledRadioLabel htmlFor="Green" checked>
           Green

--- a/src/Molecules/Input/Select/Select.mdx
+++ b/src/Molecules/Input/Select/Select.mdx
@@ -52,16 +52,16 @@ The options passed to `value` will be checked with `options` first by referentia
     </Flexbox>
     <Flexbox item container>
       <Flexbox container direction="column">
-        <Flexbox item container alignItems="center" gutter={2}>
+        <Flexbox item container alignItems="center" gap={2}>
           <OldIcon.SolidCircle color={(t) => 'rgb(255,147,1)'} /> FormField
         </Flexbox>
-        <Flexbox item container alignItems="center" gutter={2}>
+        <Flexbox item container alignItems="center" gap={2}>
           <OldIcon.SolidCircle color={(t) => 'rgb(25,25,255)'} /> SelectedValue
         </Flexbox>
-        <Flexbox item container alignItems="center" gutter={2}>
+        <Flexbox item container alignItems="center" gap={2}>
           <OldIcon.SolidCircle color={(t) => 'rgb(255,25,1)'} /> List
         </Flexbox>
-        <Flexbox item container alignItems="center" gutter={2}>
+        <Flexbox item container alignItems="center" gap={2}>
           <OldIcon.SolidCircle color={(t) => 'rgb(25,100,25)'} /> ListItem
         </Flexbox>
       </Flexbox>

--- a/src/Molecules/Input/Select/Select.stories.tsx
+++ b/src/Molecules/Input/Select/Select.stories.tsx
@@ -127,7 +127,7 @@ const AccountValue = () => {
       {!selectedOption ? (
         state.context.placeholder
       ) : (
-        <Flexbox container item justifyContent="space-between" gutter={2} grow={1}>
+        <Flexbox container item justifyContent="space-between" gap={2} grow={1}>
           <Flexbox item container alignItems="center" basis="32px" grow={0}>
             <Badge.Account badgeSize="s">{selectedOption.symbol}</Badge.Account>
           </Flexbox>
@@ -167,8 +167,8 @@ const AccountListItem = ({ index }) => {
   const focused = isKeyboardNavigation && state.context.itemFocusIdx === index;
   return (
     <StyledBox px={2} py={1} focused={focused} isKeyboardNavigation={isKeyboardNavigation}>
-      <Flexbox container justifyContent="space-between" gutter={4}>
-        <Flexbox item container alignItems="center" basis="32px" grow={0}>
+      <Flexbox container justifyContent="space-between" alignItems="center" gap={4}>
+        <Flexbox item container>
           <Badge.Account badgeSize="s">{option.symbol}</Badge.Account>
         </Flexbox>
         <Flexbox item container direction="column" grow={1}>
@@ -1130,7 +1130,7 @@ export const linkWithDropdownAndSearchBoxSecondary = () =>
 
           return (
             <Link as="div">
-              <Flexbox container alignItems="center" gutter={1}>
+              <Flexbox container alignItems="center" gap={1}>
                 <Flexbox item container alignItems="center">
                   <OldIcon.AddWithCircle inline color={(t) => t.color.text} size={3.5} />
                 </Flexbox>
@@ -1208,7 +1208,7 @@ export const linkWithDropdownAndSearchBoxTertiary = () =>
 
           return (
             <Link as="div">
-              <Flexbox container alignItems="center" gutter={1}>
+              <Flexbox container alignItems="center" gap={1}>
                 <Flexbox item container alignItems="center">
                   <OldIcon.AddWithCircle inline color={(t) => t.color.text} size={3} />
                 </Flexbox>
@@ -1289,7 +1289,7 @@ export const linkWithDropdownAndSearchBoxMultiselect = () =>
 
           return (
             <Link as="div">
-              <Flexbox container alignItems="center" gutter={1}>
+              <Flexbox container alignItems="center" gap={1}>
                 <Flexbox item container alignItems="center">
                   <OldIcon.AddWithCircle inline color={(t) => t.color.text} size={3} />
                 </Flexbox>
@@ -1386,7 +1386,7 @@ export const linkWithDropdownAndSearchBoxMultiselectWithFullScreenOnMobile = () 
 
           return (
             <Link as="div">
-              <Flexbox container alignItems="center" gutter={1}>
+              <Flexbox container alignItems="center" gap={1}>
                 <Flexbox item container alignItems="center">
                   <OldIcon.AddWithCircle inline color={(t) => t.color.text} size={3} />
                 </Flexbox>
@@ -1485,7 +1485,7 @@ export const listPositionedToTheLeft = () =>
 
           return (
             <Link as="div">
-              <Flexbox container alignItems="center" gutter={1}>
+              <Flexbox container alignItems="center" gap={1}>
                 <Flexbox item container alignItems="center">
                   <OldIcon.AddWithCircle inline color={(t) => t.color.text} size={3} />
                 </Flexbox>

--- a/src/Molecules/Input/Select/lib/MultiSelectList/MultiSelectList.tsx
+++ b/src/Molecules/Input/Select/lib/MultiSelectList/MultiSelectList.tsx
@@ -109,7 +109,7 @@ export const Option: React.FC<OptionProps> = ({
     isKeyboardNavigation={isKeyboardNavigation}
     fullscreenOnMobile={fullscreenOnMobile}
   >
-    <FullHeightFlexbox container alignItems="center" gutter={2}>
+    <FullHeightFlexbox container alignItems="center" gap={2}>
       <Flexbox item container alignItems="center" flex="0 0 auto">
         {/** TODO: revisit a11y here */}
         <Checkbox16px

--- a/src/Molecules/Input/Select/lib/defaults/Action.tsx
+++ b/src/Molecules/Input/Select/lib/defaults/Action.tsx
@@ -53,7 +53,7 @@ export const Action: React.FC<{
       weight="bold"
       color={(t) => (disabled ? t.color.disabledText : t.color.cta)}
     >
-      <Flexbox container gutter={2} alignItems="center">
+      <Flexbox container gap={2} alignItems="center">
         {icon}
         <EllipsizingText>{label}</EllipsizingText>
       </Flexbox>

--- a/src/Molecules/Input/Text/Text.stories.tsx
+++ b/src/Molecules/Input/Text/Text.stories.tsx
@@ -264,8 +264,8 @@ hiddenLabel.story = {
 };
 
 export const simpleLoginForm = () => (
-  <Flexbox container direction="column" gutter={4}>
-    <Flexbox item container gutter={4}>
+  <Flexbox container direction="column" gap={4}>
+    <Flexbox item container gap={4}>
       <Flexbox item basis="50%">
         <Input.Text
           width="100%"

--- a/src/Molecules/LabeledValue/LabeledValue.stories.tsx
+++ b/src/Molecules/LabeledValue/LabeledValue.stories.tsx
@@ -41,7 +41,7 @@ integrationLabeledValueTitle1.story = {
 
 export const integrationLabeledValueWithPositiveDevelopmentAndCurrency = () => (
   <LabeledValue label="Development this year">
-    <Flexbox container direction="row" gutter={2}>
+    <Flexbox container direction="row" gap={2}>
       <Flexbox item>
         <Typography type="secondary" weight="bold">
           <Development value={9.2} icon percentage />
@@ -62,7 +62,7 @@ integrationLabeledValueWithPositiveDevelopmentAndCurrency.story = {
 
 export const integrationLabeledValueWithNegativeDevelopmentAndCurrency = () => (
   <LabeledValue label="Development this year">
-    <Flexbox container direction="row" gutter={2}>
+    <Flexbox container direction="row" gap={2}>
       <Flexbox item>
         <Typography type="secondary">
           <Development value={-9.2} icon percentage />

--- a/src/Molecules/ListWithTitles/ListWithTitles.tsx
+++ b/src/Molecules/ListWithTitles/ListWithTitles.tsx
@@ -12,7 +12,7 @@ export const ListWithTitles: ListWithTitlesComponent = (props) => {
   return leftTitle || rightTitle ? (
     <div className={className}>
       <TitleContainer>
-        <Flexbox container gutter={0} justifyContent="space-between">
+        <Flexbox container gap={0} justifyContent="space-between">
           <Flexbox item>
             <Typography type="secondary" color={(t) => t.color.label}>
               {leftTitle}

--- a/src/Molecules/Modal/Modal.stories.tsx
+++ b/src/Molecules/Modal/Modal.stories.tsx
@@ -319,7 +319,7 @@ hideClose.story = {
 
 export const nodeAsTitle = () => {
   const Title = (
-    <Flexbox container gutter={2} alignItems="center">
+    <Flexbox container gap={2} alignItems="center">
       <OldIcon.Bolt />
       <Typography type="title2" as="h2">
         React Node Title
@@ -861,7 +861,7 @@ export const modalStandardMobile = () => {
     };
 
     const footer = (
-      <Flexbox container gutter={2}>
+      <Flexbox container gap={2}>
         <Flexbox container item flex="1">
           <Button variant="secondary" size="l" onClick={() => {}} fullWidth>
             Cancel
@@ -1010,7 +1010,7 @@ export const modalMobileSmall = () => {
     };
 
     const footer = (
-      <Flexbox container gutter={2}>
+      <Flexbox container gap={2}>
         <Flexbox container item flex="1">
           <Button variant="secondary" size="l" onClick={() => {}} fullWidth>
             Button
@@ -1133,7 +1133,7 @@ export const modalMobileFullscreenWithScroll = () => {
     };
 
     const footer = (
-      <Flexbox container gutter={2}>
+      <Flexbox container gap={2}>
         <Flexbox container item flex="1">
           <Button variant="secondary" size="l" onClick={() => {}} fullWidth>
             Button

--- a/src/Molecules/MultiStepProgress/MultiStepProgress.tsx
+++ b/src/Molecules/MultiStepProgress/MultiStepProgress.tsx
@@ -93,7 +93,7 @@ export const MultiStepProgress: MultiStepProgressComponent = ({
         <StyledDrawer
           onClose={onDrawerClose}
           title={
-            <Flexbox container gutter={2} alignItems="center">
+            <Flexbox container gap={2} alignItems="center">
               <Typography type="title2" as="h2">
                 {mobileDrawerTitle}
               </Typography>

--- a/src/Molecules/PageHeaderCard/PageHeaderCard.stories.tsx
+++ b/src/Molecules/PageHeaderCard/PageHeaderCard.stories.tsx
@@ -17,7 +17,7 @@ regularPageHeader.story = {
 export const pageHeaderWithChildren = () => (
   <PageHeaderCard title="Your darkest loaves">
     <Box py={2} sm={{ py: 0 }}>
-      <Flexbox container gutter={2} alignItems="center" justifyContent="space-between">
+      <Flexbox container gap={2} alignItems="center" justifyContent="space-between">
         <Flexbox item>The eternal loremipsum, The portuguese friend</Flexbox>
         <Flexbox item>
           <Button>Click here to recruit carl</Button>

--- a/src/Molecules/PageHeaderCard/PageHeaderCard.tsx
+++ b/src/Molecules/PageHeaderCard/PageHeaderCard.tsx
@@ -27,7 +27,7 @@ export const PageHeaderCard: PageHeaderCardComponent = ({ title, className, chil
       <PageWrapper>
         <Flexbox
           container
-          gutter={0}
+          gap={0}
           direction="column"
           sm={{ direction: 'row', justifyContent: 'space-between', alignItems: 'center' }}
         >

--- a/src/Molecules/Pagination/variants/Compact.tsx
+++ b/src/Molecules/Pagination/variants/Compact.tsx
@@ -21,7 +21,7 @@ const Compact: React.FC<PaginationCompactProps> = ({
   nextPageLabel,
 }) => {
   return (
-    <Flexbox container gutter={1}>
+    <Flexbox container gap={1}>
       {currentPage !== 1 && (
         <ChevronButton direction="left" onClick={onClickPrevious} label={previousPageLabel} />
       )}

--- a/src/Molecules/Pagination/variants/CompactLinks.tsx
+++ b/src/Molecules/Pagination/variants/CompactLinks.tsx
@@ -22,7 +22,7 @@ const CompactLinks: React.FC<PaginationCompactLinkProps> = ({
   getPageHref,
 }) => {
   return (
-    <Flexbox container gutter={1} alignItems="center">
+    <Flexbox container gap={1} alignItems="center">
       {currentPage !== 1 && (
         <ChevronLink
           direction="left"

--- a/src/Molecules/Pagination/variants/Regular.tsx
+++ b/src/Molecules/Pagination/variants/Regular.tsx
@@ -53,7 +53,7 @@ const Regular: React.FC<PaginationDefaultProps> = ({
       {currentPage !== 1 && (
         <ChevronButton direction="left" onClick={onClickPrevious} label={previousPageLabel} />
       )}
-      <Flexbox container item flex="1" justifyContent="center" gutter={2} as={List}>
+      <Flexbox container item flex="1" justifyContent="center" gap={2} as={List}>
         <PageItems
           currentPage={currentPage}
           numberOfPages={numberOfPages}

--- a/src/Molecules/Pagination/variants/RegularLinks.tsx
+++ b/src/Molecules/Pagination/variants/RegularLinks.tsx
@@ -60,7 +60,7 @@ const RegularLinks: React.FC<PaginationDefaultLinkProps> = ({
           href={getPageHref(currentPage - 1)}
         />
       )}
-      <Flexbox container item flex="1" justifyContent="center" gutter={2} as={List}>
+      <Flexbox container item flex="1" justifyContent="center" gap={2} as={List}>
         <PageItems
           currentPage={currentPage}
           numberOfPages={numberOfPages}

--- a/src/Molecules/PersistentTooltip/PersistentTooltip.stories.tsx
+++ b/src/Molecules/PersistentTooltip/PersistentTooltip.stories.tsx
@@ -106,7 +106,7 @@ export const CustomTitleAndDescription = () => {
           </Box>
         }
         description={
-          <Flexbox container gutter={4}>
+          <Flexbox container gap={4}>
             <Flexbox item>
               <Typography color={t => t.color.textLight}>
                 I am in a custom jsx description.

--- a/src/Molecules/ProgressBar/ProgressBar.stories.tsx
+++ b/src/Molecules/ProgressBar/ProgressBar.stories.tsx
@@ -30,7 +30,7 @@ export const StepProgression = () => {
   const stepLabels = ['One', 'Two', 'Three'];
   return (
     <Box px={10}>
-      <Flexbox container direction="column" gutter={2}>
+      <Flexbox container direction="column" gap={2}>
         <ProgressBar numberOfSteps={3} currentStep={1} stepLabels={stepLabels} />
         <ProgressBar numberOfSteps={3} currentStep={2} stepLabels={stepLabels} />
         <ProgressBar numberOfSteps={3} currentStep={3} stepLabels={stepLabels} />
@@ -43,7 +43,7 @@ export const FailureStep = () => {
   const stepLabels = ['One', 'Two', 'Failed step', 'Four'];
   return (
     <Box px={10}>
-      <Flexbox container direction="column" gutter={2}>
+      <Flexbox container direction="column" gap={2}>
         <ProgressBar numberOfSteps={4} currentStep={3} stepLabels={stepLabels} failed />
       </Flexbox>
     </Box>
@@ -54,7 +54,7 @@ export const WarningStep = () => {
   const stepLabels = ['One', 'Two', 'Step with warning', 'Four'];
   return (
     <Box px={10}>
-      <Flexbox container direction="column" gutter={2}>
+      <Flexbox container direction="column" gap={2}>
         <ProgressBar numberOfSteps={4} currentStep={3} stepLabels={stepLabels} warning />
       </Flexbox>
     </Box>

--- a/src/Molecules/PromotionBanner/PromotionBanner.tsx
+++ b/src/Molecules/PromotionBanner/PromotionBanner.tsx
@@ -90,11 +90,11 @@ export const PromotionBanner: PromotionBannerComponent = ({
             direction="row"
             alignItems="center"
             justifyContent={justifyContent}
-            gutter={3}
+            gap={3}
             width="100%"
-            sm={{ gutter: 5 }}
-            md={{ gutter: 5 }}
-            lg={{ gutter: 5, justifyContent, width: '772px' }}
+            sm={{ gap: 5 }}
+            md={{ gap: 5 }}
+            lg={{ gap: 5, justifyContent, width: '772px' }}
             xl={{ width: '772px' }}
           >
             {mobileBadgeContent && badgeContent && (
@@ -111,12 +111,12 @@ export const PromotionBanner: PromotionBannerComponent = ({
               container
               item
               direction="column"
-              gutter={2}
+              gap={2}
               alignItems="flex-start"
-              sm={{ gutter: 3 }}
+              sm={{ gap: 3 }}
               lg={{
                 direction: scope === 'page' ? 'row' : 'column',
-                gutter: isPageDesktop ? 5 : 3,
+                gap: isPageDesktop ? 5 : 3,
                 width: 'auto',
               }}
             >
@@ -124,9 +124,9 @@ export const PromotionBanner: PromotionBannerComponent = ({
                 container
                 item
                 direction="column"
-                gutter={1}
-                sm={{ gutter: 2, justifyContent: 'center' }}
-                lg={{ gutter: isPageDesktop ? 2 : 1 }}
+                gap={1}
+                sm={{ gap: 2, justifyContent: 'center' }}
+                lg={{ gap: isPageDesktop ? 2 : 1 }}
               >
                 <Flexbox item>
                   <Typography

--- a/src/Molecules/QuickFilter/QuickFilter.stories.tsx
+++ b/src/Molecules/QuickFilter/QuickFilter.stories.tsx
@@ -13,7 +13,7 @@ export default {
 export const WithFourFilterChips = () => (
   <Card>
     <Box p={2}>
-      <Flexbox container gutter={1}>
+      <Flexbox container gap={1}>
         <FilterChip icon={<Icon.MonthlySavings16 />} value="1" />{' '}
         <FilterChip icon={<Icon.MonthlySavings16 />} label="&nbsp;" value="1" />{' '}
         <FilterChip icon={<Icon.MonthlySavings16 />} label="label" value="1" />{' '}

--- a/src/Molecules/Rating/Rating.stories.tsx
+++ b/src/Molecules/Rating/Rating.stories.tsx
@@ -72,7 +72,7 @@ export const RatingOutOf3WithLabel = () => (
     alignItems="center"
     justifyContent="center"
     width="100%"
-    gutter={4}
+    gap={4}
     height="100vh"
   >
     <Flexbox container direction="column" alignItems="center" justifyContent="center">

--- a/src/Molecules/SelectionCard/SelectionCard.tsx
+++ b/src/Molecules/SelectionCard/SelectionCard.tsx
@@ -191,14 +191,14 @@ export const SelectionCard: SelectionCardComponent = ({
 
         <StyledDiv $feature={hasFeature} $tag={Boolean(tag)} $text={Boolean(text)}>
           {horizontal && (
-            <Flexbox container direction="row" gutter={5} alignContent="center">
+            <Flexbox container direction="row" gap={5} alignContent="center">
               {hasIcon && (
                 <Flexbox item alignSelf="center">
                   {icon}
                 </Flexbox>
               )}
 
-              <Flexbox container direction="column" gutter={1} alignItems="flex-start">
+              <Flexbox container direction="column" gap={1} alignItems="flex-start">
                 {titleItem}
                 {textItem}
               </Flexbox>
@@ -206,7 +206,7 @@ export const SelectionCard: SelectionCardComponent = ({
           )}
 
           {!horizontal && (
-            <Flexbox container direction="column" alignItems="center" gutter={1}>
+            <Flexbox container direction="column" alignItems="center" gap={1}>
               {hasIcon && (
                 <Flexbox item {...(text && { alignSelf: 'flex-start' })}>
                   {icon}

--- a/src/Molecules/Switch/SwitchToggle.stories.tsx
+++ b/src/Molecules/Switch/SwitchToggle.stories.tsx
@@ -22,7 +22,7 @@ export const defaultSwitchToggle = () => {
 
     return (
       <Box py={5} backgroundColor={(t) => t.color.bubbleBackground}>
-        <Flexbox container gutter={2}>
+        <Flexbox container gap={2}>
           <Flexbox container item>
             <SwitchToggle
               checked={toggled}
@@ -62,7 +62,7 @@ export const augmentedWidthSwitchToggle = () => {
 
     return (
       <Box py={5} backgroundColor={(t) => t.color.bubbleBackground}>
-        <Flexbox container gutter={2}>
+        <Flexbox container gap={2}>
           <Flexbox container item>
             <SwitchToggle
               checked={toggled}

--- a/src/Molecules/Switch/SwitchToggle.tsx
+++ b/src/Molecules/Switch/SwitchToggle.tsx
@@ -135,7 +135,7 @@ export const SwitchToggle: React.FC<SwitchToggleProps> = ({
 
   return (
     <Label>
-      <Flexbox container gutter={2} alignItems="center" as="span">
+      <Flexbox container gap={2} alignItems="center" as="span">
         <Flexbox item as="span">
           {hiddenLabel ? <VisuallyHidden>{titleNode}</VisuallyHidden> : titleNode}
         </Flexbox>

--- a/src/Molecules/Tabs/Tabs.tsx
+++ b/src/Molecules/Tabs/Tabs.tsx
@@ -195,8 +195,8 @@ export const Tabs: ContainerComponent & {
         <Flexbox
           container
           direction="row"
-          gutter={4}
-          sm={{ gutter: variant === 'large' ? 8 : 4 }}
+          gap={4}
+          sm={{ gap: variant === 'large' ? 8 : 4 }}
           as={StyledUl}
         >
           {titles}

--- a/src/Molecules/TabsNav/TabsNav.stories.tsx
+++ b/src/Molecules/TabsNav/TabsNav.stories.tsx
@@ -34,7 +34,7 @@ const Content = ({ height, hideFirst }: ContentProps) => {
   const route1Match = useMatch('/route1');
   const route2Match = useMatch('/route2');
   return (
-    <Flexbox container direction="column" gutter={0}>
+    <Flexbox container direction="column" gap={0}>
       <Flexbox item>
         <TabsNav height={height}>
           {!hideFirst && (
@@ -116,7 +116,7 @@ const ContentWithManyLinks = () => {
   const route6Match = useMatch('/route6');
 
   return (
-    <Flexbox container direction="column" gutter={0}>
+    <Flexbox container direction="column" gap={0}>
       <Flexbox item>
         <TabsNav height={11} scrollOptions={{ active: true, scrollBarHidden: true }}>
           <TabsNav.Tab

--- a/src/Molecules/TabsNav/TabsNav.tsx
+++ b/src/Molecules/TabsNav/TabsNav.tsx
@@ -167,7 +167,7 @@ export const TabsNav: Component = ({
       container
       ref={scrollRef}
     >
-      <Flexbox container direction="row" gutter={4} sm={{ gutter: 8 }} as={StyledUl}>
+      <Flexbox container direction="row" gap={4} sm={{ gap: 8 }} as={StyledUl}>
         {titles}
       </Flexbox>
     </StyledFlexbox>

--- a/src/Molecules/Toggle/Toggle.tsx
+++ b/src/Molecules/Toggle/Toggle.tsx
@@ -117,7 +117,7 @@ export const Toggle: React.FC<Props> = ({
 
   return (
     <Label>
-      <Flexbox container gutter={2} alignItems="center" as="span">
+      <Flexbox container gap={2} alignItems="center" as="span">
         {hiddenLabel ? (
           <VisuallyHidden>{titleNode}</VisuallyHidden>
         ) : (

--- a/src/Molecules/Tooltip/Tooltip.stories.tsx
+++ b/src/Molecules/Tooltip/Tooltip.stories.tsx
@@ -340,7 +340,7 @@ export const WithClickableContent = () => {
 
 export const WithOffset = () => (
   <Box p={20}>
-    <Flexbox container gutter={4} alignItems="center">
+    <Flexbox container gap={4} alignItems="center">
       <Typography type="primary">Hover the pen!</Typography>
       <Tooltip label="This tooltip has offset" wrapChild offset={[-20, 40]}>
         <Icon.Edit16 />
@@ -351,7 +351,7 @@ export const WithOffset = () => (
 
 export const WithOffsetAsAFunction = () => (
   <Box p={20}>
-    <Flexbox container gutter={4} alignItems="center">
+    <Flexbox container gap={4} alignItems="center">
       <Typography type="primary">Hover the pen!</Typography>
       <Tooltip
         position="bottom"

--- a/src/Organisms/StatusModal/StatusModal.tsx
+++ b/src/Organisms/StatusModal/StatusModal.tsx
@@ -54,8 +54,8 @@ const StatusModal: React.FC<Props> = ({
           container
           direction="column"
           alignItems="center"
-          gutter={6}
-          sm={{ gutter: 7 }}
+          gap={6}
+          sm={{ gap: 7 }}
           justifyContent="center"
         >
           {loading && <Spinner id={`${id}-spinner`} size={23} />}
@@ -68,7 +68,7 @@ const StatusModal: React.FC<Props> = ({
           {status === 'WARNING' && (
             <OldIcon.WarningTriangle color={(t) => t.color.warning} size={23} />
           )}
-          <Flexbox container direction="column" alignItems="center" gutter={2}>
+          <Flexbox container direction="column" alignItems="center" gap={2}>
             {title && (
               <Typography type="title2" textAlign="center">
                 {title}
@@ -97,7 +97,7 @@ const StatusModal: React.FC<Props> = ({
               </Flexbox>
             )}
             {textConfirm && textCancel && (
-              <Flexbox container item justifyContent="center" gutter={2}>
+              <Flexbox container item justifyContent="center" gap={2}>
                 <Flexbox item flex="0">
                   <Box pt={2}>
                     {textCancel && (

--- a/src/theme/Theme.stories.tsx
+++ b/src/theme/Theme.stories.tsx
@@ -70,7 +70,7 @@ const colorWithValue = (color: string | string[]) =>
     </>
   ) : (
     color?.map((c: string) => (
-      <Flexbox key={c} container gutter={1}>
+      <Flexbox key={c} container gap={1}>
         <ColorInArray $color={c} />
         <>{c}</>
       </Flexbox>


### PR DESCRIPTION
Deprecating the `gutter` prop and replacing all instances of it in favor for [`gap`](https://caniuse.com/?search=gap). `gutter` was created a long time ago, it was our hack to get spacing between flexbox iteams. We previously added support for `gap`, this just migrates all components to use it.

CSS grid component still uses `gutter` but that component needs to be completely re-written. It was written back when IE did not fully support grid and we had to hack to make it work. Now IE is dead, a cleanup is overdue.