### PR TITLE
fix: the not:empty css query messes up how flex box are applies …

### DIFF
--- a/src/Atoms/Flexbox/Flexbox.tsx
+++ b/src/Atoms/Flexbox/Flexbox.tsx
@@ -72,11 +72,11 @@ const getGapStyles = (theme: Theme, gap: Props['gap']) => {
   }
 
   if (typeof gap === 'number') {
-    gapStyle = `${theme.spacing.unit(gap)}px;`;
+    gapStyle = `${theme.spacing.unit(gap)}px`;
   } else if (typeof gap === 'string') {
     gapStyle = gap;
   } else {
-    gapStyle = `${theme.spacing.unit(gap.row)}px ${theme.spacing.unit(gap.column)}px;`;
+    gapStyle = `${theme.spacing.unit(gap.row)}px ${theme.spacing.unit(gap.column)}px`;
   }
 
   return `gap: ${gapStyle};`;

--- a/src/Atoms/Flexbox/Flexbox.tsx
+++ b/src/Atoms/Flexbox/Flexbox.tsx
@@ -78,11 +78,8 @@ const getGapStyles = (theme: Theme, gap: Props['gap']) => {
   } else {
     gapStyle = `${theme.spacing.unit(gap.row)}px ${theme.spacing.unit(gap.column)}px;`;
   }
-  /*
-    :not(:empty) to fix issue with printing in chrome
-    https://bugs.chromium.org/p/chromium/issues/detail?id=1161709
-  */
-  return `:not(:empty) { gap: ${gapStyle}; }`;
+
+  return `gap: ${gapStyle};`;
 };
 
 const getContainerStyles = (p: Props & { theme: Theme }) => `


### PR DESCRIPTION
…to children and grandchildren when styled-components version is updated to 16.0.0 and ahead