### PR TITLE
fix: enlarge card bar if bottomsheet

### DIFF
--- a/src/Molecules/CoachMarks/Bubble/Bubble.tsx
+++ b/src/Molecules/CoachMarks/Bubble/Bubble.tsx
@@ -24,7 +24,7 @@ const barStyles = css<CardProps>`
     content: '';
     display: block;
     width: 100%;
-    height: ${(p) => p.theme.spacing.unit(2)}px;
+    height: ${(p) => p.theme.spacing.unit(p.bottomSheet ? 4 : 2)}px;
     background: ${(p) => getColor(p)};
     position: absolute;
     top: 0;


### PR DESCRIPTION
The bar along with the styling of the bubble card looks a bit wonky in mobile view. (See pics)
This PR fixes this by adding a slightly larger line that covers the corners of its card.

Before:
![image](https://github.com/nordnet/ui/assets/147403186/c83ff79d-0ad4-4231-be62-ecdc9ec38442)

![image](https://github.com/nordnet/ui/assets/147403186/545e7e48-158f-46b4-a144-958147f3ea1d)

After:

