### PR TITLE
fix: stop overriding FlexTable component types

### DIFF
--- a/src/Molecules/FlexTable/Cell/Cell.types.ts
+++ b/src/Molecules/FlexTable/Cell/Cell.types.ts
@@ -1,6 +1,5 @@
 import React from 'react';
 import { FlexPropsType } from '../shared/shared.types';
-import { TextWrapper } from './TextWrapper';
 
 type RenderProp = {
   columnId: string;
@@ -13,10 +12,6 @@ export type Props = {
    */
   columnId: string;
 } & FlexPropsType;
-
-export type CellComponents = { TextWrapper: typeof TextWrapper };
-
-export type CellComponent = React.FC<Props> & CellComponents;
 
 type ExpandCellProps = {
   /**

--- a/src/Molecules/FlexTable/FlexTable.tsx
+++ b/src/Molecules/FlexTable/FlexTable.tsx
@@ -5,7 +5,7 @@ import { Header } from './Header';
 import { Footer } from './Footer';
 import { Cell } from './Cell';
 import { CellInlineContainer, ColumnProvider, constants, getStylesForSizes } from './shared';
-import { FlexTableComponent, FlexTableComponents } from './FlexTable.types';
+import { Props } from './FlexTable.types';
 import { FlexTableProvider, useFlexTable } from './shared/FlexTableProvider';
 import { ExpandCell } from './Cell/ExpandCell';
 import { Typography } from '../..';
@@ -71,7 +71,7 @@ const StyledTypography = styled(Typography)`
   padding-left: ${(p) => p.theme.spacing.unit(1)}px;
 `;
 
-const FlexTable: FlexTableComponent & FlexTableComponents = ({
+const FlexTable = ({
   className,
   density = 'm',
   columnDistance = 2,
@@ -86,7 +86,7 @@ const FlexTable: FlexTableComponent & FlexTableComponents = ({
   lg,
   xl,
   ...htmlProps
-}) => (
+}: Props) => (
   <FlexTableProvider
     id={htmlProps.id}
     density={density}

--- a/src/Molecules/FlexTable/FlexTable.types.ts
+++ b/src/Molecules/FlexTable/FlexTable.types.ts
@@ -1,15 +1,5 @@
 import React, { ReactElement } from 'react';
-import { FooterRowComponent, HeaderRowComponent, RowComponent } from './Row/Row.types';
-import { HeaderComponent } from './Header/Header.types';
-import { FooterComponent } from './Footer/Footer.types';
-import { constants } from './shared';
-import { CellComponent, ExpandCellComponent } from './Cell/Cell.types';
 import { Props as FlexTableProviderProps } from './shared/FlexTableProvider/FlexTableProvider.types';
-import { CellInlineContainerComponent } from './shared/CellInlineContainer/CellInlineContainer.types';
-import {
-  ExpandItemComponent,
-  ExpandItemsComponent,
-} from './Row/components/ExpandItems/ExpandItems.types';
 
 type HtmlProps = {} & React.HTMLAttributes<HTMLDivElement>;
 
@@ -57,22 +47,6 @@ export type Props = {
   PersistSortingOrderProps &
   Partial<FlexTableProviderProps> &
   Omit<HtmlProps, 'title' | 'id'>;
-
-export type FlexTableComponent = React.FC<Props>;
-
-export type FlexTableComponents = {
-  CONSTANTS: typeof constants;
-  Cell: CellComponent;
-  CellInlineContainer: CellInlineContainerComponent;
-  ExpandCell: ExpandCellComponent;
-  ExpandItem: ExpandItemComponent;
-  ExpandItems: ExpandItemsComponent;
-  Footer: FooterComponent;
-  FooterRow: FooterRowComponent;
-  Header: HeaderComponent;
-  HeaderRow: HeaderRowComponent;
-  Row: RowComponent;
-};
 
 export { Props as CellProps } from './Cell/Cell.types';
 export { Props as FooterProps } from './Footer/Footer.types';


### PR DESCRIPTION
Needed to make https://github.com/nordnet/ui/pull/1533 work.

We are currently saying that the Cell component is a `React.FC<Props>` but it's not, there is a react.memo around it. Let's just let Typescript infer what it is, it'capable of doing it without our input