### PR TITLE
fix: 🐛 bump to version that supports node ^20

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   },
   "dependencies": {
     "@mui/base": "5.0.0-beta.2",
-    "@nordnet/design-tokens": "2.0.0",
+    "@nordnet/design-tokens": "2.0.1",
     "@popperjs/core": "^2.11.6",
     "@xstate/react": "^0.7.1",
     "color": "^4.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3458,10 +3458,10 @@
     "@nodelib/fs.scandir" "2.1.4"
     fastq "^1.6.0"
 
-"@nordnet/design-tokens@2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@nordnet/design-tokens/-/design-tokens-2.0.0.tgz#a4eb1f0f2d3a7981a172f2efc01490ee566545c0"
-  integrity sha512-QAOy+WD8Syy1I/5HR/gM9BvIkH6TnuZ60IdChH36u8vRlUln4r1l5KwIw9r006HOxStSThWUodqgb0gM2LNqsw==
+"@nordnet/design-tokens@2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@nordnet/design-tokens/-/design-tokens-2.0.1.tgz#4d0f1044cadc6d4da51b092587d47afe6801a448"
+  integrity sha512-dy7B4DIVNjend45wR2ENJDGPF7gv44WFn+AR9YuIJvbugsK+i6rfQHiIz8anazKmsB+CcXGJKZh6sGDTemrYgg==
 
 "@npmcli/arborist@^5.6.3":
   version "5.6.3"


### PR DESCRIPTION
✅ Closes: SV-3988