### PR TITLE
SV-4145 Update CssGrid component with animation support

### DIFF
--- a/src/Atoms/CssGrid/CssGrid.stories.tsx
+++ b/src/Atoms/CssGrid/CssGrid.stories.tsx
@@ -193,13 +193,13 @@ export const StaggeredGrid = {
         <Grid.Item area="header">
           <Content>Header</Content>
         </Grid.Item>
-        <Grid.Item area="content" duration={5}>
+        <Grid.Item area="content" duration={10}>
           <Content>Content</Content>
         </Grid.Item>
-        <Grid.Item area="menu" duration={5}>
+        <Grid.Item area="menu" duration={10}>
           <Content>Menu</Content>
         </Grid.Item>
-        <Grid.Item area="ads" duration={5}>
+        <Grid.Item area="ads" duration={10}>
           <Content>Ads</Content>
         </Grid.Item>
         <Grid.Item area="footer">
@@ -232,7 +232,7 @@ export const StaggeredGrid = {
           area="header"
           variants={{
             hidden: { opacity: 0 },
-            show: { opacity: 1, scale: 1.2, transition: { duration: 10 } },
+            show: { opacity: 1, scale: 1.2, transition: { duration: 15 } },
           }}
         >
           <Content>Header</Content>
@@ -242,7 +242,7 @@ export const StaggeredGrid = {
           animate="show"
           variants={{
             hidden: { opacity: 0 },
-            show: { scale: 0.8, transition: { duration: 10 } },
+            show: { scale: 0.8, transition: { duration: 15 } },
           }}
         >
           <Content>Content</Content>
@@ -252,7 +252,7 @@ export const StaggeredGrid = {
           animate="show"
           variants={{
             hidden: { opacity: 0 },
-            show: { scale: 1.2, rotateZ: -4, transition: { duration: 10 } },
+            show: { scale: 1.2, rotateZ: -4, transition: { duration: 15 } },
           }}
         >
           <Content>Menu</Content>

--- a/src/Atoms/CssGrid/CssGrid.stories.tsx
+++ b/src/Atoms/CssGrid/CssGrid.stories.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import { action } from '@storybook/addon-actions';
 import docs from './CssGrid.mdx';
 
-import { CssGrid as Grid } from '../..';
+import { Box, Flexbox, CssGrid as Grid, Typography } from '../..';
 
 const StyledContent = styled.div`
   box-sizing: border-box;
@@ -47,10 +47,9 @@ export const SimpleCssGrid = {
       ]}
       templateColumns={['1fr', '1fr', '1fr']}
       templateRows={['1fr', '1fr', '1fr']}
-      staggerChildren={1}
     >
       <Grid.Item area="header">
-        <Content>asdasd</Content>
+        <Content>Header</Content>
       </Grid.Item>
       <Grid.Item area="content" duration={3}>
         <Content>Content</Content>
@@ -68,6 +67,221 @@ export const SimpleCssGrid = {
   ),
 
   name: 'Simple CssGrid',
+};
+
+export const StaggeredGrid = {
+  render: () => (
+    <>
+      <Box my={4}>
+        <Flexbox container gap={1} direction="column">
+          <Typography type="title1">Animated grid</Typography>
+          <Typography type="tertiary">
+            You can now use motion variants to grid container or grid item.
+          </Typography>
+        </Flexbox>
+      </Box>
+      <Box my={2}>
+        <Flexbox container gap={1} direction="column">
+          <Typography type="title3">Staggered grid - row animation</Typography>
+          <Typography type="tertiary">
+            By utilizing the <code>staggeredChildren</code> prop, you can animate grid items
+            sequentially.
+          </Typography>
+          <Typography type="tertiary">
+            The default animation is a fade-in effect over 0.5 seconds. The animation proceeds from
+            left to right, referencing the <code>areas</code> prop. The order of{' '}
+            <code>Grid.Item</code> children does not affect this process.
+          </Typography>
+        </Flexbox>
+      </Box>
+      <Grid.Container
+        // prettier-ignore
+        areas={[
+        ['header', 'header', 'header'],
+        ['menu', 'content', 'ads'],
+        ['footer', 'footer', 'footer'],
+      ]}
+        templateColumns={['1fr', '1fr', '1fr']}
+        templateRows={['1fr', '1fr', '1fr']}
+        staggerChildren={0.8}
+        style={{
+          border: '1px solid black',
+          padding: '1rem',
+        }}
+      >
+        <Grid.Item area="header">
+          <Content>Header</Content>
+        </Grid.Item>
+        <Grid.Item area="content">
+          <Content>Content</Content>
+        </Grid.Item>
+        <Grid.Item area="menu">
+          <Content>Menu</Content>
+        </Grid.Item>
+        <Grid.Item area="ads">
+          <Content>Ads</Content>
+        </Grid.Item>
+        <Grid.Item area="footer">
+          <Content>Footer</Content>
+        </Grid.Item>
+      </Grid.Container>
+      <Box my={2}>
+        <Flexbox container gap={1} direction="column">
+          <Typography type="title3">Staggered grid - column animation</Typography>
+          <Typography type="tertiary">
+            By setting <code>staggerDirection=&quot;column&quot;</code> we now animate the grid
+            items from top to bottom.
+          </Typography>
+        </Flexbox>
+      </Box>
+      <Grid.Container
+        // prettier-ignore
+        areas={[
+          ['menu', 'header', 'ads'],
+          ['menu', 'header', 'ads'],
+          ['content', 'footer', 'ads'],
+      ]}
+        templateColumns={['1fr', '1fr', '1fr']}
+        templateRows={['1fr', '1fr', '1fr']}
+        staggerChildren={0.8}
+        staggerDirection="column"
+        style={{
+          border: '1px solid black',
+          padding: '1rem',
+        }}
+      >
+        <Grid.Item area="header">
+          <Content>Header</Content>
+        </Grid.Item>
+        <Grid.Item area="content">
+          <Content>Content</Content>
+        </Grid.Item>
+        <Grid.Item area="menu">
+          <Content>Menu</Content>
+        </Grid.Item>
+        <Grid.Item area="ads">
+          <Content>Ads</Content>
+        </Grid.Item>
+        <Grid.Item area="footer">
+          <Content>Footer</Content>
+        </Grid.Item>
+      </Grid.Container>
+      <Box my={2}>
+        <Flexbox container gap={1} direction="column">
+          <Typography type="title3">Staggered grid - child durations</Typography>
+          <Typography type="tertiary">
+            Each child also has a duration prop that can be used to set the duration of the default
+            fade-in animation.
+          </Typography>
+        </Flexbox>
+      </Box>
+      <Grid.Container
+        // prettier-ignore
+        areas={[
+          ['menu', 'header', 'ads'],
+          ['menu', 'header', 'ads'],
+          ['content', 'footer', 'ads'],
+      ]}
+        templateColumns={['1fr', '1fr', '1fr']}
+        templateRows={['1fr', '1fr', '1fr']}
+        staggerChildren={0.8}
+        style={{
+          border: '1px solid black',
+          padding: '1rem',
+        }}
+      >
+        <Grid.Item area="header">
+          <Content>Header</Content>
+        </Grid.Item>
+        <Grid.Item area="content" duration={5}>
+          <Content>Content</Content>
+        </Grid.Item>
+        <Grid.Item area="menu" duration={5}>
+          <Content>Menu</Content>
+        </Grid.Item>
+        <Grid.Item area="ads" duration={5}>
+          <Content>Ads</Content>
+        </Grid.Item>
+        <Grid.Item area="footer">
+          <Content>Footer</Content>
+        </Grid.Item>
+      </Grid.Container>
+      <Box my={2}>
+        <Flexbox container gap={1} direction="column">
+          <Typography type="title3">Grid with Unique Animations</Typography>
+          <Typography type="tertiary">
+            Each grid item has a unique animation, defined by its own set of variants.
+          </Typography>
+        </Flexbox>
+      </Box>
+      <Grid.Container
+        // prettier-ignore
+        areas={[
+          ['menu', 'header', 'ads'],
+          ['menu', 'header', 'ads'],
+          ['content', 'footer', 'ads'],
+      ]}
+        templateColumns={['1fr', '1fr', '1fr']}
+        templateRows={['1fr', '1fr', '1fr']}
+        style={{
+          border: '1px solid black',
+          padding: '1rem',
+        }}
+      >
+        <Grid.Item
+          area="header"
+          variants={{
+            hidden: { opacity: 0 },
+            show: { opacity: 1, scale: 1.2, transition: { duration: 10 } },
+          }}
+        >
+          <Content>Header</Content>
+        </Grid.Item>
+        <Grid.Item
+          area="content"
+          animate="show"
+          variants={{
+            hidden: { opacity: 0 },
+            show: { scale: 0.8, transition: { duration: 10 } },
+          }}
+        >
+          <Content>Content</Content>
+        </Grid.Item>
+        <Grid.Item
+          area="menu"
+          animate="show"
+          variants={{
+            hidden: { opacity: 0 },
+            show: { scale: 1.2, rotateZ: -4, transition: { duration: 10 } },
+          }}
+        >
+          <Content>Menu</Content>
+        </Grid.Item>
+        <Grid.Item
+          area="ads"
+          animate="show"
+          variants={{
+            hidden: { opacity: 0 },
+            show: { scale: 0.5, rotateX: 4, transition: { duration: 10 } },
+          }}
+        >
+          <Content>Ads</Content>
+        </Grid.Item>
+        <Grid.Item
+          area="footer"
+          animate="show"
+          variants={{
+            hidden: { opacity: 0 },
+            show: { scale: 1.5, rotate: 2, transition: { duration: 10 } },
+          }}
+        >
+          <Content>Footer</Content>
+        </Grid.Item>
+      </Grid.Container>
+    </>
+  ),
+
+  name: 'CssGrid with animations',
 };
 
 export const CssGridWithCustomGutter = {

--- a/src/Atoms/CssGrid/CssGrid.stories.tsx
+++ b/src/Atoms/CssGrid/CssGrid.stories.tsx
@@ -47,11 +47,12 @@ export const SimpleCssGrid = {
       ]}
       templateColumns={['1fr', '1fr', '1fr']}
       templateRows={['1fr', '1fr', '1fr']}
+      staggerChildren={1}
     >
       <Grid.Item area="header">
-        <Content>Header</Content>
+        <Content>asdasd</Content>
       </Grid.Item>
-      <Grid.Item area="content">
+      <Grid.Item area="content" duration={3}>
         <Content>Content</Content>
       </Grid.Item>
       <Grid.Item area="menu">

--- a/src/Atoms/CssGrid/CssGrid.tsx
+++ b/src/Atoms/CssGrid/CssGrid.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo } from 'react';
 import R from 'ramda';
 import styled, { css, withTheme } from 'styled-components';
+import { motion } from 'framer-motion';
 import { Theme } from '../../theme/theme.types';
 import {
   AreaInfo,
@@ -113,15 +114,15 @@ const generateMSGridStyles = ({
     const rowGutter = isNumber(gutter)
       ? `${theme.spacing.unit(gutter)}px`
       : isNumber(gutter.row)
-      ? `${theme.spacing.unit(gutter.row)}px`
-      : gutter.row;
+        ? `${theme.spacing.unit(gutter.row)}px`
+        : gutter.row;
 
     // eslint-disable-next-line no-nested-ternary
     const colGutter = isNumber(gutter)
       ? `${theme.spacing.unit(gutter)}px`
       : isNumber(gutter.col)
-      ? `${theme.spacing.unit(gutter.col)}px`
-      : gutter.col;
+        ? `${theme.spacing.unit(gutter.col)}px`
+        : gutter.col;
 
     if (isRowsPresented) {
       const rawTemplateRowsStyles = templateRowsStyles
@@ -167,7 +168,7 @@ const generateMSGridStyles = ({
   return styles.join('\n');
 };
 
-const StyledDiv = styled.div<Props>`
+const styledDivCss = css<Props>`
   display: grid;
   box-sizing: border-box;
 
@@ -224,7 +225,15 @@ const StyledDiv = styled.div<Props>`
     styles.unshift(createStyles(props, undefined));
     return styles.join('\n');
   }}
-` as React.FC<Props>;
+`;
+
+const StyledMotionDiv = styled(motion.div)`
+  ${styledDivCss}
+`;
+
+const StyledDiv = styled.div`
+  ${styledDivCss}
+`;
 
 const getMsJustifySelfStyles = (justify: ItemProps['justify']) =>
   `-ms-grid-column-align: ${justify};`;
@@ -268,7 +277,7 @@ const getCssGridItemStylesFromProps = ({
   ${getPlaceSelfStyles(place)}
 `;
 
-const RawCssGridItem = styled.div<ItemProps & { css?: any }>`
+const GridItemCss = css<ItemProps & { css?: any }>`
   box-sizing: border-box;
   min-width: 0; /* prevents grid blowout */
   ${(p) => getCssGridItemStylesFromProps(p)}
@@ -284,31 +293,68 @@ const RawCssGridItem = styled.div<ItemProps & { css?: any }>`
       .join('\n')}
 `;
 
+const RawCssGridItemMotion = styled(motion.div)`
+  ${GridItemCss}
+`;
+
+const RawCssGridItemDiv = styled.div`
+  ${GridItemCss}
+`;
+
 export const CssGridItem: React.FC<ItemProps> = ({
   align,
   area,
   children,
+  duration,
   justify,
+  isAnimated,
   place,
   sm,
   md,
   lg,
   xl,
-}) => (
-  <RawCssGridItem
-    {...{
-      align,
-      area,
-      children,
-      justify,
-      place,
-      sm,
-      md,
-      lg,
-      xl,
-    }}
-  />
-);
+}) => {
+  const itemVariants = {
+    hidden: { opacity: 0 },
+    show: { opacity: 1, transition: { duration } },
+  };
+
+  return isAnimated ? (
+    <RawCssGridItemMotion
+      variants={itemVariants}
+      {...{
+        align,
+        area,
+        children,
+        justify,
+        place,
+        sm,
+        md,
+        lg,
+        xl,
+      }}
+    >
+      {children}
+    </RawCssGridItemMotion>
+  ) : (
+    <RawCssGridItemDiv
+      {...{
+        align,
+        area,
+        children,
+        justify,
+        place,
+        sm,
+        md,
+        lg,
+        xl,
+      }}
+    >
+      {children}
+    </RawCssGridItemDiv>
+  );
+};
+
 CssGridItem.displayName = 'CssGrid.Item';
 
 const generateChildStyles =
@@ -335,8 +381,14 @@ const generateChildStyles =
     : styles.join('\n');
   };
 
-const RawCSSGridContainer: React.FC<Props & { theme: Theme }> = ({ theme, children, ...props }) => {
+const RawCSSGridContainer: React.FC<Props & { theme: Theme }> = ({
+  staggerChildren,
+  theme,
+  children,
+  ...props
+}) => {
   const { sm, md, lg, xl } = props;
+  const hasStaggeredValue = staggerChildren !== undefined;
 
   type SizeAreaTuple = [undefined | Size, { areas: Props['areas'] }];
   const stylesFnsForChild = useMemo(
@@ -369,10 +421,33 @@ const RawCSSGridContainer: React.FC<Props & { theme: Theme }> = ({ theme, childr
   const stylesFnForChild = (areaName: string) =>
     stylesFnsForChild?.map((f) => f(areaName)).join('\n');
 
-  const renderedChildren = React.Children?.map<JSX.Element | null, React.ReactElement<ItemProps>>(
-    children as any,
+  const staggeredChildrenVariants = {
+    hidden: { opacity: 0 },
+    show: {
+      opacity: 1,
+      transition: {
+        staggerChildren,
+      },
+    },
+  };
+
+  // Flatten the props.areas array into a 1D array
+  const areaOrder = props.areas.flat();
+
+  const sortedChildren = hasStaggeredValue
+    ? React.Children.toArray(children).sort((a, b) => {
+        if (React.isValidElement(a) && React.isValidElement(b)) {
+          const aIndex = areaOrder.indexOf(a.props.area);
+          const bIndex = areaOrder.indexOf(b.props.area);
+          return aIndex - bIndex;
+        }
+        return 0;
+      })
+    : React.Children.toArray(children);
+
+  const renderedChildren = sortedChildren.map<React.ReactElement<ItemProps> | null>(
     (child, childIndex) => {
-      if (!child) {
+      if (!React.isValidElement(child)) {
         assert(
           false,
           `CssGrid: It seems like you have null-ish children[${childIndex}]. \nIf you wanted to do a conditional rendering, do so with areas prop on CssGrid.Container`,
@@ -381,9 +456,24 @@ const RawCSSGridContainer: React.FC<Props & { theme: Theme }> = ({ theme, childr
         return null;
       }
 
-      return (
-        // @ts-ignore
-        <RawCssGridItem
+      const itemVariants = {
+        hidden: { opacity: 0 },
+        show: { opacity: 1, transition: { duration: child.props.duration } },
+      };
+
+      return hasStaggeredValue ? (
+        <RawCssGridItemMotion
+          {...child.props}
+          variants={itemVariants}
+          isAnimated={hasStaggeredValue}
+          css={
+            css`
+              ${stylesFnForChild(child.props.area)}
+            ` as any
+          }
+        />
+      ) : (
+        <RawCssGridItemDiv
           {...child.props}
           css={
             css`
@@ -395,7 +485,18 @@ const RawCSSGridContainer: React.FC<Props & { theme: Theme }> = ({ theme, childr
     },
   );
 
-  return <StyledDiv {...props}>{renderedChildren}</StyledDiv>;
+  return hasStaggeredValue ? (
+    <StyledMotionDiv
+      variants={staggeredChildrenVariants}
+      initial="hidden"
+      animate="show"
+      {...props}
+    >
+      {renderedChildren}
+    </StyledMotionDiv>
+  ) : (
+    <StyledDiv {...props}>{renderedChildren}</StyledDiv>
+  );
 };
 
 export const CssGridContainer: React.FC<Props> = withTheme(RawCSSGridContainer);

--- a/src/Atoms/CssGrid/CssGrid.tsx
+++ b/src/Atoms/CssGrid/CssGrid.tsx
@@ -6,16 +6,18 @@ import { Theme } from '../../theme/theme.types';
 import {
   AreaInfo,
   Gutter,
-  ItemProps,
-  Props,
+  GridItemProps,
   Size,
+  GridContainerAnimatedProps,
   TemplateColumn,
   TemplateRow,
+  GridItemAnimatedProps,
+  GridContainerProps,
 } from './CssGrid.types';
 import { assert, isUndefined } from '../../common/utils';
-import { getAreasInfo, getMsRawTemplateColumnOrRowStyles } from './utils';
+import { getAreasInfo, getMsRawTemplateColumnOrRowStyles, getPosition } from './utils';
 
-const formatAreas = (areas: Props['areas']) =>
+const formatAreas = (areas: GridContainerAnimatedProps['areas']) =>
   areas
     ?.map((areaRow) => areaRow.join(' '))
     ?.map((area) => `"${area}"`)
@@ -168,13 +170,13 @@ const generateMSGridStyles = ({
   return styles.join('\n');
 };
 
-const styledDivCss = css<Props>`
+const styledDivCss = css<GridContainerAnimatedProps | GridContainerProps>`
   display: grid;
   box-sizing: border-box;
 
   ${(props) => {
     const { sm, md, lg, xl } = props;
-    const createStyles = (innerProps: Partial<Props>, size?: Size) => {
+    const createStyles = (innerProps: Partial<GridContainerAnimatedProps>, size?: Size) => {
       const { height, areas, templateRows, templateColumns } = innerProps;
       const gutter = isUndefined(innerProps.gutter)
         ? props.theme.spacing.gutter
@@ -227,20 +229,20 @@ const styledDivCss = css<Props>`
   }}
 `;
 
-const StyledMotionDiv = styled(motion.div)`
+const StyledMotionDiv = styled(motion.div)<GridContainerAnimatedProps>`
   ${styledDivCss}
 `;
 
-const StyledDiv = styled.div`
+const StyledDiv = styled.div<GridContainerProps>`
   ${styledDivCss}
 `;
 
-const getMsJustifySelfStyles = (justify: ItemProps['justify']) =>
+const getMsJustifySelfStyles = (justify: GridItemProps['justify']) =>
   `-ms-grid-column-align: ${justify};`;
 
-const getMsAlignSelfStyles = (align: ItemProps['align']) => `-ms-grid-row-align: ${align};`;
+const getMsAlignSelfStyles = (align: GridItemProps['align']) => `-ms-grid-row-align: ${align};`;
 
-const getJustifySelfStyles = (justify: ItemProps['justify']) =>
+const getJustifySelfStyles = (justify: GridItemProps['justify']) =>
   justify
     ? `
   justify-self: ${justify};
@@ -248,7 +250,7 @@ const getJustifySelfStyles = (justify: ItemProps['justify']) =>
 `
     : '';
 
-const getAlignSelfStyles = (align: ItemProps['align']) =>
+const getAlignSelfStyles = (align: GridItemProps['align']) =>
   align
     ? `
   align-self: ${align};
@@ -256,10 +258,13 @@ const getAlignSelfStyles = (align: ItemProps['align']) =>
 `
     : '';
 
-const getPlaceSelfStyles = (place: ItemProps['place']) => {
+const getPlaceSelfStyles = (place: GridItemProps['place']) => {
   const styles = [];
   if (typeof place === 'string' && place) {
-    const [alignOrBoth, justify] = place.split(' ') as [ItemProps['align'], ItemProps['justify']];
+    const [alignOrBoth, justify] = place.split(' ') as [
+      GridItemProps['align'],
+      GridItemProps['justify'],
+    ];
     styles.push(`place-self: ${place};`);
     styles.push(getMsAlignSelfStyles(alignOrBoth));
     styles.push(getMsJustifySelfStyles(justify || alignOrBoth));
@@ -271,13 +276,25 @@ const getCssGridItemStylesFromProps = ({
   justify,
   align,
   place,
-}: Pick<ItemProps, 'justify' | 'align' | 'place'>) => `
+}: Pick<GridItemProps, 'justify' | 'align' | 'place'>) => `
   ${getJustifySelfStyles(justify)}
   ${getAlignSelfStyles(align)}
   ${getPlaceSelfStyles(place)}
 `;
 
-const GridItemCss = css<ItemProps & { css?: any }>`
+const hasAnimatedProps = (props: any): props is GridContainerAnimatedProps => {
+  return (
+    (props as GridContainerAnimatedProps).staggerChildren !== undefined ||
+    (props as GridContainerAnimatedProps).staggerDirection !== undefined ||
+    (props as GridContainerAnimatedProps).variants !== undefined
+  );
+};
+
+const hasRegularContainerProps = (props: any): props is GridContainerProps => {
+  return (props as GridContainerProps).areas !== undefined;
+};
+
+const GridItemCss = css<GridItemProps & { css?: any }>`
   box-sizing: border-box;
   min-width: 0; /* prevents grid blowout */
   ${(p) => getCssGridItemStylesFromProps(p)}
@@ -301,25 +318,29 @@ const RawCssGridItemDiv = styled.div`
   ${GridItemCss}
 `;
 
-export const CssGridItem: React.FC<ItemProps> = ({
+export const CssGridItem: React.FC<GridItemAnimatedProps> = ({
   align,
   area,
   children,
+  variants,
   duration,
   justify,
-  isAnimated,
+  isStaggered,
   place,
   sm,
   md,
   lg,
   xl,
 }) => {
-  const itemVariants = {
-    hidden: { opacity: 0 },
-    show: { opacity: 1, transition: { duration } },
-  };
+  let itemVariants = variants;
+  if (isStaggered && !variants) {
+    itemVariants = {
+      hidden: { opacity: 0 },
+      show: { opacity: 1, transition: { duration: duration ?? 0.5 } },
+    };
+  }
 
-  return isAnimated ? (
+  return itemVariants ? (
     <RawCssGridItemMotion
       variants={itemVariants}
       {...{
@@ -381,16 +402,13 @@ const generateChildStyles =
     : styles.join('\n');
   };
 
-const RawCSSGridContainer: React.FC<Props & { theme: Theme }> = ({
-  staggerChildren,
-  theme,
-  children,
-  ...props
-}) => {
+const RawCSSGridContainer: React.FC<
+  (GridContainerAnimatedProps | GridContainerProps) & { theme: Theme }
+> = ({ children, theme, ...props }) => {
   const { sm, md, lg, xl } = props;
-  const hasStaggeredValue = staggerChildren !== undefined;
+  const hasAnimatedContainerProps = hasAnimatedProps(props);
 
-  type SizeAreaTuple = [undefined | Size, { areas: Props['areas'] }];
+  type SizeAreaTuple = [undefined | Size, { areas: GridContainerAnimatedProps['areas'] }];
   const stylesFnsForChild = useMemo(
     () =>
       (
@@ -420,32 +438,49 @@ const RawCSSGridContainer: React.FC<Props & { theme: Theme }> = ({
 
   const stylesFnForChild = (areaName: string) =>
     stylesFnsForChild?.map((f) => f(areaName)).join('\n');
+  let variants;
 
-  const staggeredChildrenVariants = {
-    hidden: { opacity: 0 },
-    show: {
-      opacity: 1,
-      transition: {
-        staggerChildren,
-      },
-    },
-  };
-
+  if (hasAnimatedContainerProps) {
+    if (props.staggerChildren) {
+      variants = {
+        hidden: { opacity: 0 },
+        show: {
+          opacity: 1,
+          transition: {
+            staggerChildren: props.staggerChildren,
+          },
+        },
+      };
+    } else if (props.variants) {
+      variants = props.variants;
+    }
+  }
   // Flatten the props.areas array into a 1D array
   const areaOrder = props.areas.flat();
 
-  const sortedChildren = hasStaggeredValue
+  const sortedChildren = hasAnimatedContainerProps
     ? React.Children.toArray(children).sort((a, b) => {
         if (React.isValidElement(a) && React.isValidElement(b)) {
-          const aIndex = areaOrder.indexOf(a.props.area);
-          const bIndex = areaOrder.indexOf(b.props.area);
+          let aIndex;
+          let bIndex;
+
+          if (props.staggerDirection === 'column') {
+            const aPosition = getPosition(a.props.area, props.areas);
+            const bPosition = getPosition(b.props.area, props.areas);
+            aIndex = aPosition ? aPosition.column * props.areas.length + aPosition.row : -1;
+            bIndex = bPosition ? bPosition.column * props.areas.length + bPosition.row : -1;
+          } else {
+            aIndex = areaOrder.indexOf(a.props.area);
+            bIndex = areaOrder.indexOf(b.props.area);
+          }
+
           return aIndex - bIndex;
         }
         return 0;
       })
     : React.Children.toArray(children);
 
-  const renderedChildren = sortedChildren.map<React.ReactElement<ItemProps> | null>(
+  const renderedChildren = sortedChildren.map<React.ReactElement<GridItemProps> | null>(
     (child, childIndex) => {
       if (!React.isValidElement(child)) {
         assert(
@@ -456,16 +491,19 @@ const RawCSSGridContainer: React.FC<Props & { theme: Theme }> = ({
         return null;
       }
 
-      const itemVariants = {
-        hidden: { opacity: 0 },
-        show: { opacity: 1, transition: { duration: child.props.duration } },
-      };
+      let itemVariants = child.props.variants;
+      if (hasAnimatedContainerProps && props.staggerChildren && !child.props.variants) {
+        itemVariants = {
+          hidden: { opacity: 0 },
+          show: { opacity: 1, transition: { duration: child.props.duration ?? 0.5 } },
+        };
+      }
 
-      return hasStaggeredValue ? (
+      return itemVariants ? (
         <RawCssGridItemMotion
           {...child.props}
           variants={itemVariants}
-          isAnimated={hasStaggeredValue}
+          isStaggered={hasAnimatedContainerProps && props.staggerChildren}
           css={
             css`
               ${stylesFnForChild(child.props.area)}
@@ -485,21 +523,17 @@ const RawCSSGridContainer: React.FC<Props & { theme: Theme }> = ({
     },
   );
 
-  return hasStaggeredValue ? (
-    <StyledMotionDiv
-      variants={staggeredChildrenVariants}
-      initial="hidden"
-      animate="show"
-      {...props}
-    >
+  return hasAnimatedProps(props) ? (
+    <StyledMotionDiv initial="hidden" animate="show" variants={variants} {...props}>
       {renderedChildren}
     </StyledMotionDiv>
   ) : (
-    <StyledDiv {...props}>{renderedChildren}</StyledDiv>
+    hasRegularContainerProps(props) && <StyledDiv {...props}>{renderedChildren}</StyledDiv>
   );
 };
 
-export const CssGridContainer: React.FC<Props> = withTheme(RawCSSGridContainer);
+export const CssGridContainer: React.FC<GridContainerAnimatedProps | GridContainerProps> =
+  withTheme(RawCSSGridContainer);
 CssGridContainer.displayName = 'CssGrid.Container';
 
 export const CssGrid = { Container: CssGridContainer, Item: CssGridItem };

--- a/src/Atoms/CssGrid/CssGrid.types.ts
+++ b/src/Atoms/CssGrid/CssGrid.types.ts
@@ -1,3 +1,5 @@
+import { MotionProps } from 'framer-motion';
+
 export type Areas = AreasRow[];
 type AreasRow = AreaName[];
 export type AreaInfo = {
@@ -56,9 +58,14 @@ type BaseItemProps = {
   children?: React.ReactNode;
 };
 
-export type ItemProps = SizeAwareProps<BaseItemProps>;
-export type Props = SizeAwareProps<BaseProps>;
-
+export type ItemProps = {
+  duration?: number;
+  isAnimated?: boolean;
+} & SizeAwareProps<BaseItemProps> &
+  MotionProps;
+export type Props = {
+  staggerChildren?: number;
+} & SizeAwareProps<BaseProps>;
 export type Size = 'sm' | 'md' | 'lg' | 'xl' | undefined;
 
 type Omit<T, K> = Pick<T, Exclude<keyof T, K>>;

--- a/src/Atoms/CssGrid/CssGrid.types.ts
+++ b/src/Atoms/CssGrid/CssGrid.types.ts
@@ -58,14 +58,38 @@ type BaseItemProps = {
   children?: React.ReactNode;
 };
 
-export type ItemProps = {
+type GridItemAnimationProps = {
+  /**
+   * @default 0.5s
+   * @description Duration for fade-in animation if staggerChildren is provided to GridContainer.
+   */
   duration?: number;
-  isAnimated?: boolean;
-} & SizeAwareProps<BaseItemProps> &
-  MotionProps;
-export type Props = {
+  /**
+   * @default false
+   * @description Only true when staggerChildren is provided to GridContainer
+   */
+  isStaggered?: boolean;
+} & MotionProps;
+
+export type GridItemProps = SizeAwareProps<BaseItemProps>;
+export type GridItemAnimatedProps = GridItemAnimationProps & GridItemProps;
+
+type GridContainerAnimationProps = {
+  /**
+   * @default 0
+   * @description Duration of stagger animation. If provided then all children will be animated
+   */
   staggerChildren?: number;
-} & SizeAwareProps<BaseProps>;
+  /**
+   * @default 'row'
+   * @description Direction of stagger animation. Only works if staggerChildren is provided
+   */
+  staggerDirection?: 'column' | 'row';
+} & MotionProps;
+
+export type GridContainerAnimatedProps = GridContainerAnimationProps & SizeAwareProps<BaseProps>;
+export type GridContainerProps = SizeAwareProps<BaseProps>;
+
 export type Size = 'sm' | 'md' | 'lg' | 'xl' | undefined;
 
 type Omit<T, K> = Pick<T, Exclude<keyof T, K>>;

--- a/src/Atoms/CssGrid/utils.test.ts
+++ b/src/Atoms/CssGrid/utils.test.ts
@@ -1,4 +1,4 @@
-import { getAreasInfo, getMsRawTemplateColumnOrRowStyles } from './utils';
+import { getAreasInfo, getMsRawTemplateColumnOrRowStyles, getPosition } from './utils';
 
 describe('getAreasInfo', () => {
   test('Areas #1 w/gap', () => {
@@ -108,5 +108,29 @@ describe('getMsRawTemplateColumnOrRowStyles', () => {
 
     const result = getMsRawTemplateColumnOrRowStyles(raw, gutter);
     expect(result).toEqual('10ch 30px 412px 30px 50% 30px 1fr');
+  });
+});
+
+describe('getPosition', () => {
+  test('should return correct position', () => {
+    const areas = [
+      ['header', 'header', 'header'],
+      ['menu', 'content', 'content'],
+      ['footer', 'content', 'content'],
+    ];
+
+    const result = getPosition('content', areas);
+    expect(result).toEqual({ row: 1, column: 1 });
+  });
+
+  test('should return null for non-existing area', () => {
+    const areas = [
+      ['header', 'header', 'header'],
+      ['menu', 'content', 'content'],
+      ['footer', 'content', 'content'],
+    ];
+
+    const result = getPosition('nonExistingArea', areas);
+    expect(result).toBeNull();
   });
 });

--- a/src/Atoms/CssGrid/utils.ts
+++ b/src/Atoms/CssGrid/utils.ts
@@ -81,3 +81,13 @@ export const getAreasInfo = (
 export const getMsRawTemplateColumnOrRowStyles = (raw: string, gutter: string) => {
   return raw.replace(spacesNotInsideParentheses, ` ${gutter} `);
 };
+
+export const getPosition = (area: string, areas: string[][]) => {
+  for (let column = 0; column < areas[0].length; column += 1) {
+    const row = areas.findIndex((r: any) => r[column] === area);
+    if (row !== -1) {
+      return { row, column };
+    }
+  }
+  return null;
+};


### PR DESCRIPTION
Description:
I have changed so if you set any motion props on Grid.Container or Grid.Item they will render as motion.div. Allowing the developer to add their own animations.

I have also added a basic `staggerChildren` prop to the Grid.Container that will add a stagger animation to all of its children. 

I think I have explained it better in the documents and with the example. Here is a video of the result:

https://github.com/nordnet/ui/assets/122264327/af27a730-120f-4f48-9e99-3803b258d753

