### PR TITLE
fix: Remove re-export of PopperUpdate from src/common/PopOver/index.ts

### DIFF
--- a/src/Molecules/PersistentTooltip/PersistentTooltip.stories.tsx
+++ b/src/Molecules/PersistentTooltip/PersistentTooltip.stories.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
-import { PopperUpdate } from 'common/PopOver';
+import { PopperUpdate } from '../../common/PopOver/PopOver.types';
 import {
   Box,
   Flexbox,

--- a/src/Molecules/PersistentTooltip/PersistentTooltip.stories.tsx
+++ b/src/Molecules/PersistentTooltip/PersistentTooltip.stories.tsx
@@ -48,7 +48,7 @@ export const MovingTooltip = () => {
     <StoryWrapper>
       <AccordionItem
         key={123123}
-        title="I will expand after 1500ms"
+        title="I will expand after 1000ms"
         disableFocusOutline
         expanded={isAccordionExpanded}
         onClick={() => setIsAccordionExpanded(!isAccordionExpanded)}

--- a/src/Molecules/PersistentTooltip/PersistentTooltip.tsx
+++ b/src/Molecules/PersistentTooltip/PersistentTooltip.tsx
@@ -2,7 +2,8 @@ import React, { cloneElement, ReactElement, useRef, useState } from 'react';
 import styled from 'styled-components';
 import { isElement, mergeRefs } from '../../common/utils';
 import { Box, Button, Flexbox, OldIcon, Typography } from '../..';
-import { PopOver, PopperUpdate } from '../../common/PopOver';
+import { PopOver } from '../../common/PopOver';
+import { PopperUpdate } from '../../common/PopOver/PopOver.types';
 import { Props as PersistentTooltipProps } from './PersistentTooltip.types';
 import { useGeneratedId } from '../../common/Hooks';
 

--- a/src/common/PopOver/index.ts
+++ b/src/common/PopOver/index.ts
@@ -1,2 +1,1 @@
 export { default as PopOver } from './PopOver';
-export { PopperUpdate } from './PopOver.types';


### PR DESCRIPTION
Aims to fix warning 👇 
```
export 'PopperUpdate' (reexported as 'PopperUpdate') was not found in './PopOver.types' (module has no exports)
```