### PR TITLE
fix: use same border radius in mobile as bar

### DIFF
--- a/src/Molecules/CoachMarks/Bubble/Bubble.tsx
+++ b/src/Molecules/CoachMarks/Bubble/Bubble.tsx
@@ -56,7 +56,10 @@ const Card = styled.div<CardProps>`
           transform: none !important;
           inset: auto auto 0px 0px !important;
           position: fixed !important;
-          border-radius: ${p.theme.borderRadius20} ${p.theme.borderRadius20} 0 0 !important; 
+          border-radius: 
+          ${p.barColor ? p.theme.borderRadius8 : p.theme.borderRadius20} 
+          ${p.barColor ? p.theme.borderRadius8 : p.theme.borderRadius20} 
+          0 0 !important; 
         `
         : ''}
   }


### PR DESCRIPTION
The bar along with the styling of the bubble card looks a bit wonky in mobile view. (See pics)
This PR fixes this by adding the same border radius as the bar.

Before:
![image](https://github.com/nordnet/ui/assets/147403186/634e8430-f443-4dbf-abd1-4759dbbc769f)

After:
![image](https://github.com/nordnet/ui/assets/147403186/90cc98d1-0da3-4d6e-aeb2-701c244e3183)
