### PR TITLE
Add prop onPopperMounted that exposes update function from popper

### DIFF
--- a/src/Molecules/PersistentTooltip/PersistentTooltip.stories.tsx
+++ b/src/Molecules/PersistentTooltip/PersistentTooltip.stories.tsx
@@ -1,6 +1,15 @@
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
-import { Box, Flexbox, Drawer, Input, PersistentTooltip, Typography, OldIcon } from '../..';
+import {
+  Box,
+  Flexbox,
+  Drawer,
+  Input,
+  PersistentTooltip,
+  Typography,
+  OldIcon,
+  AccordionItem,
+} from '../..';
 
 export default {
   title: 'Molecules / Persistent Tooltip',
@@ -17,9 +26,54 @@ const StoryWrapper: React.FC<{ children?: React.ReactNode }> = ({ children }) =>
   </div>
 );
 
+export const MovingTooltip = () => {
+  const [isOpen, setIsOpen] = useState(true);
+  const [isAccordionExpanded, setIsAccordionExpanded] = useState(false);
+  const updateFnRef = useRef<() => void>();
+
+  useEffect(() => {
+    setTimeout(() => {
+      setIsAccordionExpanded(true);
+    }, 1000);
+  }, []);
+
+  useEffect(() => {
+    setTimeout(() => {
+      updateFnRef.current?.();
+    }, 160);
+  }, [isAccordionExpanded]);
+
+  const updateCallback = (popperUpdate: () => void) => {
+    updateFnRef.current = popperUpdate;
+  };
+
+  return (
+    <StoryWrapper>
+      <AccordionItem
+        key={123123}
+        title="I will expand after 1500ms"
+        disableFocusOutline
+        expanded={isAccordionExpanded}
+        onClick={() => setIsAccordionExpanded(!isAccordionExpanded)}
+      >
+        This is accordion content, will this push down the Tooltip?
+      </AccordionItem>
+      <PersistentTooltip
+        isOpen={isOpen}
+        title="Default persistent tooltip"
+        description="The tooltip will not close until the user clicks the close-button – useful for pointing the user's attention somewhere (for instance when showcasing new features)."
+        closeButtonTitle="Close by clicking X"
+        onClose={() => setIsOpen(false)}
+        onPopperMounted={updateCallback}
+      >
+        <Input.Text label="Label" placeholder="This is wrapped by a tooltip" />
+      </PersistentTooltip>
+    </StoryWrapper>
+  );
+};
+
 export const DefaultStory = () => {
   const [isOpen, setIsOpen] = useState(true);
-
   return (
     <StoryWrapper>
       <PersistentTooltip

--- a/src/Molecules/PersistentTooltip/PersistentTooltip.stories.tsx
+++ b/src/Molecules/PersistentTooltip/PersistentTooltip.stories.tsx
@@ -43,8 +43,8 @@ export const MovingTooltip = () => {
     }, 160);
   }, [isAccordionExpanded]);
 
-  const updateCallback = (popperUpdate: () => void) => {
-    updateFnRef.current = popperUpdate;
+  const updateCallback = (popperUpdateFn: () => void) => {
+    updateFnRef.current = popperUpdateFn;
   };
 
   return (

--- a/src/Molecules/PersistentTooltip/PersistentTooltip.tsx
+++ b/src/Molecules/PersistentTooltip/PersistentTooltip.tsx
@@ -44,6 +44,7 @@ export const PersistentTooltip: FC<PersistentTooltipProps> & {
   inModal,
   wrapChild,
   pointerArrow = true,
+  onPopperMounted,
   ...htmlDivProps
 }) => {
   const child = React.Children.only(children) as ReactElement;
@@ -121,6 +122,7 @@ export const PersistentTooltip: FC<PersistentTooltipProps> & {
           ariaLabel={ariaLabel}
           inModal={inModal}
           pointerArrow={pointerArrow}
+          onPopperMounted={onPopperMounted}
           {...htmlDivProps}
         />
       )}

--- a/src/Molecules/PersistentTooltip/PersistentTooltip.types.ts
+++ b/src/Molecules/PersistentTooltip/PersistentTooltip.types.ts
@@ -18,6 +18,7 @@ export type Props = {
    */
   wrapChild?: boolean;
   textColor?: ColorFn;
+  onPopperMounted?: (popperUpdate: () => void) => void;
 } & Pick<
   PopOverProps,
   | 'id'

--- a/src/common/PopOver/PopOver.tsx
+++ b/src/common/PopOver/PopOver.tsx
@@ -1,4 +1,4 @@
-import React, { MutableRefObject, useRef, useState } from 'react';
+import React, { MutableRefObject, useEffect, useRef, useState } from 'react';
 import { usePopper } from 'react-popper';
 import { mergeRefs } from '../utils';
 import { Portal } from '../..';
@@ -33,6 +33,7 @@ const PopOver: React.FC<Props> & {
   customBoundary,
   pointerArrow = true,
   invertedColors,
+  onPopperMounted,
   ...htmlSpanProps
 }) => {
   const [popperElement, setPopperElement] = useState(null);
@@ -71,6 +72,13 @@ const PopOver: React.FC<Props> & {
 
   const { state, styles, attributes } = popper;
   const { placement } = state || {};
+
+  // exposes update function from popper to consumers, so PopOver can be repositioned properly
+  useEffect(() => {
+    if (popper?.update && typeof onPopperMounted === 'function') {
+      onPopperMounted(popper?.update);
+    }
+  }, [onPopperMounted, popper]);
 
   if (positionCallback && placement) {
     positionCallback(placement as NonNullable<Props['position']>);
@@ -120,6 +128,7 @@ const PopOver: React.FC<Props> & {
   if (!customBoundary) {
     return <Portal>{content}</Portal>;
   }
+
   return content;
 };
 

--- a/src/common/PopOver/PopOver.types.ts
+++ b/src/common/PopOver/PopOver.types.ts
@@ -47,4 +47,5 @@ export type Props = {
   customBoundary?: HTMLElement | Array<HTMLElement>;
   pointerArrow?: boolean;
   invertedColors?: boolean;
+  onPopperMounted?: (popperUpdate: () => void) => void;
 };


### PR DESCRIPTION
Used as 👇 

```ts
// inside some component that uses PersistentTooltip

const updateFnRef = useRef<() => void>();

useEffect(() => {
  if (something) {
    updateFnRef();
  }
}, [something])

const updateCallback = (popperUpdate: () => void) => {
  updateFnRef.current = popperUpdate;
};

return (
  <PersistentTooltip
    isOpen={isOpen}
    title="Default persistent tooltip"
    description="The tooltip is here.."
    closeButtonTitle="Close by clicking X"
    onClose={() => setIsOpen(false)}
    onPopperMounted={updateCallback}
  >
    Trigger
  </PersistentTooltip>
);
```